### PR TITLE
Step 3.9.1: Migrate library lint type checking from mypy/pyright to ty

### DIFF
--- a/docs/architecture/00-main-architecture.md
+++ b/docs/architecture/00-main-architecture.md
@@ -24,7 +24,7 @@ The new implementation preserves all existing user-facing behavior while replaci
 | `shell` | `--skip-services` | Start bash shell in venv | Must preserve |
 | `invenio` | `--skip-services` | Run Invenio commands | Must preserve |
 | `translations` | - | Extract/compile translations via oarepo-tools | Must preserve |
-| `lint` | - | Run ruff, mypy, pyright, license checks (**planned:** drop mypy/pyright for `ty` — see §1.5 note and [implementation-steps.md Step 3.9.1](./implementation-steps.md)) | Must preserve |
+| `lint` | - | Run ruff, `ty`, license checks | Must preserve |
 | `format` | - | Format code with ruff | Must preserve |
 | `license-headers` | - | Add MIT license headers | Must preserve |
 | `jslint` | - | Run ESLint and Prettier | Must preserve |
@@ -93,20 +93,18 @@ The new implementation preserves all existing user-facing behavior while replaci
 | `docker compose` | Service orchestration | Optional (for services) |
 | `docker-services-cli` | Service environment setup | Optional |
 | `pytest` | Python testing | Optional (for test cmd) |
-| `ruff` | Linting/formatting | Optional |
-| `mypy` / `pyright` | Type checking | Optional |
+| `ruff` | Linting/formatting | Yes (bundled dependency, not shelled out to via `uvx`) |
+| `ty` | Type checking | Yes (bundled dependency, not shelled out to via `uvx`) |
 | `npm` / `pnpm` | JavaScript dependencies | Optional |
 | `jest` | JavaScript testing | Optional |
 | `curl` | Self-update download | Yes |
 | `openssl` | Certificate generation | Yes |
 | `git` | Repo initialization | Optional |
 
