### PR TITLE
Step 3.5: Library start/stop commands

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -387,17 +387,17 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 ### Step 3.5: Library `start`/`stop` Commands
 **Goal**: Implement service start/stop commands.
 
-- [ ] Implement `library_start()` and `library_stop()` functions
-- [ ] Delegate to `ServicesLifecycleManager`
-- [ ] Display colored status messages
+- [x] Implement `library_start()` and `library_stop()` functions
+- [x] Delegate to `ServicesLifecycleManager`
+- [x] Display colored status messages
 
 **Deliverables**:
 - Start/stop commands
 
 **Tests** (`tests/integration/test_library_services.py`):
-- [ ] Test start creates env file
-- [ ] Test stop removes env file
-- [ ] Test exit codes match bash
+- [x] Test start creates env file
+- [x] Test stop removes env file
+- [x] Test exit codes match bash
 
 ---
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -128,3 +128,74 @@ def library_upgrade() -> None:
 
     typer.secho("✨ ✓ Upgrade completed successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
     typer.secho(f"  Virtual environment ready at {venv_path}", fg=typer.colors.GREEN)
+
+
+@library_app.command("start")
+def library_start() -> None:
+    """Start Docker services for development and testing.
+
+    Starts the configured Docker services (database, search, message queue,
+    cache, S3) and writes connection details to .env-services file.
+
+    The services are configured via environment variables or [tool.oarepo-cli.services]
+    in pyproject.toml.
+    """
+    # Discover project context
+    context = discover_context()
+
+    typer.secho("🚀 Starting services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    # Start services using ServicesLifecycleManager
+    services_mgr = ServicesLifecycleManager(
+        config=context.config, project_root=context.root_directory
+    )
+
+    try:
+        env_vars = services_mgr.start_services()
+
+        if not env_vars:
+            # Services were skipped (SKIP_SERVICES=1)
+            typer.secho("✓ Services skipped", fg=typer.colors.YELLOW)
+        else:
+            typer.secho(
+                "✨ ✓ Services started successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
+            )
+            typer.secho(
+                f"  Environment variables written to {context.root_directory / '.env-services'}",
+                fg=typer.colors.GREEN,
+            )
+    except Exception as e:
+        typer.secho(
+            f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
+        )
+        raise typer.Exit(code=1) from e
+
+
+@library_app.command("stop")
+def library_stop() -> None:
+    """Stop Docker services.
+
+    Stops all running Docker services and removes the .env-services file.
+    """
+    # Discover project context
+    context = discover_context()
+
+    if not (context.root_directory / ".env-services").exists():
+        typer.secho("✓ No services running", fg=typer.colors.YELLOW)
+        return
+
+    typer.secho("🛑 Stopping services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    # Stop services using ServicesLifecycleManager
+    services_mgr = ServicesLifecycleManager(
+        config=context.config, project_root=context.root_directory
+    )
+
+    try:
+        services_mgr.stop_services()
+        typer.secho("✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    except Exception as e:
+        typer.secho(
+            f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
+        )
+        raise typer.Exit(code=1) from e

--- a/tests/integration/test_library_services.py
+++ b/tests/integration/test_library_services.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for library start/stop commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_subprocess import FakeProcess
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CLI runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_library_project(tmp_path: Path) -> Path:
+    """Create a minimal mock library project."""
+    project_dir = tmp_path / "test-library"
+    project_dir.mkdir()
+
+    # Create pyproject.toml
+    pyproject_content = """
+[project]
+name = "test-library"
+version = "1.0.0"
+requires-python = ">=3.14,<3.15"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.oarepo-cli]
+oarepo.version = 14
+"""
+    (project_dir / "pyproject.toml").write_text(pyproject_content)
+
+    # Create minimal package structure
+    pkg_dir = project_dir / "test_library"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+
+    return project_dir
+
+
+def test_start_help_displays(runner: CliRunner) -> None:
+    """Test that 'library start --help' displays help text."""
+    result = runner.invoke(app, ["library", "start", "--help"])
+
+    assert result.exit_code == 0
+    assert "start" in result.stdout.lower()
+    assert "services" in result.stdout.lower() or "docker" in result.stdout.lower()
+
+
+def test_stop_help_displays(runner: CliRunner) -> None:
+    """Test that 'library stop --help' displays help text."""
+    result = runner.invoke(app, ["library", "stop", "--help"])
+
+    assert result.exit_code == 0
+    assert "stop" in result.stdout.lower()
+    assert "services" in result.stdout.lower() or "docker" in result.stdout.lower()
+
+
+def test_start_creates_env_file(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that start command creates .env-services file."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Mock docker-services-cli output
+    env_output = "export SQLALCHEMY_DATABASE_URI=postgresql://test\nexport INVENIO_SEARCH_HOSTS=localhost:9200\n"
+
+    # Register docker-services-cli up command
+    fake_process.register(
+        [
+            "uvx",
+            "--with",
+            "setuptools",
+            "docker-services-cli",
+            "up",
+            "--db",
+            "postgresql",
+            "--search",
+            "opensearch",
+            "--mq",
+            "rabbitmq",
+            "--cache",
+            "redis",
+            "--s3",
+            "minio",
+            "--env",
+        ],
+        stdout=env_output,
+    )
+
+    result = runner.invoke(app, ["library", "start"])
+
+    # Should have created .env-services file
+    env_file = mock_library_project / ".env-services"
+    assert env_file.exists()
+    assert env_file.read_text() == env_output
+
+    # Should exit successfully
+    assert result.exit_code == 0
+    assert "started" in result.stdout.lower() or "success" in result.stdout.lower()
+
+
+def test_stop_removes_env_file(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that stop command removes .env-services file."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Create existing .env-services file
+    env_file = mock_library_project / ".env-services"
+    env_file.write_text("export SQLALCHEMY_DATABASE_URI=postgresql://test\n")
+
+    # Register docker-services-cli down command
+    fake_process.register(["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"])
+
+    result = runner.invoke(app, ["library", "stop"])
+
+    # Should have removed .env-services file
+    assert not env_file.exists()
+
+    # Should exit successfully
+    assert result.exit_code == 0
+    assert "stopped" in result.stdout.lower() or "success" in result.stdout.lower()
+
+
+def test_stop_when_no_services_running(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that stop command handles no services gracefully."""
+    monkeypatch.chdir(mock_library_project)
+
+    # No .env-services file exists
+
+    result = runner.invoke(app, ["library", "stop"])
+
+    # Should exit successfully with message
+    assert result.exit_code == 0
+    assert "no services" in result.stdout.lower() or "not running" in result.stdout.lower()
+
+
+def test_start_exit_code_on_failure(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that start command exits with code 1 on failure."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Register docker-services-cli to fail
+    fake_process.register(
+        [
+            "uvx",
+            "--with",
+            "setuptools",
+            "docker-services-cli",
+            "up",
+            "--db",
+            "postgresql",
+            "--search",
+            "opensearch",
+            "--mq",
+            "rabbitmq",
+            "--cache",
+            "redis",
+            "--s3",
+            "minio",
+            "--env",
+        ],
+        returncode=1,
+        stderr="Docker not running",
+    )
+
+    result = runner.invoke(app, ["library", "start"])
+
+    # Should exit with code 1
+    assert result.exit_code == 1
+
+
+def test_stop_exit_code_on_failure(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that stop command exits with code 1 on failure."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Create existing .env-services file
+    env_file = mock_library_project / ".env-services"
+    env_file.write_text("export SQLALCHEMY_DATABASE_URI=postgresql://test\n")
+
+    # Register docker-services-cli to fail
+    fake_process.register(
+        ["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"],
+        returncode=1,
+        stderr="Docker not running",
+    )
+
+    result = runner.invoke(app, ["library", "stop"])
+
+    # Should exit with code 1
+    assert result.exit_code == 1


### PR DESCRIPTION
This PR implements the library start and stop commands for managing Docker services.

## Changes

### Commands Implemented
- **`oarepo-cli library start`** - starts Docker services and writes .env-services
- **`oarepo-cli library stop`** - stops Docker services and removes .env-services

### Features
- Colored output with emoticons:
  - 🚀 Starting services
  - 🛑 Stopping services
  - ✨ ✓ Success messages
  - ❌ Error messages
- Proper error handling with exit code 1 on failure
- Graceful handling when no services are running
- Delegates all service operations to `ServicesLifecycleManager`

### Tests Added
All tests in `tests/integration/test_library_services.py`:
- `test_start_creates_env_file()` - verifies .env-services created
- `test_stop_removes_env_file()` - verifies .env-services removed
- `test_stop_when_no_services_running()` - graceful handling
- `test_start_exit_code_on_failure()` - exit code 1 on error
- `test_stop_exit_code_on_failure()` - exit code 1 on error

## Testing
All 216 tests pass. Step 3.5 is now complete.

## Next Steps
Step 3.6: Test Orchestrator