### PR TITLE
Add Step 4.1's missing repository install integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Real repository fixture for integration tests, generated on demand via
+# repository_installer.sh (see tests/conftest.py:testrepo_project) -- large,
+# machine-local, and contains its own nested git repo.
+tests/testrepo/
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -762,11 +762,20 @@ from dependency constraints instead of requiring explicit configuration. Step
 - Working install command
 
 **Tests** (`tests/integration/test_repository_install.py`):
-- [ ] Test venv synced
-- [ ] Test translations copied
-- [ ] Test instance path created
-- [ ] Test `.invenio.private` configured
-- [ ] Integration test: full install in temp repo
+- [x] Test venv synced
+- [x] Test translations copied
+- [x] Test instance path created
+- [x] Test `.invenio.private` configured
+- [x] Integration test: full install in temp repo
+
+Runs against a real scaffolded repository rather than a mocked one: see
+`tests/conftest.py`'s `testrepo_project` (creates it once via the real
+`repository_installer.sh` — https://nrp-cz.github.io/docs/installation/create_instance
+— and reuses the cached scaffold on subsequent runs) and `clean_testrepo`/
+`reset_testrepo_state`. A full install (`uv sync` of invenio-app-rdm and
+friends, `invenio-cli install`) takes 1-2 minutes even with a warm cache,
+so `installed_repo` (module-scoped, in the test file) runs it once and
+every test asserts on a distinct side effect of that single run.
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import contextlib
 import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,7 +19,22 @@ if TYPE_CHECKING:
 
 from oarepo_cli.core.config import CliConfig, ServicesConfig, TestingConfig
 from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
+
+# https://raw.githubusercontent.com/oarepo/oarepo/refs/heads/main/tools/repository_installer.sh
+# creates a real repository from the nrp-app-copier template, as documented at
+# https://nrp-cz.github.io/docs/installation/create_instance
+REPOSITORY_INSTALLER_URL = (
+    "https://raw.githubusercontent.com/oarepo/oarepo/refs/heads/main/tools/repository_installer.sh"
+)
+
+REPOSITORY_CONFIG_YAML = """\
+repository_human_name: Test Repository
+repository_description: Integration test repository for oarepo-cli
+languages: cs
+use_ccmm: false
+"""
 
 
 @pytest.fixture
@@ -125,3 +142,108 @@ def test_context(clean_testlib: Path) -> ProjectContext:
         oarepo_version=14,
         config=config,
     )
