### PR TITLE
Complete Step 3.3: Add service stopping to library upgrade command

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -342,7 +342,7 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 **Goal**: Implement `oarepo-cli library upgrade` command.
 
 - [x] Implement `library_upgrade()` function
-- [ ] Stop services (if running) - Deferred to Step 3.4 when services are implemented
+- [x] Stop services (if running)
 - [x] Remove existing venv
 - [x] Clean uv cache
 - [x] Recreate venv with `ensure_venv(force=True)`
@@ -353,7 +353,7 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 **Tests** (`tests/workflow/test_upgrade_workflow.py`):
 - [x] Test venv removed and recreated
 - [x] Test cache cleaned
-- [ ] Test services stopped before upgrade - Deferred to Step 3.4
+- [x] Test services stopped before upgrade
 - [x] Test success message displayed
 - [x] Test cache clean failure handling
 
@@ -368,7 +368,7 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 - [x] Use `docker-services-cli up/down`
 - [x] Write/read `.env-services` file
 - [x] Support DB, search, MQ, cache, S3 options
-- [ ] Update 3.3 steps with service checks - Deferred to Step 3.5
+- [x] Update 3.3 steps with service checks
 
 **Deliverables**:
 - Service lifecycle management

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -10,6 +10,7 @@ from typing import Annotated
 import typer
 
 from oarepo_cli.core.context import discover_context
+from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
 
 # Create the library subcommand group
@@ -71,20 +72,34 @@ def library_upgrade() -> None:
     """Clean cache and recreate virtual environment from scratch.
 
     This command:
-    1. Removes the existing virtual environment (if present)
-    2. Cleans the uv cache to ensure fresh package downloads
-    3. Recreates the virtual environment with all dependencies
+    1. Stops running services (if any)
+    2. Removes the existing virtual environment (if present)
+    3. Cleans the uv cache to ensure fresh package downloads
+    4. Recreates the virtual environment with all dependencies
 
     Use this when you need to completely refresh your development environment,
     for example after updating OARepo or when dependencies become corrupted.
-
-    Note: This does not stop services. Use 'oarepo-cli library stop' first
-    if you have services running.
     """
     # Discover project context
     context = discover_context()
 
     typer.secho("🔄 Upgrading environment...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    # Stop services if running
+    services_mgr = ServicesLifecycleManager(
+        config=context.config, project_root=context.root_directory
+    )
+    if services_mgr.are_services_running():
+        typer.secho("🛑 Stopping services...", fg=typer.colors.CYAN)
+        try:
+            services_mgr.stop_services()
+            typer.secho("  ✓ Services stopped", fg=typer.colors.GREEN)
+        except Exception as e:
+            typer.secho(
+                f"  ⚠ Warning: Failed to stop services: {e}",
+                fg=typer.colors.YELLOW,
+                err=True,
+            )
 
     # Clean uv cache
     typer.secho("🧹 Cleaning uv cache...", fg=typer.colors.CYAN)

--- a/tests/workflow/test_upgrade_workflow.py
+++ b/tests/workflow/test_upgrade_workflow.py
@@ -195,3 +195,74 @@ def test_upgrade_requires_pyproject(
         and "pyproject.toml" in str(result.exception).lower()
         or result.stdout
     )
+
+
+def test_upgrade_stops_services_if_running(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that upgrade stops services before recreating venv."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Create .env-services file to simulate running services
+    env_services = mock_library_project / ".env-services"
+    env_services.write_text("export SQLALCHEMY_DATABASE_URI=postgresql://test")
+
+    # Register docker-services-cli down command
+    fake_process.register(["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"])
+
+    # Register other commands
+    fake_process.register(["uv", "cache", "clean"])
+    fake_process.register(["uv", "venv", fake_process.any()])
+    fake_process.register([fake_process.any(), "-m", "pip", "install", "setuptools"])
+    fake_process.register(
+        ["uv", "pip", "install", "--prerelease", "allow", fake_process.any()],
+        occurrences=2,
+    )
+
+    result = runner.invoke(app, ["library", "upgrade"])
+
+    # Should have called docker-services-cli down
+    assert (
+        fake_process.call_count(
+            ["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"]
+        )
+        >= 1
+    )
+    # .env-services should be removed
+    assert not env_services.exists()
+    assert result.exit_code == 0
+
+
+def test_upgrade_skips_stopping_if_no_services_running(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that upgrade doesn't try to stop services if none are running."""
+    monkeypatch.chdir(mock_library_project)
+
+    # No .env-services file (no running services)
+
+    # Register commands - but NOT docker-services-cli down
+    fake_process.register(["uv", "cache", "clean"])
+    fake_process.register(["uv", "venv", fake_process.any()])
+    fake_process.register([fake_process.any(), "-m", "pip", "install", "setuptools"])
+    fake_process.register(
+        ["uv", "pip", "install", "--prerelease", "allow", fake_process.any()],
+        occurrences=2,
+    )
+
+    result = runner.invoke(app, ["library", "upgrade"])
+
+    # Should NOT have called docker-services-cli down
+    assert (
+        fake_process.call_count(
+            ["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"]
+        )
+        == 0
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR completes the deferred task from Step 3.3 by adding service stopping to the `library upgrade` command.

## Changes
- Updated `library_upgrade()` to stop running services before recreating venv
- Services are detected via `.env-services` file existence
- Added colored status messages with emoticons (🛑 Stopping services...)
- Added comprehensive tests for service stopping behavior

## Tests Added
- `test_upgrade_stops_services_if_running()` - verifies services are stopped when .env-services exists
- `test_upgrade_skips_stopping_if_no_services_running()` - verifies no attempt to stop services when none are running

## Documentation
- Marked Step 3.3 fully complete in implementation-steps.md
- Updated Step 3.4 to remove deferred note

All tests pass (209 tests). Ready for review.