### PR TITLE
arch: Step 3.13 - Extract oarepo versions from dependency constraints

### DIFF
--- a/docs/architecture/00-main-architecture.md
+++ b/docs/architecture/00-main-architecture.md
@@ -61,53 +61,75 @@ requested explicitly, not derived from the bash scripts:
   modifies target project files, only generates `.ruff.toml`/`ty.toml`,
   same as `lint`/`format` already do).
 
-#### 1.1.2 Intentional divergence: `oarepo-versions` uses `[tool.oarepo-cli]` configuration
+#### 1.1.2 Intentional divergence: `oarepo-versions` extracts from dependency constraints
 
-**Implemented in Step 3.12** — see [implementation-steps.md Step
-3.12](./implementation-steps.md).
+**To be implemented in Step 3.13** — see [implementation-steps.md Step
+3.13](./implementation-steps.md).
 
 The original bash script extracted OARepo versions by scanning
 `pyproject.toml` for keys like `oarepo14`, `oarepo13` in
 `[project.optional-dependencies]`, supporting multiple versions:
 
 ```bash
-egrep "^oarepo[0-9]{2}\s*=" pyproject.toml
+egrep "^oarepo[0-9]{2}\\s*=" pyproject.toml
 ```
 
-This approach is replaced with a cleaner configuration model that aligns
-with the `[tool.oarepo-cli]` section used throughout the Python CLI:
+The initial Python CLI implementation (Step 3.12) replaced this with a
+`[tool.oarepo-cli].version` configuration key. **Step 3.13 refactors this
+approach** to instead extract version information directly from dependency
+constraints in `[project.dependencies]` or `[project.optional-dependencies]`,
+eliminating the need for separate configuration.
 
-**Old bash approach** (multiple versions from optional-dependencies keys):
+**Old bash approach** (scanned optional-dependencies keys):
 ```toml
 [project.optional-dependencies]
 oarepo14 = ["oarepo>=14.0.0,<15.0.0"]
 oarepo13 = ["oarepo>=13.0.0,<14.0.0"]
 ```
 
-**New Python CLI approach** (single version from tool configuration):
+**Step 3.12 approach** (explicit configuration, now deprecated):
 ```toml
 [tool.oarepo-cli]
 version = 14
 ```
 
-**Rationale:**
-- Aligns with the `[tool.oarepo-cli]` configuration section used for other
-  CLI settings (`venv.path`, `services.*`, etc.)
-- Simplifies configuration: projects target a single OARepo version, not
-  multiple simultaneously
-- Removes dependency on optional-dependencies key names for configuration
-  discovery
-- Provides a canonical location for OARepo version that's consistent with
-  how the CLI discovers it elsewhere (via `CliConfig.from_pyproject()`)
+**New Step 3.13 approach** (extracted from standard dependency declarations):
+```toml
+[project.dependencies]
+oarepo = ">=14.0.0,<15.0.0"
 
-The JSON output format remains compatible (returns a single-element list):
+# OR in optional dependencies:
+[project.optional-dependencies]
+dev = ["oarepo>=14.0.0,<15.0.0"]
+tests = ["oarepo>=13.0.0,<14.0.0"]  # multi-version support
+```
+
+**Rationale:**
+- **Single source of truth**: Version information lives where it already must
+  be declared (in dependency specs), not duplicated in a tool-specific config
+- **Standard Python packaging**: Aligns with PEP 621 and how all other tools
+  (pip, uv, poetry) already consume version constraints
+- **Multi-version support restored**: Unlike the Step 3.12 single-version
+  config, this approach can detect multiple oarepo versions across different
+  extras (e.g., dev with v14, tests with v13) and return them highest-first
+- **Zero configuration**: Projects following standard packaging conventions
+  work out-of-the-box without any `[tool.oarepo-cli]` section
+- **Less opinionated**: The CLI doesn't dictate a specific configuration
+  structure beyond standard dependencies
+
+The JSON output format returns all detected major versions, sorted
+highest-first:
 ```json
 {
-  "oarepo_versions": ["14"],
+  "oarepo_versions": [14, 13],
   "python_versions": ["3.14"],
   "node_versions": ["24"]
 }
 ```
+
+For projects with a single oarepo dependency, the behavior is identical to
+Step 3.12 (single-element list). Projects with multiple versions in different
+extras now get all versions reported, restoring the bash script's capability.
 
 ### 1.2 Repository Installer Commands
 