+
+
+@pytest.fixture(scope="session")
+def testrepo_project() -> Path:
+    """Path to a real, scaffolded Invenio RDM repository for repository-install tests.
+
+    Unlike ``testlib_project`` (a small, hand-written fixture committed to
+    the repo), a real repository is too large and heavyweight (its own
+    nested git repo, generated docker/i18n/UI assets) to commit. Instead
+    it's created on demand, once, via the real installer described at
+    https://nrp-cz.github.io/docs/installation/create_instance -- the same
+    ``repository_installer.sh`` a user would run, driving the
+    ``nrp-app-copier`` template through ``copier``. If ``tests/testrepo``
+    already exists (from a previous run), creation is skipped entirely and
+    the cached scaffold is reused, since generation itself is slow
+    (network + copier) even before ``repository install`` runs anything.
+    """
+    root = Path(__file__).parent / "testrepo"
+    if (root / "pyproject.toml").exists():
+        return root
+
+    root.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        installer = tmp_path / "repository_installer.sh"
+        subprocess.run(
+            ["curl", "-fsSL", "-o", str(installer), REPOSITORY_INSTALLER_URL],
+            check=True,
+        )
+        installer.chmod(0o755)
+
+        config_file = tmp_path / "repo_config.yaml"
+        config_file.write_text(REPOSITORY_CONFIG_YAML)
+
+        # macOS ships bash 3.2 as /bin/bash (frozen for licensing reasons),
+        # which mishandles the script's `"${@}"` expansion under `set -u`
+        # when called with zero arguments. Same issue and fix as
+        # PlatformDetector.get_default_shell().
+        subprocess.run(
+            [
+                get_platform_detector().get_default_shell(),
+                str(installer),
+                "--python",
+                "python3.14",
+                "--config",
+                str(config_file),
+                root.name,
+            ],
+            cwd=root.parent,
+            check=True,
+        )
+
+    return root
+
+
+def reset_testrepo_state(testrepo_project: Path) -> None:
+    """Remove everything a `repository install`/`services` run generates.
+
+    Removes ``.venv``, ``uv.lock``, ``.invenio.private``, the rendered
+    Invenio instance directory, ``.env-services``, and the ``docker/.env``
+    symlink invenio-cli's install step creates -- while leaving the real
+    scaffolded project (``pyproject.toml``, ``invenio.cfg``, ``variables``,
+    docker compose files, ...) untouched. Plain function (not a fixture) so
+    it can be reused at whatever fixture scope a given test module needs --
+    see ``clean_testrepo`` (function scope) and
+    ``tests/integration/test_repository_install.py``'s ``installed_repo``
+    (module scope, since a full install is too slow to redo per test).
+    """
+    venv_path = testrepo_project / ".venv"
+    uv_lock = testrepo_project / "uv.lock"
+    invenio_private = testrepo_project / ".invenio.private"
+    env_services = testrepo_project / ".env-services"
+    docker_env = testrepo_project / "docker" / ".env"
+
+    config = CliConfig()
+    config.services = ServicesConfig(skip=False)
+    services_mgr = ServicesLifecycleManager(config=config, project_root=testrepo_project)
+    if services_mgr.are_services_running():
+        with contextlib.suppress(Exception):
+            services_mgr.stop_services()
+
+    if venv_path.exists():
+        shutil.rmtree(venv_path)
+    if uv_lock.exists():
+        uv_lock.unlink()
+    if invenio_private.exists():
+        invenio_private.unlink()
+    if env_services.exists():
+        env_services.unlink()
+    if docker_env.exists() or docker_env.is_symlink():
+        docker_env.unlink()
+    for pycache in testrepo_project.rglob("__pycache__"):
+        shutil.rmtree(pycache, ignore_errors=True)
+
+
+@pytest.fixture
+def clean_testrepo(testrepo_project: Path) -> Iterator[Path]:
+    """Reset testrepo_project's install-generated state before and after each test.
+
+    See ``reset_testrepo_state`` for exactly what's removed.
+    """
+    reset_testrepo_state(testrepo_project)
+    yield testrepo_project
+    reset_testrepo_state(testrepo_project)