-> **Planned change (not yet implemented):** `library lint`'s type checking is
-> planned to migrate from `mypy` + `pyright` to `ty` alone (dropping both in
-> favor of the single tool already used for oarepo-cli's own type checking).
-> This is not reflected elsewhere in this document yet — see
-> [implementation-steps.md Step 3.9.1](./implementation-steps.md) for the
-> tracked follow-up work.
+`library lint`'s type checking uses `ty` alone (the same tool already used
+for oarepo-cli's own type checking) rather than `mypy` + `pyright` — see
+[implementation-steps.md Step 3.9.1](./implementation-steps.md) for the
+mapping from the old mypy/pyright configuration to `ty`'s.
 
 ### 1.6 Identified Issues & Risks
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -523,40 +523,37 @@ For unit-level tests, call `run()`/`stream()`/`get_output()` directly against re
 ### Step 3.9.1: Migrate Library `lint` Type Checking from mypy/pyright to `ty`
 **Goal**: Replace `mypy` and `pyright` in `library lint` with `ty` alone, so the CLI bundles and invokes a single type checker instead of two.
 
-This step is **not part of the original architecture design** — `00-main-architecture.md` §1.1 and §1.5 still describe `lint` as running `mypy`/`pyright` (with a "planned change" note pointing here) and were not otherwise updated for this decision. Update those notes to describe `ty` as the shipped implementation once this step lands.
+This step was **not part of the original architecture design** — `00-main-architecture.md` §1.1 and §1.5 originally described `lint` as running `mypy`/`pyright`, with a "planned change" note pointing here. Both sections have been updated to describe `ty` as the shipped implementation now that this step is complete.
 
-- [ ] Remove `mypy`, `pyright`, `types-pyyaml`, `types-requests` from oarepo-cli's dependencies (`pyproject.toml`)
-- [ ] Add `ty` as a runtime dependency of oarepo-cli (already present as a `dev`-only dependency for oarepo-cli's own type checking; needs to become a runtime one so `library lint` can invoke it)
-- [ ] Replace the `mypy`/`pyright` invocations in `LintRunner.run_lint()` (`oarepo_cli/services/lint.py`) with a single `ty check` invocation against `code_directories[0]`
-- [ ] Remove `.mypy.ini` generation; generate a `ty.toml` in the target project instead (same pattern as the existing `_write_config(root / ".ruff.toml", RUFF_TOML)` / `_write_config(root / ".mypy.ini", MYPY_INI)` calls — add a `TY_TOML` constant alongside `RUFF_TOML`/`MYPY_INI`)
-- [ ] Decide `ty`-equivalent handling for the old `--ignore-missing-imports`/`--exclude os-v2` mypy flags and pyright's `--pythonpath <venv_python>` (or confirm they're no longer applicable)
-- [ ] Update `docs/architecture/00-main-architecture.md` §1.1 and §1.5 to remove the "planned change" notes added for this step and describe `ty` as the actual implementation
+- [x] Remove `mypy`, `pyright`, `types-pyyaml`, `types-requests` from oarepo-cli's dependencies (`pyproject.toml`)
+- [x] Add `ty` as a runtime dependency of oarepo-cli (previously a `dev`-only dependency for oarepo-cli's own type checking; moved to core `dependencies` so `library lint` can invoke it too, and dropped from `dev` since core deps are always installed regardless of extras)
+- [x] Replace the `mypy`/`pyright` invocations in `LintRunner.run_lint()` (`oarepo_cli/services/lint.py`) with a single `ty check` invocation against `code_directories[0]`
+- [x] Remove `.mypy.ini` generation; generate a `ty.toml` in the target project instead. Note: by the time this step landed, `RUFF_TOML`/`MYPY_INI` were no longer Python string constants in `lint.py` — an earlier refactor moved them to real data files under `oarepo_cli/configuration/` (`ruff.toml.tmpl`, loaded lazily via `importlib.resources`). Followed that existing pattern instead of the string-constant one this bullet originally described: added `oarepo_cli/configuration/ty.toml.tmpl`, loaded via `resources.read_text("ty.toml.tmpl")`. The `.tmpl` suffix matters — a bare `ruff.toml`/`ty.toml` inside `oarepo_cli/configuration/` gets auto-discovered by ruff (confirmed) and could plausibly confuse `ty` (not confirmed either way, but not worth the risk) when linting/type-checking oarepo-cli's own source in that directory
+- [x] Decide `ty`-equivalent handling for the old `--ignore-missing-imports`/`--exclude os-v2` mypy flags and pyright's `--pythonpath <venv_python>` (or confirm they're no longer applicable) — see mapping below
+- [x] Update `docs/architecture/00-main-architecture.md` §1.1 and §1.5 to remove the "planned change" notes added for this step and describe `ty` as the actual implementation
 
-> **Note to whoever implements this step:** `ty.toml`'s ruleset must match
-> the behavior of the current `.mypy.ini` + pyright invocation as closely as
-> `ty` allows — this migration is meant to change *which tool* runs, not to
-> loosen or tighten what the target project's lint step actually catches.
-> Before writing `TY_TOML`, re-derive each setting from what's live today
-> rather than guessing at reasonable-looking defaults:
-> - `.mypy.ini`'s `warn_return_any`, `warn_unused_configs`, `warn_unreachable`,
->   `follow_untyped_imports` (see `MYPY_INI` in `oarepo_cli/services/lint.py`)
-> - the mypy CLI flags `--ignore-missing-imports` and `--exclude os-v2`
-> - pyright's `--pythonpath <venv_python>` (import resolution against the
->   target project's own venv, not oarepo-cli's)
->
-> For each one, find `ty`'s closest equivalent rule/option and carry it into
-> `ty.toml` deliberately (or record in this step, and in the PR description,
-> that `ty` has no equivalent and the check is being dropped) — don't just
-> ship `ty`'s defaults and call it done.
+**Resolved mypy/pyright → `ty` mapping** (researched against `ty` 0.0.65 and
+[docs.astral.sh/ty](https://docs.astral.sh/ty/), verified empirically — see
+below — rather than guessed from defaults):
+
+| Old setting | Where | `ty` equivalent | Notes |
+|---|---|---|---|
+| `--ignore-missing-imports` | mypy CLI flag | `ty.toml`: `[rules]` → `unresolved-import = "ignore"` | Confirmed by test: without it, an unresolvable import errors; with it, `ty check` passes. |
+| `--exclude os-v2` | mypy CLI flag | `ty.toml`: `[src]` → `exclude = ["**/os-v2/**"]` | A bare `"os-v2"` pattern does **not** exclude nested contents when the parent directory is passed explicitly on the command line (verified empirically — `ty check src/cleanlib` with `exclude = ["os-v2"]` still reported an error inside `src/cleanlib/os-v2/`); needed the `**/os-v2/**` glob form to actually exclude it. |
+| pyright `--pythonpath <venv_python>` | pyright CLI flag | `ty check --python <venv_python>` CLI flag | Kept as a CLI flag rather than baked into `ty.toml`, same as the old pyright invocation — it's per-invocation (the target project's venv path), not a static ruleset preference. |
+| `warn_return_any` | `.mypy.ini` | **Dropped, no equivalent** | `ty`'s rule set (checked against the full list at docs.astral.sh/ty/reference/rules/) has no rule for "function returns a value ty inferred as `Any`" — `ty`'s `invalid-return-type` rule checks assignability, not implicit-`Any` leakage, which is a different, mypy-specific inference-strictness concept. |
+| `warn_unreachable` | `.mypy.ini` | **Dropped, no equivalent** | No unreachable-code rule exists in `ty`'s rule set at all (confirmed against the full rule list). |
+| `warn_unused_configs` | `.mypy.ini` | **Dropped, not applicable** | This warns about stale/unmatched sections in `.mypy.ini` itself — a mypy-config-file-specific meta-check with no meaning under `ty`'s config format. |
+| `follow_untyped_imports` | `.mypy.ini` | **Dropped, no equivalent toggle** | Controls whether mypy analyzes untyped third-party packages' source instead of treating them as `Any`; `ty`'s import resolution model doesn't expose an equivalent on/off switch. |
 
 **Deliverables**:
