### PR TITLE
Step 3.5.1: Interactive output for long-running commands

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -401,6 +401,33 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 
 ---
 
+### Step 3.5.1: Interactive Output for Long-Running Commands
+**Goal**: Enable real-time output for long-running commands with --quiet option.
+
+- [x] Add `--quiet` flag to commands that run long operations (venv, upgrade, etc.)
+- [x] Update `process.run()` to support interactive mode (no capture_output)
+- [x] Use PTY for interactive subprocesses when appropriate
+- [x] By default, show real-time output (visible to user)
+- [x] With `--quiet`, suppress output (capture and silence)
+- [x] Apply to commands:
+  - `library venv` - `uv pip install` can take long time
+  - `library upgrade` - cache clean + full reinstall
+  - Future commands with long operations
+
+**Deliverables**:
+- Interactive output for long-running commands
+- `--quiet` flag support
+- Real-time visibility of subprocess output
+
+**Tests** (`tests/integration/test_quiet_mode.py`):
+- [x] Existing tests pass with new interactive mode
+- [x] Test venv command shows output by default (manual verification)
+- [x] Test venv --quiet suppresses output (manual verification)
+- [x] Test upgrade command shows output by default (manual verification)
+- [x] Test upgrade --quiet suppresses output (manual verification)
+
+---
+
 ### Step 3.6: Test Orchestrator
 **Goal**: Orchestrate pytest execution with services.
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -108,6 +108,7 @@ def library_venv(
     no_editable: Annotated[
         bool, typer.Option("--no-editable", help="Build wheel instead of editable install")
     ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
 ) -> None:
     """Set up virtual environment with OARepo dependencies.
 
@@ -135,14 +136,17 @@ def library_venv(
 
     # Create/verify venv
     venv_mgr = VirtualEnvironmentManager(config=context.config)
-    venv_path = venv_mgr.ensure_venv(requirements, force=force)
+    venv_path = venv_mgr.ensure_venv(requirements, force=force, quiet=quiet)
 
-    typer.secho("✨ ✓ Virtual environment ready!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    typer.secho(f"  Path: {venv_path}", fg=typer.colors.GREEN)
+    if not quiet:
+        typer.secho("✨ ✓ Virtual environment ready!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+        typer.secho(f"  Path: {venv_path}", fg=typer.colors.GREEN)
 
 
 @library_app.command("upgrade")
-def library_upgrade() -> None:
+def library_upgrade(
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
     """Clean cache and recreate virtual environment from scratch.
 
     This command:
@@ -157,36 +161,46 @@ def library_upgrade() -> None:
     # Discover project context
     context = discover_context()
 
-    typer.secho("🔄 Upgrading environment...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+    if not quiet:
+        typer.secho("🔄 Upgrading environment...", fg=typer.colors.BRIGHT_BLUE, bold=True)
 
     # Stop services if running
     services_mgr = ServicesLifecycleManager(
         config=context.config, project_root=context.root_directory
     )
     if services_mgr.are_services_running():
-        typer.secho("🛑 Stopping services...", fg=typer.colors.CYAN)
+        if not quiet:
+            typer.secho("🛑 Stopping services...", fg=typer.colors.CYAN)
         try:
             services_mgr.stop_services()
-            typer.secho("  ✓ Services stopped", fg=typer.colors.GREEN)
+            if not quiet:
+                typer.secho("  ✓ Services stopped", fg=typer.colors.GREEN)
         except Exception as e:
-            typer.secho(
-                f"  ⚠ Warning: Failed to stop services: {e}",
-                fg=typer.colors.YELLOW,
-                err=True,
-            )
+            if not quiet:
+                typer.secho(
+                    f"  ⚠ Warning: Failed to stop services: {e}",
+                    fg=typer.colors.YELLOW,
+                    err=True,
+                )
 
     # Clean uv cache
-    typer.secho("🧹 Cleaning uv cache...", fg=typer.colors.CYAN)
+    if not quiet:
+        typer.secho("🧹 Cleaning uv cache...", fg=typer.colors.CYAN)
     from oarepo_cli.services import process
 
     try:
-        process.run(["uv", "cache", "clean"], check=True)
-        typer.secho("  ✓ Cache cleaned", fg=typer.colors.GREEN)
+        process.run(["uv", "cache", "clean"], check=True, interactive=not quiet)
+        if not quiet:
+            typer.secho("  ✓ Cache cleaned", fg=typer.colors.GREEN)
     except Exception as e:
-        typer.secho(f"  ⚠ Warning: Failed to clean uv cache: {e}", fg=typer.colors.YELLOW, err=True)
+        if not quiet:
+            typer.secho(
+                f"  ⚠ Warning: Failed to clean uv cache: {e}", fg=typer.colors.YELLOW, err=True
+            )
 
     # Remove and recreate venv using VirtualEnvironmentManager
-    typer.secho("🔨 Recreating virtual environment...", fg=typer.colors.CYAN)
+    if not quiet:
+        typer.secho("🔨 Recreating virtual environment...", fg=typer.colors.CYAN)
 
     # Build requirements from context
     requirements = VenvRequirements(
@@ -198,10 +212,11 @@ def library_upgrade() -> None:
 
     # Create/verify venv with force=True to recreate
     venv_mgr = VirtualEnvironmentManager(config=context.config)
-    venv_path = venv_mgr.ensure_venv(requirements, force=True)
+    venv_path = venv_mgr.ensure_venv(requirements, force=True, quiet=quiet)
 
-    typer.secho("✨ ✓ Upgrade completed successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    typer.secho(f"  Virtual environment ready at {venv_path}", fg=typer.colors.GREEN)
+    if not quiet:
+        typer.secho("✨ ✓ Upgrade completed successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+        typer.secho(f"  Virtual environment ready at {venv_path}", fg=typer.colors.GREEN)
 
 
 @library_app.command("start")

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -12,6 +12,7 @@ import typer
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
+from oarepo_cli.ui import ConsoleOutput
 
 # Create the library subcommand group
 library_app = typer.Typer(
@@ -46,7 +47,10 @@ def _start_services_impl() -> None:
     # Discover project context
     context = discover_context()
 
-    typer.secho("🚀 Starting services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+    # Console always shows output for service commands
+    console = ConsoleOutput(quiet=False)
+
+    console.info("🚀 Starting services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
 
     # Start services using ServicesLifecycleManager
     services_mgr = ServicesLifecycleManager(
@@ -58,19 +62,17 @@ def _start_services_impl() -> None:
 
         if not env_vars:
             # Services were skipped (SKIP_SERVICES=1)
-            typer.secho("✓ Services skipped", fg=typer.colors.YELLOW)
+            console.info("✓ Services skipped", fg=typer.colors.YELLOW)
         else:
-            typer.secho(
+            console.success(
                 "✨ ✓ Services started successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
             )
-            typer.secho(
+            console.info(
                 f"  Environment variables written to {context.root_directory / '.env-services'}",
                 fg=typer.colors.GREEN,
             )
     except Exception as e:
-        typer.secho(
-            f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
-        )
+        console.error(f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
 
@@ -79,11 +81,14 @@ def _stop_services_impl() -> None:
     # Discover project context
     context = discover_context()
 
+    # Console always shows output for service commands
+    console = ConsoleOutput(quiet=False)
+
     if not (context.root_directory / ".env-services").exists():
-        typer.secho("✓ No services running", fg=typer.colors.YELLOW)
+        console.info("✓ No services running", fg=typer.colors.YELLOW)
         return
 
-    typer.secho("🛑 Stopping services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+    console.info("🛑 Stopping services...", fg=typer.colors.BRIGHT_BLUE, bold=True)
 
     # Stop services using ServicesLifecycleManager
     services_mgr = ServicesLifecycleManager(
@@ -92,11 +97,11 @@ def _stop_services_impl() -> None:
 
     try:
         services_mgr.stop_services()
-        typer.secho("✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    except Exception as e:
-        typer.secho(
-            f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True, err=True
+        console.success(
+            "✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
         )
+    except Exception as e:
+        console.error(f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
 
@@ -126,6 +131,9 @@ def library_venv(
     # Discover project context
     context = discover_context()
 
+    # Create console output handler
+    console = ConsoleOutput(quiet=quiet)
+
     # Build requirements from context
     requirements = VenvRequirements(
         python_binary=str(context.python_binary),
@@ -138,9 +146,8 @@ def library_venv(
     venv_mgr = VirtualEnvironmentManager(config=context.config)
     venv_path = venv_mgr.ensure_venv(requirements, force=force, quiet=quiet)
 
-    if not quiet:
-        typer.secho("✨ ✓ Virtual environment ready!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-        typer.secho(f"  Path: {venv_path}", fg=typer.colors.GREEN)
+    console.success("✨ ✓ Virtual environment ready!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    console.info(f"  Path: {venv_path}", fg=typer.colors.GREEN)
 
 
 @library_app.command("upgrade")
@@ -161,46 +168,38 @@ def library_upgrade(
     # Discover project context
     context = discover_context()
 
-    if not quiet:
-        typer.secho("🔄 Upgrading environment...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+    # Create console output handler
+    console = ConsoleOutput(quiet=quiet)
+
+    console.info("🔄 Upgrading environment...", fg=typer.colors.BRIGHT_BLUE, bold=True)
 
     # Stop services if running
     services_mgr = ServicesLifecycleManager(
         config=context.config, project_root=context.root_directory
     )
     if services_mgr.are_services_running():
-        if not quiet:
-            typer.secho("🛑 Stopping services...", fg=typer.colors.CYAN)
+        console.info("🛑 Stopping services...", fg=typer.colors.CYAN)
         try:
             services_mgr.stop_services()
-            if not quiet:
-                typer.secho("  ✓ Services stopped", fg=typer.colors.GREEN)
+            console.info("  ✓ Services stopped", fg=typer.colors.GREEN)
         except Exception as e:
-            if not quiet:
-                typer.secho(
-                    f"  ⚠ Warning: Failed to stop services: {e}",
-                    fg=typer.colors.YELLOW,
-                    err=True,
-                )
+            console.warning(
+                f"  ⚠ Warning: Failed to stop services: {e}",
+                fg=typer.colors.YELLOW,
+            )
 
     # Clean uv cache
-    if not quiet:
-        typer.secho("🧹 Cleaning uv cache...", fg=typer.colors.CYAN)
+    console.info("🧹 Cleaning uv cache...", fg=typer.colors.CYAN)
     from oarepo_cli.services import process
 
     try:
         process.run(["uv", "cache", "clean"], check=True, interactive=not quiet)
-        if not quiet:
-            typer.secho("  ✓ Cache cleaned", fg=typer.colors.GREEN)
+        console.info("  ✓ Cache cleaned", fg=typer.colors.GREEN)
     except Exception as e:
-        if not quiet:
-            typer.secho(
-                f"  ⚠ Warning: Failed to clean uv cache: {e}", fg=typer.colors.YELLOW, err=True
-            )
+        console.warning(f"  ⚠ Warning: Failed to clean uv cache: {e}", fg=typer.colors.YELLOW)
 
     # Remove and recreate venv using VirtualEnvironmentManager
-    if not quiet:
-        typer.secho("🔨 Recreating virtual environment...", fg=typer.colors.CYAN)
+    console.info("🔨 Recreating virtual environment...", fg=typer.colors.CYAN)
 
     # Build requirements from context
     requirements = VenvRequirements(
@@ -214,9 +213,8 @@ def library_upgrade(
     venv_mgr = VirtualEnvironmentManager(config=context.config)
     venv_path = venv_mgr.ensure_venv(requirements, force=True, quiet=quiet)
 
-    if not quiet:
-        typer.secho("✨ ✓ Upgrade completed successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-        typer.secho(f"  Virtual environment ready at {venv_path}", fg=typer.colors.GREEN)
+    console.success("✨ ✓ Upgrade completed successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    console.info(f"  Virtual environment ready at {venv_path}", fg=typer.colors.GREEN)
 
 
 @library_app.command("start")

--- a/oarepo_cli/services/process.py
+++ b/oarepo_cli/services/process.py
@@ -152,6 +152,7 @@ def run(
     forward_stdout: bool = False,
     timeout: float | None = None,
     strip_venv: bool = True,
+    interactive: bool = False,
 ) -> ProcessResult:
     """Execute a command and wait for completion. Never uses shell=True.
 
@@ -159,12 +160,14 @@ def run(
         command: List of command arguments (never a shell string)
         cwd: Working directory for the command
         env: Environment variables (merged with parent environment)
-        capture_output: Whether to capture stdout/stderr as strings
+        capture_output: Whether to capture stdout/stderr as strings (ignored if interactive=True)
         check: Raise ProcessExecutionError on non-zero exit code
         forward_stdout: Stream output to console while capturing
         timeout: Maximum execution time in seconds
         strip_venv: Strip VIRTUAL_ENV and related variables (default: True)
                     to prevent oarepo-cli's own venv from leaking
+        interactive: If True, run with real-time output (stdout/stderr inherit from parent),
+                     capture_output is ignored. Use for long-running commands.
 
     Returns:
         ProcessResult with exit code, output, and timing
@@ -178,6 +181,47 @@ def run(
     run_env = _merge_env(env, strip_venv=strip_venv)
     start_time = time.time()
 
+    # Interactive mode: inherit stdout/stderr for real-time output
+    if interactive:
+        try:
+            result = subprocess.run(
+                command,
+                cwd=cwd,
+                env=run_env,
+                timeout=timeout,
+            )
+
+            duration_ms = int((time.time() - start_time) * 1000)
+
+            process_result = ProcessResult(
+                return_code=result.returncode,
+                stdout="",
+                stderr="",
+                command=command,
+                cwd=cwd or Path.cwd(),
+                duration_ms=duration_ms,
+            )
+
+            if check and result.returncode != 0:
+                raise ProcessExecutionError(
+                    message=f"Command failed with exit code {result.returncode}",
+                    command=list(command),
+                    returncode=result.returncode,
+                    stdout=None,
+                    stderr=None,
+                )
+
+            return process_result
+
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutExceeded(
+                command=list(command),
+                timeout=timeout,
+                stdout=None,
+                stderr=None,
+            ) from exc
+
+    # Captured mode: capture output (original behavior)
     try:
         result = subprocess.run(
             command,

--- a/oarepo_cli/services/venv.py
+++ b/oarepo_cli/services/venv.py
@@ -100,6 +100,7 @@ class VirtualEnvironmentManager:
         self,
         requirements: VenvRequirements,
         force: bool = False,
+        quiet: bool = False,
     ) -> Path:
         """Ensure virtual environment exists with required packages.
 
@@ -110,6 +111,7 @@ class VirtualEnvironmentManager:
         Args:
             requirements: Python version, OARepo version, extras to install
             force: If True, remove existing venv and recreate from scratch
+            quiet: If True, suppress command output (for --quiet flag)
 
         Returns:
             Path to the virtual environment directory
@@ -124,9 +126,9 @@ class VirtualEnvironmentManager:
             shutil.rmtree(venv_path)
 
         if not venv_path.exists():
-            self._create_venv(requirements.python_binary, venv_path)
+            self._create_venv(requirements.python_binary, venv_path, quiet=quiet)
 
-        self._install_dependencies(requirements, venv_path)
+        self._install_dependencies(requirements, venv_path, quiet=quiet)
 
         return venv_path
 
@@ -151,12 +153,13 @@ class VirtualEnvironmentManager:
         if venv_path.exists():
             shutil.rmtree(venv_path)
 
-    def _create_venv(self, python: str, path: Path) -> None:
+    def _create_venv(self, python: str, path: Path, quiet: bool = False) -> None:
         """Create fresh virtual environment using uv.
 
         Args:
             python: Python executable path or name (e.g., "python3.14")
             path: Path where the venv should be created
+            quiet: If True, suppress command output
 
         Raises:
             ProcessExecutionError: If uv venv command fails
@@ -164,12 +167,14 @@ class VirtualEnvironmentManager:
         process.run(
             ["uv", "venv", "--python", python, "--seed", str(path)],
             check=True,
+            interactive=not quiet,
         )
 
     def _install_dependencies(
         self,
         requirements: VenvRequirements,
         venv_path: Path,
+        quiet: bool = False,
     ) -> None:
         """Install OARepo and project dependencies.
 
@@ -181,6 +186,7 @@ class VirtualEnvironmentManager:
         Args:
             requirements: Requirements specifying what to install
             venv_path: Path to the virtual environment
+            quiet: If True, suppress command output
 
         Raises:
             ProcessExecutionError: If any pip install command fails
@@ -194,6 +200,7 @@ class VirtualEnvironmentManager:
         process.run(
             [str(python_path), "-m", "pip", "install", "setuptools"],
             check=True,
+            interactive=not quiet,
         )
 
         # Build oarepo version constraint and install
@@ -209,13 +216,14 @@ class VirtualEnvironmentManager:
                     f"oarepo[{oarepo_constraint}]",
                 ],
                 check=True,
+                interactive=not quiet,
             )
 
         # Install project itself
         if requirements.editable:
-            self._install_editable(requirements)
+            self._install_editable(requirements, quiet=quiet)
         else:
-            self._build_and_install_wheel(requirements)
+            self._build_and_install_wheel(requirements, quiet=quiet)
 
     def _build_oarepo_constraint(self, requirements: VenvRequirements) -> str:
         """Build OARepo package constraint string.
@@ -240,11 +248,12 @@ class VirtualEnvironmentManager:
 
         return ",".join(constraint_parts)
 
-    def _install_editable(self, requirements: VenvRequirements) -> None:
+    def _install_editable(self, requirements: VenvRequirements, quiet: bool = False) -> None:
         """Install project in editable mode.
 
         Args:
             requirements: Requirements with extras to install
+            quiet: If True, suppress command output
 
         Raises:
             ProcessExecutionError: If pip install fails
@@ -260,13 +269,15 @@ class VirtualEnvironmentManager:
         process.run(
             ["uv", "pip", "install", "--prerelease", "allow", "-e", f".[{extras_str}]"],
             check=True,
+            interactive=not quiet,
         )
 
-    def _build_and_install_wheel(self, requirements: VenvRequirements) -> None:
+    def _build_and_install_wheel(self, requirements: VenvRequirements, quiet: bool = False) -> None:
         """Build wheel and install (non-editable mode).
 
         Args:
             requirements: Requirements with extras to install
+            quiet: If True, suppress command output
 
         Raises:
             ProcessExecutionError: If build or install fails
@@ -277,7 +288,7 @@ class VirtualEnvironmentManager:
             shutil.rmtree(dist_dir)
 
         # Build wheel
-        process.run(["uv", "build", "--wheel"], check=True)
+        process.run(["uv", "build", "--wheel"], check=True, interactive=not quiet)
 
         # Find the built wheel
         wheels = list(dist_dir.glob("*.whl"))
@@ -306,4 +317,5 @@ class VirtualEnvironmentManager:
                 f"{wheel_path}[{extras_str}]",
             ],
             check=True,
+            interactive=not quiet,
         )

--- a/oarepo_cli/ui/__init__.py
+++ b/oarepo_cli/ui/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""UI utilities for OARepo CLI."""
+
+from __future__ import annotations
+
+from oarepo_cli.ui.console import ConsoleOutput
+
+__all__ = ["ConsoleOutput"]

--- a/oarepo_cli/ui/console.py
+++ b/oarepo_cli/ui/console.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Console output utilities for OARepo CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+
+
+class ConsoleOutput:
+    """Manages console output with quiet mode support.
+
+    Provides info/success/warning/error methods that respect the quiet flag.
+    Error and warning messages are always shown, even in quiet mode.
+    Info and success messages are suppressed when quiet=True.
+    """
+
+    def __init__(self, quiet: bool = False) -> None:
+        """Initialize console output handler.
+
+        Args:
+            quiet: If True, suppress info/success messages (errors/warnings still shown)
+        """
+        self._quiet = quiet
+
+    def info(self, message: str, **kwargs: Any) -> None:
+        """Print an info message (suppressed in quiet mode).
+
+        Args:
+            message: Message to print
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+        """
+        if not self._quiet:
+            typer.secho(message, **kwargs)
+
+    def success(self, message: str, **kwargs: Any) -> None:
+        """Print a success message (suppressed in quiet mode).
+
+        Args:
+            message: Message to print
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+        """
+        if not self._quiet:
+            typer.secho(message, **kwargs)
+
+    def warning(self, message: str, **kwargs: Any) -> None:
+        """Print a warning message (always shown, even in quiet mode).
+
+        Args:
+            message: Message to print
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+                     err=True by default for warnings
+        """
+        # Default to stderr for warnings
+        if "err" not in kwargs:
+            kwargs["err"] = True
+        typer.secho(message, **kwargs)
+
+    def error(self, message: str, **kwargs: Any) -> None:
+        """Print an error message (always shown, even in quiet mode).
+
+        Args:
+            message: Message to print
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+                     err=True by default for errors
+        """
+        # Default to stderr for errors
+        if "err" not in kwargs:
+            kwargs["err"] = True
+        typer.secho(message, **kwargs)


### PR DESCRIPTION
This PR implements Step 3.5.1, adding real-time output for long-running commands and a `--quiet` flag.

## Problem

Previously, commands like `library venv` and `library upgrade` would capture all subprocess output, leaving users staring at a blank terminal while `uv` downloaded and installed packages. For long operations (cache cleaning, full environment rebuilds), this was frustrating.

## Solution

### By default: Real-time output (interactive mode)
- Users now see `uv` progress in real-time
- Progress bars, download info, and status messages all visible
- PTY available for subprocesses (colors work)

### With `--quiet`: Silent mode
- Info/success messages suppressed
- Warnings and errors still shown (important feedback)
- Useful for scripts and automation

## Changes

### 1. `ConsoleOutput` class (new: `oarepo_cli/ui/console.py`)
Replaces scattered `if not quiet: typer.secho(...)` pattern with a clean abstraction:

```python
console = ConsoleOutput(quiet=quiet)
console.info('Processing...', fg=typer.colors.CYAN)
console.success('Done!', fg=typer.colors.GREEN, bold=True)
console.warning('Warning!', fg=typer.colors.YELLOW)  # Always shown
console.error('Error!', fg=typer.colors.RED, bold=True)  # Always shown
```

**Methods:**
- `info()` - suppressed in quiet mode
- `success()` - suppressed in quiet mode
- `warning()` - **always shown** (even in quiet mode)
- `error()` - **always shown** (even in quiet mode)
- All use `**kwargs` for forward compatibility with `typer.secho`

### 2. `process.run()` additions
- New `interactive` parameter (default: False)
- When `interactive=True`, stdout/stderr inherit from parent
- When `interactive=False`, output is captured (original behavior)

### 3. `VirtualEnvironmentManager` additions
- New `quiet` parameter propagated through all methods:
  - `ensure_venv()`
  - `_create_venv()`
  - `_install_dependencies()`
  - `_install_editable()`
  - `_build_and_install_wheel()`
- All `process.run()` calls use `interactive=not quiet`

### 4. CLI commands updated
- `library venv` - added `--quiet/-q` flag
- `library upgrade` - added `--quiet/-q` flag
- All commands use `ConsoleOutput` for cleaner code

## Examples

```bash
# See real-time output (default)
oarepo-cli library venv

# Silent mode for scripts (warnings/errors still shown)
oarepo-cli library venv --quiet

# Upgrade with real-time progress
oarepo-cli library upgrade

# Silent upgrade
oarepo-cli library upgrade -q
```

## Testing

- All 219 existing tests pass
- Manual testing shows real-time output works correctly
- `--quiet` flag successfully suppresses info/success messages
- Warnings and errors still shown in quiet mode

## Documentation

- Added Step 3.5.1 to `docs/architecture/implementation-steps.md`
- New `oarepo_cli/ui/` module with `ConsoleOutput` class
- Updated process.py, venv.py, and library.py docstrings