--- a/docs/architecture/01-detailed-design.md
+++ b/docs/architecture/01-detailed-design.md
@@ -564,25 +564,88 @@ class PyProjectData:
 
     @property
     def oarepo_versions(self) -> list[int]:
-        """Extract OARepo versions from dependency constraints.
+        """Extract OARepo major versions from dependency constraints.
 
-        Looks for patterns like:
-          oarepo13 = ">=13.0.0,<14.0.0"
-          oarepo14 = ">=14.0.0,<15.0.0"
+        Scans [project].dependencies and [project].optional-dependencies for
+        'oarepo' package references and extracts major version numbers from
+        version constraints.
+
+        Supports patterns like:
+          oarepo>=14.0.0,<15.0.0  → 14
+          oarepo>=13.0.0,<14.0.0  → 13
+          oarepo==14.0.5         → 14
+
+        Returns:
+            List of unique major versions, sorted highest-first.
+            Example: [14, 13] for a project using oarepo 14 in main deps
+                     and oarepo 13 in tests extra.
+
+        Note:
+            This replaces the Step 3.12 approach of reading from
+            [tool.oarepo-cli].version, eliminating duplicate configuration.
+            Version constraints are parsed using packaging.specifiers.
         """
-        versions = []
-        deps = self.optional_dependencies.get("oarepo", [])
+        versions = set()
 
-        for dep in deps:
-            if match := re.match(r"oarepo(\d+)", dep):
-                versions.append(int(match.group(1)))
+        # Scan main dependencies
+        for dep in self.dependencies:
+            if version := _extract_oarepo_version_from_specifier(dep):
+                versions.add(version)
 
-        return sorted(set(versions))
+        # Scan all optional dependency groups
+        for extra_deps in self.optional_dependencies.values():
+            for dep in extra_deps:
+                if version := _extract_oarepo_version_from_specifier(dep):
+                    versions.add(version)
+
+        return sorted(versions, reverse=True)  # Highest first
 
     @property
     def default_extras(self) -> list[str]:
         """Default extras to always install."""
         return self.raw.get("tool", {}).get("oarepo", {}).get("default_extras", [])
+
+
+def _extract_oarepo_version_from_specifier(dep_spec: str) -> int | None:
+    """Extract major version from an oarepo dependency specifier.
+
+    Args:
+        dep_spec: A PEP 508 dependency specifier, e.g.:
+                  "oarepo>=14.0.0,<15.0.0"
+                  "oarepo==14.0.5"
+                  "oarepo[search]>=13.0.0,<14.0.0"
+
+    Returns:
+        The major version number if the package is 'oarepo', else None.
+        Returns None for invalid specifiers (logs warning).
+
+    Example:
+        >>> _extract_oarepo_version_from_specifier("oarepo>=14.0.0,<15.0.0")
+        14
+        >>> _extract_oarepo_version_from_specifier("other-package>=1.0")
+        None
+    """
+    from packaging.requirements import Requirement, InvalidRequirement
+    import logging
+
+    try:
+        req = Requirement(dep_spec)
+    except InvalidRequirement:
+        logging.warning(f"Invalid dependency specifier: {dep_spec}")
+        return None
+
+    if req.name != "oarepo":
+        return None
+
+    # Extract major version from specifiers (>=X.Y.Z or ==X.Y.Z patterns)
+    for spec in req.specifier:
+        if spec.operator in (">=", "==", "~="):
+            # Parse version string (e.g., "14.0.0" -> 14)
+            version_str = spec.version
+            major = int(version_str.split(".")[0])
+            return major
+
+    return None
 
 
 class PyProjectReader:

--- a/docs/architecture/03-migration-guide.md
+++ b/docs/architecture/03-migration-guide.md
@@ -285,45 +285,71 @@ Step 3.12](./implementation-steps.md) and [00-main-architecture.md
 
 **What changed:** The OARepo version is now configured in `[tool.oarepo-cli]`
 instead of being inferred from `[project.optional-dependencies]` keys.
+### 5.6 `oarepo-versions` now extracts from dependency constraints (Step 3.13)
 
-**Old approach** (bash script):
+**Old approach** (bash script, scanned for `oarepoXX` keys):
 ```toml
 [project.optional-dependencies]
 oarepo14 = ["oarepo>=14.0.0,<15.0.0"]
 oarepo13 = ["oarepo>=13.0.0,<14.0.0"]
 ```
 
-**New approach** (Python CLI):
+**Interim approach** (Step 3.12, explicit configuration - now **deprecated**):
 ```toml
 [tool.oarepo-cli]
 version = 14
 ```
 
-**Reason:**
-- Aligns with the `[tool.oarepo-cli]` configuration section used for other
-  CLI settings
-- Simplifies configuration: projects target a single OARepo version, not
-  multiple simultaneously
-- Provides a canonical location for version discovery, consistent with how
-  the CLI reads other settings via `CliConfig.from_pyproject()`
+**New approach** (Step 3.13, extracted from standard dependencies):
+```toml
+# Main dependencies (most common)
+[project.dependencies]
+oarepo = ">=14.0.0,<15.0.0"
 
-**Migration:** Add `[tool.oarepo-cli]` section with `version` key to your
-`pyproject.toml`. The JSON output format remains compatible (still returns a
-list, now with a single element):
-
-```bash
-# Old bash output (multi-version)
-./run.sh oarepo-versions
-{"oarepo_versions": ["13", "14"], ...}
-
-# New Python CLI output (single version)
-oarepo-cli library oarepo-versions
-{"oarepo_versions": ["14"], ...}
+# OR in optional dependencies
+[project.optional-dependencies]
+dev = ["oarepo>=14.0.0,<15.0.0"]
+tests = ["oarepo>=13.0.0,<14.0.0"]  # supports multi-version
 ```
 
-**Note:** The optional-dependencies keys (`oarepo14`, etc.) are no longer
-used by the CLI for version discovery, but you may keep them for dependency
-management purposes.
+**Reason:**
+- **Single source of truth**: Version information is extracted from where it
+  must already be declared (dependency specs), not duplicated in tool config
+- **Standard Python packaging**: Aligns with PEP 621 and how pip/uv/poetry
+  already consume version constraints
+- **Zero configuration**: Projects using standard dependency declarations work
+  out-of-the-box
+- **Multi-version support**: Unlike the Step 3.12 config approach, this can
+  detect multiple oarepo versions across different extras (restoring bash
+  behavior)
+
+**Migration:**
+
+1. **If you added `[tool.oarepo-cli].version` in Step 3.12**: Remove it. The
+   CLI will now extract the version from your existing `oarepo` dependency in
+   `[project.dependencies]` or `[project.optional-dependencies]`.
+
+2. **If you have standard oarepo dependencies**: No action needed! The CLI
+   automatically detects version constraints from patterns like:
+   - `oarepo>=14.0.0,<15.0.0` → version 14
+   - `oarepo==14.0.5` → version 14
+   - Multiple versions in different extras → returns all, highest-first
+
+3. **If you have no oarepo dependency**: The command returns an empty list
+   (same as before if `[tool.oarepo-cli].version` was missing).
+
+**Output format** (unchanged, still JSON):
+```bash
+# Single version
+oarepo-cli library oarepo-versions
+{"oarepo_versions": [14], "python_versions": ["3.14"], ...}
+
+# Multi-version (if oarepo appears in multiple extras with different constraints)
+{"oarepo_versions": [14, 13], "python_versions": ["3.14"], ...}
+```
+
+**Note:** The `[tool.oarepo-cli].version` key from Step 3.12 is ignored with a
+warning if present. The CLI always reads from dependency constraints now.
 
 ---
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -658,8 +658,44 @@ them to describe the shipped behavior once this step lands).
 - [x] Test versions extracted correctly
 - [x] Test configuration from `[tool.oarepo-cli].version`
 
-**Note**: This is an intentional divergence from the bash script's multi-version
-approach. See `docs/architecture/00-main-architecture.md` §1.1.2 for rationale.
+**Note**: This approach is **superseded by Step 3.13**, which extracts versions
+from dependency constraints instead of requiring explicit configuration. Step
+3.12 remains functional but the `[tool.oarepo-cli].version` key is deprecated.
+
+---
+
+### Step 3.13: Refactor `oarepo-versions` to Extract from Dependencies
+**Goal**: Replace `[tool.oarepo-cli].version` configuration with automatic extraction from main/optional dependencies.
+
+- [ ] Update `PyProjectData.oarepo_versions()` to scan `dependencies` and `optional-dependencies` for `oarepo` package
+- [ ] Parse version constraints (e.g., `"oarepo>=14.0.0,<15.0.0"` → major version `14`)
+- [ ] Return list of major versions sorted highest-first
+- [ ] Support both main dependencies and dev/tests extras
+- [ ] Remove reliance on `[tool.oarepo-cli].version` key
+
+**Deliverables**:
+- [ ] Updated `PyProjectData.oarepo_versions` property
+- [ ] Updated architectural docs (00-main-architecture.md §1.1.2, 01-detailed-design.md §6.3, 03-migration-guide.md §5.6)
+
+**Tests** (`tests/unit/test_pyproject_reader.py`, `tests/integration/test_library_versions.py`):
+- [ ] Test extraction from main dependencies: `oarepo>=14.0.0,<15.0.0` → `[14]`
+- [ ] Test extraction from optional dependencies (dev, tests extras)
+- [ ] Test multiple constraints: `oarepo>=13.0.0,<14.0.0` and `oarepo>=14.0.0,<15.0.0` → `[14, 13]` (highest first)
+- [ ] Test exact version pins: `oarepo==14.0.5` → `[14]`
+- [ ] Test no oarepo dependency → `[]`
+- [ ] Test invalid constraint format (gracefully ignore/log warning)
+- [ ] Integration test: JSON output still valid after refactor
+
+**Migration impact**:
+- Existing `[tool.oarepo-cli].version` configuration becomes **deprecated but not removed** (CLI ignores it with a warning if present)
+- Projects using standard dependency declarations automatically work without config changes
+- See updated migration guide for transition plan
+
+**Rationale**:
+- Eliminates duplicate configuration: the oarepo version is already declared in dependencies
+- Aligns with standard Python packaging practices (version constraints live in `[project]` section)
+- Supports projects with multiple oarepo versions in different extras (e.g., dev with v14, tests with v13)
+- Makes the CLI less opinionated about project structure
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds **Step 3.13** to the implementation plan, planning a refactor of the `oarepo-versions` command to extract version information from dependency constraints instead of requiring explicit `[tool.oarepo-cli].version` configuration.

## Changes

### Architecture Documents Updated

1. **implementation-steps.md**: Added new Step 3.13 with:
   - Implementation tasks for updating `PyProjectData.oarepo_versions()`
   - Comprehensive test plan covering various constraint patterns
   - Migration impact notes
   - Rationale for the change

2. **00-main-architecture.md §1.1.2**: Updated divergence documentation to:
   - Show evolution from bash \u2192 Step 3.12 \u2192 Step 3.13
   - Explain rationale for extracting from dependencies vs. config
   - Document restored multi-version support capability

3. **01-detailed-design.md §6.3**: Updated `PyProjectData` interface with:
   - New implementation of `oarepo_versions` property
   - Helper function `_extract_oarepo_version_from_specifier()`
   - Uses `packaging.requirements` for robust PEP 508 parsing

4. **03-migration-guide.md §5.6**: Updated migration section to:
   - Mark `[tool.oarepo-cli].version` as deprecated
   - Provide migration path from Step 3.12
   - Show zero-config approach for standard projects

### Key Benefits

- **Single source of truth**: No duplicate version configuration
- **Standard Python packaging**: Aligns with PEP 621, pip/uv/poetry conventions
- **Zero configuration**: Works out-of-the-box for projects with standard dependencies
- **Multi-version support**: Restores bash script's capability to detect multiple versions
- **Less opinionated**: Doesn't dictate configuration structure

### Migration Path

Projects using `[tool.oarepo-cli].version` from Step 3.12 can simply remove that configuration. The CLI will automatically extract the version from existing `oarepo` dependencies in `[project.dependencies]` or `[project.optional-dependencies]`.

## Related Steps

- Supersedes: Step 3.12 (which introduced `[tool.oarepo-cli].version`)
- Depends on: Nothing (architectural planning only)
- Blocks: Nothing (can be implemented independently)

## Testing Strategy

Comprehensive test plan included in implementation-steps.md covering:
- Main dependencies extraction
- Optional dependencies (dev/tests extras)
- Multi-version scenarios
- Edge cases (exact pins, no oarepo, invalid specs)

---

**Note**: This is an **architectural planning PR** only — no code changes. The implementation will follow in a separate PR per step 3.13's checklist.