### PR TITLE
Step 4.2: Repository upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | Command | Description | Status |
 |---------|-------------|--------|
 | [`install`](#repository-install) | Install repository in virtual environment | ✅ Implemented |
-| `upgrade` | Clean cache and reinstall | 🔜 Phase 4.2 |
+| [`upgrade`](#repository-upgrade) | Clean cache and reinstall | ✅ Implemented |
 | `services` | Manage Docker services | 🔜 Phase 4.3 |
 | `model` | Create/update record models | 🔜 Phase 4.4 |
 | `local` | Manage local package dependencies | 🔜 Phase 4.5 |
@@ -522,7 +522,7 @@ oarepo-cli repository install
 **What it does:**
 1. Creates/syncs virtual environment with `uv sync` (reads `pyproject.toml`)
 2. Copies translation overlays from `oarepo/collected_translations` to site-packages
-3. Detects instance path via `invenio shell` (`app.instance_path`)
+3. Resolves instance path (`INVENIO_INSTANCE_PATH` env var, else `<venv>/var/instance` — Invenio's own default, computed directly rather than booting `invenio shell`)
 4. Creates instance directory and symlinks `invenio.cfg`
 5. Runs `invenio-cli install` (sets up assets, database tables, etc.)
 6. Configures local service ports in `.invenio.private` (reads from `variables` file)
@@ -546,9 +546,41 @@ oarepo-cli repository install --quiet
 - Better error messages (Python exceptions vs. bash set -e)
 - No parent-shell environment mutation (writes `.invenio.private` instead)
 
+### `repository upgrade`
+
+Cleans the virtual environment, uv cache, and lockfile, then fully reinstalls the repository.
+
+```bash
+oarepo-cli repository upgrade
+```
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses (uv, invenio-cli, etc.)
+
+**What it does:**
+1. Removes the virtual environment (`.venv`), if present
+2. Removes `uv.lock`, if present
+3. Cleans the uv cache with `uv cache clean --force`
+4. Reinstalls the repository (same steps as `repository install`)
+
+**Examples:**
+```bash
+# Standard upgrade
+oarepo-cli repository upgrade
+
+# Quiet mode (suppress subprocess output)
+oarepo-cli repository upgrade --quiet
+```
+
+**Exit codes:**
+- `0`: Upgrade successful
+- `1`: Upgrade failed (subprocess error, missing files, etc.)
+
+Use this after updating OARepo/RDM version pins, or when the environment needs a clean rebuild.
+
 ### Other Repository Commands
 
-_Commands below are to be implemented in Phase 4 (steps 4.2-4.11)._
+_Commands below are to be implemented in Phase 4 (steps 4.3-4.11)._
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -827,18 +827,36 @@ default resolution rule. See
 ### Step 4.2: Repository `upgrade` Command
 **Goal**: Implement repository upgrade.
 
-- [ ] Implement `repository_upgrade()` function
-- [ ] Remove venv and uv.lock
-- [ ] Clean uv cache
-- [ ] Reinstall repository
+- [x] Implement `repository_upgrade()` function
+- [x] Remove venv and uv.lock
+- [x] Clean uv cache
+- [x] Reinstall repository
+
+`install`'s steps were extracted into `_install_repository()` (no top-level
+success/failure messaging) so `install` and `upgrade` share the exact same
+reinstall logic, mirroring how `repository_runner.sh`'s
+`upgrade_repository()` calls `install_repository()` directly. Uses
+`VirtualEnvironmentManager.cleanup()` for venv+lock removal (same method
+`library upgrade` uses) and `uv cache clean --force` (note: `--force`,
+unlike `library upgrade`'s plain `uv cache clean` — matches
+`repository_runner.sh` exactly, which is stricter here than
+`library_runner.sh`).
 
 **Deliverables**:
 - Working upgrade command
 
 **Tests** (`tests/integration/test_repository_upgrade.py`):
-- [ ] Test venv and lock removed
-- [ ] Test cache cleaned
-- [ ] Test reinstall succeeds
+- [x] Test venv and lock removed
+- [x] Test cache cleaned
+- [x] Test reinstall succeeds
+
+The venv/lock-removed and cache-cleaned checks mock out `_install_repository`
+and the `uv cache clean` subprocess call so they run in milliseconds rather
+than repeating a multi-minute reinstall; a separate real, slow
+`test_upgrade_reinstalls_successfully` runs a full install-then-upgrade
+cycle end-to-end (including a real `uv cache clean --force` — verified it
+actually clears the machine's uv cache, ~1.1GiB in local testing, and that
+the subsequent reinstall re-populates it correctly).
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -10,9 +10,9 @@ from typing import Annotated
 
 import typer
 
-from oarepo_cli.core.context import discover_context
+from oarepo_cli.core.context import ProjectContext, discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
-from oarepo_cli.services import invenio_cli, repository, translations
+from oarepo_cli.services import invenio_cli, process, repository, translations
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
@@ -29,6 +29,98 @@ def repository_callback() -> None:
     """Repository command group."""
 
 
+def _install_repository(context: ProjectContext, *, quiet: bool) -> None:
+    """Run the install steps, without any top-level success/failure messaging.
+
+    Mirrors ``repository_runner.sh``'s ``install_repository`` function:
+    1. Creates/syncs virtual environment with uv
+    2. Copies translation overlays to site-packages
+    3. Resolves instance path (INVENIO_INSTANCE_PATH or <venv>/var/instance)
+    4. Creates instance directory and symlinks invenio.cfg
+    5. Runs invenio-cli install
+    6. Configures local service ports in .invenio.private
+    7. Compiles backend translations
+
+    Shared by both ``install`` and ``upgrade`` (which cleans the venv and uv
+    cache, then reinstalls), mirroring how ``repository_runner.sh``'s
+    ``upgrade_repository`` calls ``install_repository`` directly. Callers
+    are responsible for their own top-level success message and
+    ``(OARepoError, ProcessExecutionError)`` handling.
+    """
+    console = ConsoleOutput(quiet=quiet)
+
+    # Step 1: Ensure virtual environment exists and sync dependencies
+    console.info(f"→ Syncing dependencies in {context.config.venv.path}\n")
+
+    venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
+    requirements = VenvRequirements(
+        python_binary=str(context.python_binary),
+        oarepo_version=context.oarepo_version,
+        extras=[],  # No explicit extras for repositories; uv sync reads pyproject.toml
+        editable=True,  # Repositories are always editable installs
+    )
+    venv_manager.ensure_venv(requirements, quiet=quiet)
+
+    # Step 2: Copy translation overlays
+    console.info("→ Copying translation overlays\n")
+
+    collected_dir = os.environ.get("COLLECTED_TRANSLATIONS_DIR")
+    translations.copy_translations(
+        context,
+        collected_translations_dir=collected_dir,
+        quiet=quiet,
+    )
+
+    # Step 3: Get instance path from Invenio shell
+    console.info("→ Detecting instance path\n")
+
+    instance_path = repository.get_instance_path(context)
+
+    # Step 4: Ensure instance structure (directory + invenio.cfg symlink)
+    repository.ensure_instance_structure(context, instance_path, quiet=quiet)
+
+    # Step 5: Run invenio-cli install
+    console.info("→ Running invenio-cli install\n")
+
+    invenio_cli.run_invenio_cli(
+        context,
+        ["install"],
+        quiet=quiet,
+        check=True,
+    )
+
+    # Step 6: Configure local service ports
+    console.info("→ Configuring service ports\n")
+
+    repository.configure_local_ports(context, quiet=quiet)
+
+    # Step 7: Compile backend translations
+    # First, ensure translations directory structure exists (bootstrap if needed)
+    translations_dir = context.root_directory / "translations"
+    messages_pot = translations_dir / "messages.pot"
+    en_lc_messages = translations_dir / "en" / "LC_MESSAGES"
+
+    if not messages_pot.exists() or not en_lc_messages.exists():
+        console.info("→ Bootstrapping translations with make-translations\n")
+        # Try to run make-translations to bootstrap; don't fail if it errors
+        result = translations.run_translations(context, quiet=quiet)
+        if not result.success:
+            console.warning("⚠️  Warning: make-translations failed, translations not compiled!")
+
+    console.info("→ Compiling backend translations\n")
+
+    # Run invenio-cli translations compile
+    result = invenio_cli.run_invenio_cli(
+        context,
+        ["translations", "compile"],
+        quiet=quiet,
+        check=False,  # Don't fail if translations compile fails
+    )
+
+    if not result.success:
+        console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")
+
+
 @repository_app.command()
 def install(
     quiet: Annotated[
@@ -42,14 +134,7 @@ def install(
 ) -> None:
     """Install repository in virtual environment.
 
-    Mirrors ``repository_runner.sh``'s ``install_repository`` function:
-    1. Creates/syncs virtual environment with uv
-    2. Copies translation overlays to site-packages
-    3. Resolves instance path (INVENIO_INSTANCE_PATH or <venv>/var/instance)
-    4. Creates instance directory and symlinks invenio.cfg
-    5. Runs invenio-cli install
-    6. Configures local service ports in .invenio.private
-    7. Compiles backend translations
+    See ``_install_repository`` for the individual steps.
 
     Examples:
         $ oarepo-cli repository install
@@ -60,86 +145,13 @@ def install(
         1: Installation failed
     """
     try:
-        # Load context and config
         context = discover_context()
-
-        # Create console output handler
         console = ConsoleOutput(quiet=quiet)
 
         console.info("\n→ Installing repository...\n")
 
-        # Step 1: Ensure virtual environment exists and sync dependencies
-        console.info(f"→ Syncing dependencies in {context.config.venv.path}\n")
+        _install_repository(context, quiet=quiet)
 
-        venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
-        requirements = VenvRequirements(
-            python_binary=str(context.python_binary),
-            oarepo_version=context.oarepo_version,
-            extras=[],  # No explicit extras for repositories; uv sync reads pyproject.toml
-            editable=True,  # Repositories are always editable installs
-        )
-        venv_manager.ensure_venv(requirements, quiet=quiet)
-
-        # Step 2: Copy translation overlays
-        console.info("→ Copying translation overlays\n")
-
-        collected_dir = os.environ.get("COLLECTED_TRANSLATIONS_DIR")
-        translations.copy_translations(
-            context,
-            collected_translations_dir=collected_dir,
-            quiet=quiet,
-        )
-
-        # Step 3: Get instance path from Invenio shell
-        console.info("→ Detecting instance path\n")
-
-        instance_path = repository.get_instance_path(context)
-
-        # Step 4: Ensure instance structure (directory + invenio.cfg symlink)
-        repository.ensure_instance_structure(context, instance_path, quiet=quiet)
-
-        # Step 5: Run invenio-cli install
-        console.info("→ Running invenio-cli install\n")
-
-        invenio_cli.run_invenio_cli(
-            context,
-            ["install"],
-            quiet=quiet,
-            check=True,
-        )
-
-        # Step 6: Configure local service ports
-        console.info("→ Configuring service ports\n")
-
-        repository.configure_local_ports(context, quiet=quiet)
-
-        # Step 7: Compile backend translations
-        # First, ensure translations directory structure exists (bootstrap if needed)
-        translations_dir = context.root_directory / "translations"
-        messages_pot = translations_dir / "messages.pot"
-        en_lc_messages = translations_dir / "en" / "LC_MESSAGES"
-
-        if not messages_pot.exists() or not en_lc_messages.exists():
-            console.info("→ Bootstrapping translations with make-translations\n")
-            # Try to run make-translations to bootstrap; don't fail if it errors
-            result = translations.run_translations(context, quiet=quiet)
-            if not result.success:
-                console.warning("⚠️  Warning: make-translations failed, translations not compiled!")
-
-        console.info("→ Compiling backend translations\n")
-
-        # Run invenio-cli translations compile
-        result = invenio_cli.run_invenio_cli(
-            context,
-            ["translations", "compile"],
-            quiet=quiet,
-            check=False,  # Don't fail if translations compile fails
-        )
-
-        if not result.success:
-            console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")
-
-        # Success!
         console.success(
             "\n✓ Repository installed successfully!\n",
             fg=typer.colors.BRIGHT_GREEN,
@@ -149,4 +161,62 @@ def install(
     except (OARepoError, ProcessExecutionError) as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Installation failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@repository_app.command()
+def upgrade(
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from subprocesses (uv, invenio-cli, etc.)",
+        ),
+    ] = False,
+) -> None:
+    """Upgrade repository: clean venv/cache and reinstall from scratch.
+
+    Mirrors ``repository_runner.sh``'s ``upgrade_repository`` function:
+    1. Removes the virtual environment (if present)
+    2. Removes uv.lock (if present)
+    3. Cleans the uv cache (``uv cache clean --force``)
+    4. Reinstalls the repository (same steps as ``repository install``)
+
+    Examples:
+        $ oarepo-cli repository upgrade
+        $ oarepo-cli repository upgrade --quiet
+
+    Exit codes:
+        0: Upgrade successful
+        1: Upgrade failed
+    """
+    try:
+        context = discover_context()
+        console = ConsoleOutput(quiet=quiet)
+
+        console.info("\n→ Upgrading repository...\n")
+
+        venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
+        if context.venv_path.exists():
+            console.info("→ Removing virtual environment...\n")
+        if (context.root_directory / "uv.lock").exists():
+            console.info("→ Removing uv.lock...\n")
+        venv_manager.cleanup()
+
+        console.info("→ Cleaning uv cache...\n")
+        process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
+
+        console.info("→ Reinstalling repository...\n")
+        _install_repository(context, quiet=quiet)
+
+        console.success(
+            "\n✓ Upgrade completed successfully!\n",
+            fg=typer.colors.BRIGHT_GREEN,
+            bold=True,
+        )
+
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Upgrade failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e

--- a/oarepo_cli/core/context.py
+++ b/oarepo_cli/core/context.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from oarepo_cli.core.config import CliConfig
 from oarepo_cli.core.errors import ConfigurationError, ValidationError
+from oarepo_cli.services.process import get_system_path
 from oarepo_cli.services.pyproject_reader import PyProjectReader
 from oarepo_cli.services.version_resolver import VersionResolver
 
@@ -256,16 +257,24 @@ class ContextBuilder:
         elif config.python.binary:
             python_binary = Path(config.python.binary)
             if not python_binary.is_absolute():
-                # Try to find in PATH
-                resolved = shutil.which(python_binary.name)
+                # Try to find in PATH, excluding any active venv (see get_system_path)
+                resolved = shutil.which(python_binary.name, path=get_system_path())
                 if resolved:
                     python_binary = Path(resolved)
         else:
-            # Auto-detect using version resolver
+            # Auto-detect using version resolver, excluding any active venv
+            # from PATH -- otherwise resolving e.g. "python3.14" while a
+            # project's own venv is activated finds that venv's own
+            # interpreter, which is wrong for anything that needs to
+            # (re)create that very venv (e.g. `repository upgrade`, which
+            # removes the venv before reinstalling).
             resolver = VersionResolver(pyproject_reader=pyproject_reader)
             info = resolver.resolve_from_pyproject(self._pyproject_path)
             python_version = resolver.find_available_python(info.python_versions)
-            python_binary = Path(shutil.which(f"python{python_version}") or "python")
+            system_path = get_system_path()
+            python_binary = Path(
+                shutil.which(f"python{python_version}", path=system_path) or "python"
+            )
 
         # Validate Python binary exists
         if not python_binary.exists():

--- a/oarepo_cli/services/process.py
+++ b/oarepo_cli/services/process.py
@@ -102,6 +102,24 @@ def _strip_venv_vars(env: dict[str, str]) -> dict[str, str]:
     return cleaned
 
 
+def get_system_path() -> str:
+    """Return PATH with the currently active venv's bin directory stripped out.
+
+    Mirrors ``repository_runner.sh``'s ``get_highest_available_python``,
+    which temporarily removes the activated venv from PATH before searching
+    for a system Python interpreter. Without this, resolving e.g.
+    ``python3.14`` while a project's own venv is activated finds that
+    venv's own interpreter -- which is wrong for anything that needs to
+    (re)create that very venv, e.g. ``shutil.which()`` calls used to pick
+    the interpreter for ``uv venv --python ...`` after ``repository
+    upgrade`` has just removed it.
+
+    Returns:
+        PATH string with the active venv's bin directory removed, if any
+    """
+    return _strip_venv_vars(dict(os.environ)).get("PATH", os.environ.get("PATH", ""))
+
+
 def _merge_env(
     env: dict[str, str] | None,
     strip_venv: bool = True,

--- a/oarepo_cli/services/version_resolver.py
+++ b/oarepo_cli/services/version_resolver.py
@@ -17,6 +17,7 @@ from packaging.version import Version
 
 from oarepo_cli.configuration.constants import KNOWN_PYTHON_VERSIONS, OAREPO_PYTHON_COMPATIBILITY
 from oarepo_cli.core.errors import VersionMismatchError
+from oarepo_cli.services.process import get_system_path
 from oarepo_cli.services.pyproject_reader import PyProjectReader
 
 
@@ -233,7 +234,7 @@ class VersionResolver:
             version: Python version string (e.g., "3.12")
 
         Returns:
-            True if the Python binary is found in PATH
+            True if the Python binary is found in PATH (excluding any active venv)
         """
         major, minor = version.split(".")
 
@@ -244,4 +245,11 @@ class VersionResolver:
             f"python{major}.{minor}",  # python3.12
         ]
 
-        return any(shutil.which(candidate) is not None for candidate in candidates)
+        # Exclude any active venv from PATH (see process.get_system_path):
+        # otherwise a version only present inside the currently-active venv
+        # would be reported "available" even when nothing about to (re)create
+        # that venv could actually use it.
+        system_path = get_system_path()
+        return any(
+            shutil.which(candidate, path=system_path) is not None for candidate in candidates
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 from oarepo_cli.core.config import CliConfig, ServicesConfig, TestingConfig
 from oarepo_cli.core.context import ProjectContext
@@ -247,3 +247,20 @@ def clean_testrepo(testrepo_project: Path) -> Iterator[Path]:
     reset_testrepo_state(testrepo_project)
     yield testrepo_project
     reset_testrepo_state(testrepo_project)
+
+
+@pytest.fixture(scope="session")
+def reset_testrepo_state_fn() -> Callable[[Path], None]:
+    """Session-scoped fixture handle for ``reset_testrepo_state``.
+
+    Lets test modules that need a broader-than-function fixture scope (e.g.
+    a module-scoped "run this expensive command once" fixture, which can't
+    depend on the function-scoped ``clean_testrepo``) reuse the same reset
+    logic via normal fixture injection, instead of ``from tests.conftest
+    import reset_testrepo_state`` -- an absolute ``tests.*`` import that
+    breaks pytest's rootdir-based collection once combined with the nested
+    ``tests/testlib/tests/`` directory (both resolve to a top-level `tests`
+    package/namespace, and Python's import system doesn't like it: manifests
+    as ``ModuleNotFoundError: No module named 'tests.test_sample'``).
+    """
+    return reset_testrepo_state

--- a/tests/integration/test_repository_install.py
+++ b/tests/integration/test_repository_install.py
@@ -23,24 +23,25 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from tests.conftest import reset_testrepo_state
 from typer.testing import CliRunner
 
 from oarepo_cli.cli.main import app
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 
 @pytest.fixture(scope="module")
-def installed_repo(testrepo_project: Path) -> Iterator[Path]:
+def installed_repo(
+    testrepo_project: Path, reset_testrepo_state_fn: Callable[[Path], None]
+) -> Iterator[Path]:
     """Run a real `oarepo-cli repository install` once, shared by this module's tests.
 
-    Uses ``reset_testrepo_state`` directly rather than the (function-scoped)
-    ``clean_testrepo`` fixture, since a full install is too slow to redo for
-    every test function -- see that function's docstring.
+    Uses ``reset_testrepo_state_fn`` (session-scoped) rather than the
+    function-scoped ``clean_testrepo``, since a full install is too slow to
+    redo for every test function -- see that fixture's docstring.
     """
-    reset_testrepo_state(testrepo_project)
+    reset_testrepo_state_fn(testrepo_project)
     previous_cwd = Path.cwd()
     os.chdir(testrepo_project)
     try:
@@ -50,7 +51,7 @@ def installed_repo(testrepo_project: Path) -> Iterator[Path]:
         yield testrepo_project
     finally:
         os.chdir(previous_cwd)
-        reset_testrepo_state(testrepo_project)
+        reset_testrepo_state_fn(testrepo_project)
 
 
 def _site_packages(repo: Path) -> Path:

--- a/tests/integration/test_repository_upgrade.py
+++ b/tests/integration/test_repository_upgrade.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `repository upgrade` against a real scaffolded repository.
+
+``test_upgrade_removes_venv_and_lock`` and ``test_upgrade_cleans_uv_cache_with_force``
+mock out ``_install_repository`` (already covered end-to-end by
+``test_repository_install.py``) and the actual ``uv cache clean`` invocation
+(global, machine-wide state -- not something to exercise for real on every
+run) so they run fast and deterministically, per AGENTS.md's guidance to use
+fakes for slow external tools rather than real invocations at this layer.
+``test_upgrade_reinstalls_successfully`` is the real, slow, end-to-end check
+that a full install-then-upgrade cycle actually works.
+
+See tests/conftest.py:testrepo_project for how the fixture repository is
+created (via the real ``repository_installer.sh``, as documented at
+https://nrp-cz.github.io/docs/installation/create_instance).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.services import process
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+
+def test_upgrade_removes_venv_and_lock(
+    clean_testrepo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`repository upgrade` removes the existing .venv and uv.lock before reinstalling."""
+    monkeypatch.chdir(clean_testrepo)
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository._install_repository", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.process.run",
+        lambda cmd, **_kwargs: process.ProcessResult(
+            return_code=0, stdout="", stderr="", command=cmd, cwd=clean_testrepo, duration_ms=0
+        ),
+    )
+
+    venv_marker = clean_testrepo / ".venv" / "marker.txt"
+    venv_marker.parent.mkdir(parents=True)
+    venv_marker.write_text("old venv")
+    (clean_testrepo / "uv.lock").write_text("old lock")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "upgrade", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert not venv_marker.exists()
+    assert not (clean_testrepo / "uv.lock").exists()
+
+
+def test_upgrade_cleans_uv_cache_with_force(
+    clean_testrepo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`repository upgrade` runs `uv cache clean --force` (unlike `library upgrade`,
+    which omits --force), mirroring repository_runner.sh's upgrade_repository."""
+    monkeypatch.chdir(clean_testrepo)
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository._install_repository", lambda *_args, **_kwargs: None
+    )
+
+    calls: list[list[str]] = []
+
+    def spy_run(cmd, **_kwargs):
+        calls.append(list(cmd))
+        return process.ProcessResult(
+            return_code=0, stdout="", stderr="", command=cmd, cwd=clean_testrepo, duration_ms=0
+        )
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.process.run", spy_run)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "upgrade", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert ["uv", "cache", "clean", "--force"] in calls
+
+
+@pytest.fixture(scope="module")
+def upgraded_repo(
+    testrepo_project: Path, reset_testrepo_state_fn: Callable[[Path], None]
+) -> Iterator[Path]:
+    """Run a real install then a real `repository upgrade`, once for this module."""
+    reset_testrepo_state_fn(testrepo_project)
+    previous_cwd = Path.cwd()
+    os.chdir(testrepo_project)
+    try:
+        runner = CliRunner()
+        install_result = runner.invoke(app, ["repository", "install"], catch_exceptions=False)
+        assert install_result.exit_code == 0, install_result.output
+
+        upgrade_result = runner.invoke(app, ["repository", "upgrade"], catch_exceptions=False)
+        assert upgrade_result.exit_code == 0, upgrade_result.output
+        yield testrepo_project
+    finally:
+        os.chdir(previous_cwd)
+        reset_testrepo_state_fn(testrepo_project)
+
+
+def test_upgrade_reinstalls_successfully(upgraded_repo: Path) -> None:
+    """Integration test: a full install-then-upgrade cycle completes successfully."""
+    assert (upgraded_repo / ".venv" / "bin" / "python").exists()
+    assert (upgraded_repo / "uv.lock").exists()
+    assert (upgraded_repo / ".invenio.private").exists()

--- a/tests/services/test_process_venv_isolation.py
+++ b/tests/services/test_process_venv_isolation.py
@@ -225,3 +225,27 @@ def test_get_output_strips_venv_by_default(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     assert output == "NOT_SET"
+
+
+def test_get_system_path_strips_active_venv_bin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_system_path() must exclude an active venv's bin dir, mirroring
+    repository_runner.sh's get_highest_available_python -- otherwise
+    resolving a system Python while a project's own venv is activated
+    finds that venv's own interpreter, which is wrong for anything that
+    needs to (re)create that very venv (e.g. `repository upgrade`)."""
+    if sys.platform == "win32":
+        pytest.skip("Unix-specific test")
+
+    venv_path = "/home/user/project/.venv"
+    monkeypatch.setenv("VIRTUAL_ENV", venv_path)
+    monkeypatch.setenv("PATH", f"{venv_path}/bin:/usr/bin:/usr/local/bin")
+
+    assert process.get_system_path() == "/usr/bin:/usr/local/bin"
+
+
+def test_get_system_path_unchanged_without_active_venv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_system_path() returns PATH unchanged when no venv is active."""
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin:/usr/local/bin")
+
+    assert process.get_system_path() == "/usr/bin:/usr/local/bin"

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -360,6 +360,52 @@ tests = ["oarepo>=13.0.0,<14.0.0"]
     assert context.oarepo_version == 14
 
 
+def test_python_autodetect_ignores_active_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-detecting the Python binary must exclude the currently active venv.
+
+    Regression test: running oarepo-cli from inside a project with its own
+    venv activated (VIRTUAL_ENV/PATH pointing at that project's own .venv)
+    previously resolved python_binary to that venv's own interpreter. That's
+    harmless for a plain `install` on an existing venv (uv sync just reuses
+    it), but `repository upgrade` removes the venv *before* reinstalling --
+    so recreating it with a python_binary that lived inside the very venv
+    just deleted fails with "No interpreter found at path ...".
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-project"
+requires-python = ">=3.14,<3.15"
+
+[tool.oarepo-cli]
+oarepo = { version = 14 }
+"""
+    )
+
+    # A fake "activated venv" interpreter that must NOT be picked...
+    venv_bin = tmp_path / "project-venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python3.14"
+    venv_python.write_text("#!/bin/sh\n")
+    venv_python.chmod(0o755)
+
+    # ...and a real "system" interpreter that should be picked instead.
+    system_bin = tmp_path / "system-bin"
+    system_bin.mkdir()
+    system_python = system_bin / "python3.14"
+    system_python.write_text("#!/bin/sh\n")
+    system_python.chmod(0o755)
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "project-venv"))
+    monkeypatch.setenv("PATH", f"{venv_bin}:{system_bin}")
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    assert context.python_binary == system_python
+
+
 def test_oarepo_version_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that OAREPO_VERSION environment variable overrides auto-detection."""
     (tmp_path / "pyproject.toml").write_text(

--- a/tests/unit/test_version_resolver.py
+++ b/tests/unit/test_version_resolver.py
@@ -118,7 +118,7 @@ def test_finding_highest_available_python(mocker: MockerFixture) -> None:
     resolver = VersionResolver()
 
     # Mock shutil.which to simulate python3.14 and python3.12 being available
-    def mock_which(name: str) -> str | None:
+    def mock_which(name: str, **_kwargs: object) -> str | None:
         if name in ("python3.14", "python3.12"):
             return f"/usr/bin/{name}"
         return None
@@ -135,7 +135,7 @@ def test_fallback_to_lower_version_if_highest_unavailable(mocker: MockerFixture)
     resolver = VersionResolver()
 
     # Mock shutil.which to simulate only python3.12 being available
-    def mock_which(name: str) -> str | None:
+    def mock_which(name: str, **_kwargs: object) -> str | None:
         if name == "python3.12":
             return "/usr/bin/python3.12"
         return None


### PR DESCRIPTION
## Summary
- Implements `oarepo-cli repository upgrade`, mirroring `repository_runner.sh`'s `upgrade_repository()`: removes `.venv` and `uv.lock` (via `VirtualEnvironmentManager.cleanup()`, same as `library upgrade`), cleans the uv cache with `uv cache clean --force` (note `--force` — unlike `library upgrade`'s plain `uv cache clean`, matching the bash script exactly, which is stricter for repositories than for libraries), then reinstalls.
- `install()`'s steps are extracted into `_install_repository()` (no top-level success/failure messaging of its own) so `install` and `upgrade` share the exact same reinstall logic — mirroring how `upgrade_repository()` calls `install_repository()` directly in the bash version.
- README.md updated: `repository upgrade` moved from "🔜 Phase 4.2" to "✅ Implemented" with a new section; also fixed a stale line in `repository install`'s docs still describing the old `invenio shell`-based instance path detection (superseded by #121's fast-path resolution).
- Also fixes a **pre-existing** collection bug from #121 (not introduced here): `from tests.conftest import reset_testrepo_state` is an absolute `tests.*` import that collides with the nested `tests/testlib/tests/` directory once Python treats `tests` as a namespace package, breaking `pytest`/`make test` on a plain full-suite run with `ModuleNotFoundError: No module named 'tests.test_sample'`. Replaced with a session-scoped `reset_testrepo_state_fn` fixture so cross-file reuse goes through normal fixture injection instead of a raw import.

## Test plan
- [x] `uv run pytest tests/integration/test_repository_install.py tests/integration/test_repository_upgrade.py -v` — 8/8 passed (includes a real, slow full install-then-upgrade cycle, including a real `uv cache clean --force` that cleared ~1.1GiB and successfully re-populated on reinstall)
- [x] `uv run pytest --collect-only -q` — 366 tests collected, 0 errors (previously errored on full-suite collection)
- [x] `uv run pytest tests/unit tests/core -q` — 204 passed, no regressions
- [x] `make check` (ruff check / format / ty) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)