--- a/tests/integration/test_repository_install.py
+++ b/tests/integration/test_repository_install.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `repository install` against a real scaffolded repository.
+
+Unlike the library integration tests, a full repository install pulls in
+invenio-app-rdm and friends, so it is slow (several minutes). The
+``installed_repo`` fixture below runs it exactly once per test session and
+every test in this module asserts on a distinct side effect of that single
+run, matching the checklist in docs/architecture/implementation-steps.md's
+Step 4.1: venv synced, translations copied, instance path created,
+``.invenio.private`` configured, and the run succeeding end-to-end.
+
+See tests/conftest.py:testrepo_project for how the fixture repository
+itself is created (via the real ``repository_installer.sh``, as documented
+at https://nrp-cz.github.io/docs/installation/create_instance).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from tests.conftest import reset_testrepo_state
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(scope="module")
+def installed_repo(testrepo_project: Path) -> Iterator[Path]:
+    """Run a real `oarepo-cli repository install` once, shared by this module's tests.
+
+    Uses ``reset_testrepo_state`` directly rather than the (function-scoped)
+    ``clean_testrepo`` fixture, since a full install is too slow to redo for
+    every test function -- see that function's docstring.
+    """
+    reset_testrepo_state(testrepo_project)
+    previous_cwd = Path.cwd()
+    os.chdir(testrepo_project)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(app, ["repository", "install"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        yield testrepo_project
+    finally:
+        os.chdir(previous_cwd)
+        reset_testrepo_state(testrepo_project)
+
+
+def _site_packages(repo: Path) -> Path:
+    lib_dir = repo / ".venv" / "lib"
+    (python_dir,) = lib_dir.glob("python*")
+    return python_dir / "site-packages"
+
+
+def test_full_install_succeeds(installed_repo: Path) -> None:
+    """Integration test: a full `repository install` run completes successfully."""
+    assert (installed_repo / ".venv").exists()
+    assert (installed_repo / ".venv" / "bin" / "python").exists()
+
+
+def test_venv_synced(installed_repo: Path) -> None:
+    """`uv sync` installed the project's dependencies into .venv, with a lockfile."""
+    assert (installed_repo / ".venv" / "bin" / "python").exists()
+    assert (installed_repo / "uv.lock").exists()
+
+    # invenio-app-rdm (or an equivalent oarepo-provided package) must actually
+    # be installed, not just an empty venv.
+    site_packages = _site_packages(installed_repo)
+    assert (site_packages / "invenio_app_rdm").is_dir() or (site_packages / "oarepo").is_dir()
+
+
+def test_translations_copied(installed_repo: Path) -> None:
+    """Collected OARepo translations were overlaid onto site-packages."""
+    site_packages = _site_packages(installed_repo)
+    overlay_source = site_packages / "oarepo" / "collected_translations"
+    if not overlay_source.exists():
+        pytest.skip("installed oarepo package has no collected_translations to overlay")
+
+    overlaid_items = list(overlay_source.iterdir())
+    assert overlaid_items, "collected_translations exists but is empty"
+    for item in overlaid_items:
+        assert (site_packages / item.name).exists()
+
+
+def test_instance_path_created(installed_repo: Path) -> None:
+    """The Invenio instance directory was created with invenio.cfg symlinked in."""
+    instance_path = installed_repo / ".venv" / "var" / "instance"
+    assert instance_path.is_dir()
+
+    invenio_cfg_link = instance_path / "invenio.cfg"
+    if (installed_repo / "invenio.cfg").exists():
+        assert invenio_cfg_link.is_symlink()
+        assert invenio_cfg_link.resolve() == (installed_repo / "invenio.cfg").resolve()
+
+
+def test_invenio_private_configured(installed_repo: Path) -> None:
+    """.invenio.private has the local service ports written by configure_local_ports()."""
+    invenio_private = installed_repo / ".invenio.private"
+    assert invenio_private.exists()
+
+    content = invenio_private.read_text()
+    for key in ("search_port", "db_port", "redis_port", "rabbitmq_port", "s3_port", "web_port"):
+        assert f"{key} =" in content, f"{key} missing from .invenio.private:\n{content}"


### PR DESCRIPTION
## Summary
- Implements the 5 outstanding checklist items under Step 4.1 in `docs/architecture/implementation-steps.md`: venv synced, translations copied, instance path created, `.invenio.private` configured, and a full end-to-end install.
- Tests run against a **real** scaffolded Invenio RDM repository, per https://nrp-cz.github.io/docs/installation/create_instance, rather than a mocked one.
- `tests/conftest.py`'s new `testrepo_project` fixture downloads and runs the real `repository_installer.sh` (driving the `nrp-app-copier` template via `copier`) once, caching the scaffold at `tests/testrepo/` (gitignored — it's large and has its own nested git repo) and reusing it on later runs. `clean_testrepo`/`reset_testrepo_state` reset everything an install generates (`.venv`, `uv.lock`, `.invenio.private`, ...) without touching the scaffold.
- `tests/integration/test_repository_install.py`'s module-scoped `installed_repo` fixture runs one real `oarepo-cli repository install` (~1-2 min even with a warm scaffold cache), and each test asserts a distinct side effect of that single run.
- Along the way: the installer script's `"${@}"` under `set -u` crashes on macOS's ancient default `/bin/bash` (3.2). Fixed by reusing this codebase's existing `PlatformDetector.get_default_shell()` (prefers Homebrew bash), the same workaround already used elsewhere for this exact issue.

## Test plan
- [x] `uv run pytest tests/integration/test_repository_install.py -v` — 5/5 passed, both cold (creates `tests/testrepo`) and warm (reuses cached scaffold)
- [x] `uv run pytest tests/unit tests/core -q` — 204 passed, no regressions
- [x] `uv run ruff check` / `ruff format --check` / `ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)