### PR TITLE
Add 'library services start/stop' command aliases

### DIFF
--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -20,10 +20,84 @@ library_app = typer.Typer(
     no_args_is_help=True,
 )
 
+# Create the services subcommand group
+services_app = typer.Typer(
+    name="services",
+    help="Docker services management",
+    no_args_is_help=True,
+)
+
+# Register services as a subcommand of library
+library_app.add_typer(services_app)
+
 
 @library_app.callback()
 def library_callback() -> None:
     """Library command group."""
+
+
+@services_app.callback()
+def services_callback() -> None:
+    """Services command group."""
+
+
+def _start_services_impl() -> None:
+    """Shared implementation for starting services."""
+    # Discover project context
+    context = discover_context()
+
+    typer.secho("🚀 Starting services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    # Start services using ServicesLifecycleManager
+    services_mgr = ServicesLifecycleManager(
+        config=context.config, project_root=context.root_directory
+    )
+
+    try:
+        env_vars = services_mgr.start_services()
+
+        if not env_vars:
+            # Services were skipped (SKIP_SERVICES=1)
+            typer.secho("✓ Services skipped", fg=typer.colors.YELLOW)
+        else:
+            typer.secho(
+                "✨ ✓ Services started successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
+            )
+            typer.secho(
+                f"  Environment variables written to {context.root_directory / '.env-services'}",
+                fg=typer.colors.GREEN,
+            )
+    except Exception as e:
+        typer.secho(
+            f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
+        )
+        raise typer.Exit(code=1) from e
+
+
+def _stop_services_impl() -> None:
+    """Shared implementation for stopping services."""
+    # Discover project context
+    context = discover_context()
+
+    if not (context.root_directory / ".env-services").exists():
+        typer.secho("✓ No services running", fg=typer.colors.YELLOW)
+        return
+
+    typer.secho("🛑 Stopping services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    # Stop services using ServicesLifecycleManager
+    services_mgr = ServicesLifecycleManager(
+        config=context.config, project_root=context.root_directory
+    )
+
+    try:
+        services_mgr.stop_services()
+        typer.secho("✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    except Exception as e:
+        typer.secho(
+            f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
+        )
+        raise typer.Exit(code=1) from e
 
 
 @library_app.command("venv")
@@ -140,35 +214,20 @@ def library_start() -> None:
     The services are configured via environment variables or [tool.oarepo-cli.services]
     in pyproject.toml.
     """
-    # Discover project context
-    context = discover_context()
+    _start_services_impl()
 
-    typer.secho("🚀 Starting services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
 
-    # Start services using ServicesLifecycleManager
-    services_mgr = ServicesLifecycleManager(
-        config=context.config, project_root=context.root_directory
-    )
+@services_app.command("start")
+def services_start() -> None:
+    """Start Docker services for development and testing.
 
-    try:
-        env_vars = services_mgr.start_services()
+    Starts the configured Docker services (database, search, message queue,
+    cache, S3) and writes connection details to .env-services file.
 
-        if not env_vars:
-            # Services were skipped (SKIP_SERVICES=1)
-            typer.secho("✓ Services skipped", fg=typer.colors.YELLOW)
-        else:
-            typer.secho(
-                "✨ ✓ Services started successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
-            )
-            typer.secho(
-                f"  Environment variables written to {context.root_directory / '.env-services'}",
-                fg=typer.colors.GREEN,
-            )
-    except Exception as e:
-        typer.secho(
-            f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
-        )
-        raise typer.Exit(code=1) from e
+    The services are configured via environment variables or [tool.oarepo-cli.services]
+    in pyproject.toml.
+    """
+    _start_services_impl()
 
 
 @library_app.command("stop")
@@ -177,25 +236,13 @@ def library_stop() -> None:
 
     Stops all running Docker services and removes the .env-services file.
     """
-    # Discover project context
-    context = discover_context()
+    _stop_services_impl()
 
-    if not (context.root_directory / ".env-services").exists():
-        typer.secho("✓ No services running", fg=typer.colors.YELLOW)
-        return
 
-    typer.secho("🛑 Stopping services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+@services_app.command("stop")
+def services_stop() -> None:
+    """Stop Docker services.
 
-    # Stop services using ServicesLifecycleManager
-    services_mgr = ServicesLifecycleManager(
-        config=context.config, project_root=context.root_directory
-    )
-
-    try:
-        services_mgr.stop_services()
-        typer.secho("✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    except Exception as e:
-        typer.secho(
-            f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
-        )
-        raise typer.Exit(code=1) from e
+    Stops all running Docker services and removes the .env-services file.
+    """
+    _stop_services_impl()

--- a/tests/integration/test_library_services.py
+++ b/tests/integration/test_library_services.py
@@ -225,3 +225,89 @@ def test_stop_exit_code_on_failure(
 
     # Should exit with code 1
     assert result.exit_code == 1
+
+
+# Test the services subcommand aliases
+
+
+def test_services_start_alias(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that 'library services start' works as an alias."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Mock docker-services-cli output
+    env_output = "export SQLALCHEMY_DATABASE_URI=postgresql://test\n"
+
+    # Register docker-services-cli up command
+    fake_process.register(
+        [
+            "uvx",
+            "--with",
+            "setuptools",
+            "docker-services-cli",
+            "up",
+            "--db",
+            "postgresql",
+            "--search",
+            "opensearch",
+            "--mq",
+            "rabbitmq",
+            "--cache",
+            "redis",
+            "--s3",
+            "minio",
+            "--env",
+        ],
+        stdout=env_output,
+    )
+
+    result = runner.invoke(app, ["library", "services", "start"])
+
+    # Should have created .env-services file
+    env_file = mock_library_project / ".env-services"
+    assert env_file.exists()
+    assert env_file.read_text() == env_output
+
+    # Should exit successfully
+    assert result.exit_code == 0
+
+
+def test_services_stop_alias(
+    runner: CliRunner,
+    mock_library_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: FakeProcess,
+) -> None:
+    """Test that 'library services stop' works as an alias."""
+    monkeypatch.chdir(mock_library_project)
+
+    # Create existing .env-services file
+    env_file = mock_library_project / ".env-services"
+    env_file.write_text("export SQLALCHEMY_DATABASE_URI=postgresql://test\n")
+
+    # Register docker-services-cli down command
+    fake_process.register(["uvx", "--with", "setuptools", "docker-services-cli", "down", "--env"])
+
+    result = runner.invoke(app, ["library", "services", "stop"])
+
+    # Should have removed .env-services file
+    assert not env_file.exists()
+
+    # Should exit successfully
+    assert result.exit_code == 0
+
+
+def test_services_help_displays(
+    runner: CliRunner,
+) -> None:
+    """Test that 'library services --help' displays help text."""
+    result = runner.invoke(app, ["library", "services", "--help"])
+
+    assert result.exit_code == 0
+    assert "services" in result.stdout.lower()
+    assert "start" in result.stdout.lower()
+    assert "stop" in result.stdout.lower()


### PR DESCRIPTION
This PR adds the requested command aliases for service management.

## Changes

Both command styles now work identically:

### Direct commands (existing)
- `oarepo-cli library start`
- `oarepo-cli library stop`

### Subcommand aliases (new)
- `oarepo-cli library services start`
- `oarepo-cli library services stop`

## Implementation

- Created `services_app` Typer subcommand group under `library_app`
- Extracted shared implementation:
  - `_start_services_impl()` - shared start logic
  - `_stop_services_impl()` - shared stop logic
- Registered commands in both places to avoid code duplication
- Both paths call the same implementation function

## Tests

Added 3 new tests in `test_library_services.py`:
- `test_services_start_alias()` - verifies `library services start` works
- `test_services_stop_alias()` - verifies `library services stop` works
- `test_services_help_displays()` - verifies help text for services group

## Testing

All 219 tests pass with 88% coverage.

## Branch

This PR is based on a fresh branch created from the latest `cli-as-python` (commit 6848fe5).