-- [ ] `library lint` runs `ruff check`, `ruff format --check`, license header check, future annotations check, `ty check` — no `mypy`/`pyright` involved
-- [ ] Generated `ty.toml` whose rules are traceable back to the specific `.mypy.ini`/mypy-flag/pyright-flag settings they replace (documented in the PR description, not just the code)
-- [ ] Architecture docs no longer reference `mypy`/`pyright` as the lint type checker
+- [x] `library lint` runs `ruff check`, `ruff format --check`, license header check, future annotations check, `ty check` — no `mypy`/`pyright` involved
+- [x] Generated `ty.toml` whose rules are traceable back to the specific `.mypy.ini`/mypy-flag/pyright-flag settings they replace (see mapping table above; also documented in the PR description)
+- [x] Architecture docs no longer reference `mypy`/`pyright` as the lint type checker
 
 **Tests** (`tests/integration/test_library_lint_format.py`):
-- [ ] Update `test_lint_passes_on_clean_code`/`test_lint_fails_on_dirty_code` fixtures for `ty`'s diagnostics if they differ from mypy/pyright's
-- [ ] Test that `library lint` no longer shells out to `mypy`/`pyright` (e.g. no `.mypy.ini` generated)
+- [x] Update `test_lint_passes_on_clean_code`/`test_lint_fails_on_dirty_code` fixtures for `ty`'s diagnostics if they differ from mypy/pyright's — not needed, the existing clean/dirty fixtures pass/fail identically under `ty`; added a new `test_lint_fails_on_type_error` test (return-type mismatch) to exercise the `ty check` step specifically, since the existing dirty-code test only exercises the earlier `ruff check` step
+- [x] Test that `library lint` no longer shells out to `mypy`/`pyright` (e.g. no `.mypy.ini` generated) — folded into `test_lint_passes_on_clean_code`, which now asserts `ty.toml` exists and `.mypy.ini` does not
 
 ---
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -787,8 +787,8 @@ def library_lint(
 
     Runs, in order, stopping at the first failure: ruff check, ruff format
     --check, a license header check, a `from __future__ import annotations`
-    check, mypy, and pyright. Generates .ruff.toml and .mypy.ini config files
-    in the project root.
+    check, and ty check. Generates .ruff.toml and ty.toml config files in the
+    project root.
 
     Exits with the exit code of the first failing check.
     """

--- a/oarepo_cli/configuration/mypy.ini.tmpl
+++ b/oarepo_cli/configuration/mypy.ini.tmpl
@@ -1,5 +1,0 @@
-[mypy]
-warn_return_any = True
-warn_unused_configs = True
-warn_unreachable = True
-follow_untyped_imports = True

--- a/oarepo_cli/configuration/resources.py
+++ b/oarepo_cli/configuration/resources.py
@@ -11,7 +11,7 @@ from importlib import resources
 def read_text(filename: str) -> str:
     """Read a bundled configuration template's contents.
 
-    Templates (e.g. ``ruff.toml.tmpl``, ``mypy.ini.tmpl``) are stored as real
+    Templates (e.g. ``ruff.toml.tmpl``, ``ty.toml.tmpl``) are stored as real
     data files in this package rather than embedded as Python string
     constants, and are only read from disk when a caller actually needs them
     (e.g. `library lint`/`library format` writing them out to a target

--- a/oarepo_cli/configuration/ty.toml.tmpl
+++ b/oarepo_cli/configuration/ty.toml.tmpl
@@ -1,0 +1,11 @@
+[rules]
+# Equivalent to mypy's `--ignore-missing-imports`: don't error on
+# third-party imports ty can't resolve (e.g. untyped/undeclared deps).
+unresolved-import = "ignore"
+
+[src]
+# Equivalent to mypy's `--exclude os-v2`. Needs the `**/.../**` form. ty's
+# gitignore-style matcher (unlike mypy's regex) doesn't exclude a bare
+# "os-v2" pattern's nested contents when the parent directory is passed
+# explicitly on the command line - verified empirically against ty 0.0.65.
+exclude = ["**/os-v2/**"]

--- a/oarepo_cli/services/lint.py
+++ b/oarepo_cli/services/lint.py
@@ -24,7 +24,7 @@ def _tool_path(name: str) -> str:
     """Resolve a linter/type-checker binary installed alongside oarepo-cli.
 
     Args:
-        name: Console script name (e.g. "ruff", "mypy", "pyright")
+        name: Console script name (e.g. "ruff", "ty")
 
     Returns:
         Absolute path to the binary if found next to the current
@@ -113,7 +113,7 @@ class LintRunner:
         self._quiet = quiet
 
     def run_lint(self) -> process.ProcessResult:
-        """Run the full lint suite: ruff, license headers, future annotations, mypy, pyright.
+        """Run the full lint suite: ruff, license headers, future annotations, ty.
 
         Returns:
             ProcessResult of the first failing step, or a success result if all pass
@@ -161,26 +161,11 @@ class LintRunner:
                 + [f"{len(missing_annotations)} file(s) are missing future annotations."],
             )
 
-        _write_config(root / ".mypy.ini", resources.read_text("mypy.ini.tmpl"))
+        _write_config(root / "ty.toml", resources.read_text("ty.toml.tmpl"))
 
         venv_python = self._context.venv_path / "bin" / "python"
-        result = process.run(
-            [
-                _tool_path("mypy"),
-                str(code_directories[0]),
-                "--ignore-missing-imports",
-                "--exclude",
-                "os-v2",
-            ],
-            cwd=root,
-            check=False,
-            interactive=not self._quiet,
-        )
-        if not result.success:
-            return result
-
         return process.run(
-            [_tool_path("pyright"), "--pythonpath", str(venv_python), str(code_directories[0])],
+            [_tool_path("ty"), "check", "--python", str(venv_python), str(code_directories[0])],
             cwd=root,
             check=False,
             interactive=not self._quiet,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,8 @@ dependencies = [
     # Linters/type checkers run by `library lint`/`library format` against
     # the target project. Bundled as regular dependencies (rather than
     # invoked via `uvx`) so they run without a per-call resolve/download.
-    "mypy>=1.13.0",
-    "pyright>=1.1.380",
     "ruff>=0.9.0",
-    "types-pyyaml>=6.0",
-    "types-requests>=2.31",
+    "ty>=0.0.65",
 ]
 requires-python = ">=3.14,<3.15"
 
@@ -32,7 +29,6 @@ oarepo-cli = "oarepo_cli.cli.main:cli_main"
 [project.optional-dependencies]
 dev = [
     "ruff>=0.9.0",
-    "ty>=0.0.1a10",
     "pre-commit>=4.0.0",
 ]
 tests = [

--- a/tests/integration/test_library_lint_format.py
+++ b/tests/integration/test_library_lint_format.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
-"""Integration tests for library lint/format commands using real ruff/mypy/pyright."""
+"""Integration tests for library lint/format commands using real ruff/ty."""
 
 from __future__ import annotations
 
@@ -107,7 +107,10 @@ def test_lint_passes_on_clean_code(
 
     assert result.exit_code == 0
     assert (lint_project / ".ruff.toml").exists()
-    assert (lint_project / ".mypy.ini").exists()
+    assert (lint_project / "ty.toml").exists()
+    # ty replaced mypy/pyright entirely (Step 3.9.1) - no .mypy.ini should
+    # ever get generated anymore.
+    assert not (lint_project / ".mypy.ini").exists()
 
 
 def test_lint_fails_on_dirty_code(
@@ -153,6 +156,35 @@ def test_lint_fails_when_future_annotations_missing(
         "# Copyright (c) 2026 Example Org.\n\n"
         '"""Sample clean module."""\n\n\n'
         "def greet() -> str:\n"
+        '    """Return a greeting message."""\n'
+        '    return "hello"\n'
+    )
+
+    result = runner.invoke(app, ["library", "lint", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+
+def test_lint_fails_on_type_error(
+    runner: CliRunner, lint_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that 'library lint' exits non-zero when ty finds a real type error.
+
+    Exercises the ty check step specifically (Step 3.9.1's mypy/pyright ->
+    ty migration): the return type doesn't match the annotation, which
+    ruff/license/future-annotations checks don't catch, only a type checker
+    does.
+    """
+    monkeypatch.chdir(lint_project)
+
+    module = lint_project / "src" / "cleanlib" / "__init__.py"
+    module.write_text(
+        "# Copyright (c) 2026 Example Org.\n"
+        "#\n"
+        "# This file is a part of cleanlib.\n\n"
+        '"""Sample clean module."""\n\n'
+        "from __future__ import annotations\n\n\n"
+        "def greet() -> int:\n"
         '    """Return a greeting message."""\n'
         '    return "hello"\n'
     )


### PR DESCRIPTION
## Summary
- `library lint` now runs `ty check` instead of `mypy` + `pyright` — a single bundled type checker instead of two.
- `pyproject.toml`: drops `mypy`, `pyright`, `types-pyyaml`, `types-requests`; moves `ty` from a `dev`-only dependency to a core one.
- `LintRunner.run_lint()`: replaces the mypy+pyright pair with `ty check --python <venv_python> <code_directories[0]>`, and generates `ty.toml` (via the existing `oarepo_cli/configuration` template pattern, `ty.toml.tmpl` loaded through `importlib.resources`) instead of `.mypy.ini`.

## mypy/pyright → ty mapping

Deliberately re-derived from what was actually configured before, not shipped with ty's defaults (verified empirically against ty 0.0.65, full details/verification notes in `docs/architecture/implementation-steps.md` Step 3.9.1):

| Old setting | ty equivalent |
|---|---|
| mypy `--ignore-missing-imports` | `ty.toml`: `[rules] unresolved-import = "ignore"` |
| mypy `--exclude os-v2` | `ty.toml`: `[src] exclude = ["**/os-v2/**"]` (a bare `"os-v2"` pattern doesn't exclude nested contents when the parent dir is passed explicitly on the CLI — confirmed empirically, needed the `**/os-v2/**` glob form) |
| pyright `--pythonpath <venv_python>` | `ty check --python <venv_python>` CLI flag (kept dynamic, not baked into `ty.toml`) |
| mypy `warn_return_any` / `warn_unreachable` / `warn_unused_configs` / `follow_untyped_imports` | **Dropped, no ty equivalent** (checked against ty's full rule list — no unreachable-code rule exists at all, no rule for implicit-`Any` returns, and the other two are mypy-config-file-specific meta-settings) |

## Test plan
- [x] `make check` (lint + format + type-check)
- [x] `tests/integration/test_library_lint_format.py` — updated for `ty.toml`/no-`.mypy.ini`, added `test_lint_fails_on_type_error` (real return-type mismatch caught by `ty check`, not reachable by the earlier ruff/license/annotations steps)
- [x] Full `tests/unit` + `tests/core` + lint/format integration suite (178 tests) — all passing, no regressions
- [x] Verified `ty.toml.tmpl` lands in the built wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)