### PR TITLE
Step 4.3: Repository services subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 |---------|-------------|--------|
 | [`install`](#repository-install) | Install repository in virtual environment | ✅ Implemented |
 | [`upgrade`](#repository-upgrade) | Clean cache and reinstall | ✅ Implemented |
-| `services` | Manage Docker services | 🔜 Phase 4.3 |
+| [`services`](#repository-services) | Manage Docker services | ✅ Implemented |
 | `model` | Create/update record models | 🔜 Phase 4.4 |
 | `local` | Manage local package dependencies | 🔜 Phase 4.5 |
 | `run` | Start repository server | 🔜 Phase 4.6 |
@@ -578,9 +578,42 @@ oarepo-cli repository upgrade --quiet
 
 Use this after updating OARepo/RDM version pins, or when the environment needs a clean rebuild.
 
+### `repository services`
+
+Manages the repository's Docker services (database, search, message queue, cache, S3). Each subcommand is a pure passthrough to `invenio-cli services <subcommand>` — any extra arguments or flags are forwarded verbatim, and `--help` reaches invenio-cli's own help for that subcommand rather than oarepo-cli's.
+
+```bash
+oarepo-cli repository services setup
+oarepo-cli repository services start
+oarepo-cli repository services stop
+oarepo-cli repository services destroy
+```
+
+**Subcommands:**
+- `setup`: Setup Docker services (accepts invenio-cli's own flags, e.g. `-N`/`--no-demo-data`, `-f`/`--force`, `--stop-services`)
+- `start`: Start Docker services
+- `stop`: Stop Docker services
+- `destroy`: Destroy Docker services
+
+**Options** (each subcommand):
+- `--quiet` / `-q`: Suppress output from invenio-cli
+
+**Examples:**
+```bash
+# Setup services without demo data
+oarepo-cli repository services setup -N
+
+# See invenio-cli's own help for a subcommand
+oarepo-cli repository services setup --help
+```
+
+**Exit codes:**
+- Whatever `invenio-cli services <subcommand>` returns (propagated exactly, not collapsed to 0/1)
+- `1`: Project context could not be discovered (e.g. no `pyproject.toml`)
+
 ### Other Repository Commands
 
-_Commands below are to be implemented in Phase 4 (steps 4.3-4.11)._
+_Commands below are to be implemented in Phase 4 (steps 4.4-4.11)._
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -863,16 +863,42 @@ the subsequent reinstall re-populates it correctly).
 ### Step 4.3: Repository `services` Subcommands
 **Goal**: Implement services subcommands (setup/start/stop/destroy).
 
-- [ ] Implement `repository_services()` with subcommands
-- [ ] Delegate to `run_invenio_cli services ...`
-- [ ] Pass through all arguments
+- [x] Implement `repository_services()` with subcommands
+- [x] Delegate to `run_invenio_cli services ...`
+- [x] Pass through all arguments
+
+Implemented as a `services_app` sub-Typer group mounted on `repository_app`
+(same pattern as `library`'s own `services_app`), with each of
+`setup`/`start`/`stop`/`destroy` a separate command delegating through
+`_run_services_subcommand()` to `invenio_cli.run_invenio_cli(context,
+["services", subcommand, *extra_args], check=False)`. `check=False` plus
+`raise typer.Exit(code=result.return_code)` propagates invenio-cli's exact
+exit code, rather than collapsing failures to `1` the way `install`/
+`upgrade` do — matching `repository_runner.sh`'s `services()`, which is a
+pure passthrough under `set -e` (whatever invenio-cli exits with is what
+the script exits with). `context_settings` (`allow_extra_args`,
+`ignore_unknown_options`, `help_option_names: []`) mirror the existing
+`library invenio` passthrough command, so extra flags (e.g. invenio-cli's
+own `-N`/`--no-demo-data`) and `--help` reach invenio-cli itself instead of
+being intercepted by Typer/Click.
 
 **Deliverables**:
 - Services subcommands
 
 **Tests** (`tests/integration/test_repository_services.py`):
-- [ ] Test each subcommand delegates correctly
-- [ ] Test arguments passed through
+- [x] Test each subcommand delegates correctly
+- [x] Test arguments passed through
+
+All 4 subcommands are parametrized over the same test bodies: delegates to
+`invenio-cli services <subcommand>`, forwards extra args verbatim,
+propagates a non-0/1 exit code exactly, and forwards `--help`. Mocked
+(`discover_context`/`run_invenio_cli`) rather than run for real — a pure
+passthrough wrapper has no real side effects of its own to exercise beyond
+command construction (unlike `install`/`upgrade`, which do get a real
+end-to-end test). Manually verified against the real `tests/testrepo`
+fixture too: `repository services setup --help` prints invenio-cli's own
+real help text (`-f`/`--force`, `-N`/`--no-demo-data`, `--stop-services`,
+`-s`/`--services`).
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -23,10 +23,127 @@ repository_app = typer.Typer(
     no_args_is_help=True,
 )
 
+# Create the services subcommand group
+services_app = typer.Typer(
+    name="services",
+    help="Docker services management (delegates to invenio-cli)",
+    no_args_is_help=True,
+)
+
+# Register services as a subcommand of repository
+repository_app.add_typer(services_app)
+
+# Each services subcommand is a pure passthrough to invenio-cli: extra
+# arguments/options are forwarded verbatim, and --help must reach
+# invenio-cli itself (producing invenio-cli's own help) rather than being
+# intercepted by Typer/Click.
+_SERVICES_CONTEXT_SETTINGS = {
+    "allow_extra_args": True,
+    "allow_interspersed_args": True,
+    "ignore_unknown_options": True,
+    "help_option_names": [],
+}
+
 
 @repository_app.callback()
 def repository_callback() -> None:
     """Repository command group."""
+
+
+@services_app.callback()
+def services_callback() -> None:
+    """Repository services command group."""
+
+
+def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool) -> None:
+    """Delegate to ``invenio-cli services <subcommand> [args...]``.
+
+    Mirrors ``repository_runner.sh``'s ``services()`` function: pure
+    passthrough, with the subcommand's own exit code propagated exactly
+    (not collapsed to 0/1), and any extra arguments/options forwarded
+    verbatim to invenio-cli.
+
+    Args:
+        ctx: Typer context, used to capture passthrough arguments
+        subcommand: One of "setup", "start", "stop", "destroy"
+        quiet: If True, suppress real-time subprocess output
+    """
+    extra_args = ctx.args if ctx.args else []
+
+    try:
+        context = discover_context()
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ services {subcommand} failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    result = invenio_cli.run_invenio_cli(
+        context,
+        ["services", subcommand, *extra_args],
+        quiet=quiet,
+        check=False,
+    )
+    raise typer.Exit(code=result.return_code)
+
+
+@services_app.command("setup", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def services_setup(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from invenio-cli")
+    ] = False,
+) -> None:
+    """Setup Docker services.
+
+    Delegates to ``invenio-cli services setup``. Any extra arguments
+    (e.g. ``-N`` for no demo data) are passed through verbatim.
+    """
+    _run_services_subcommand(ctx, "setup", quiet=quiet)
+
+
+@services_app.command("start", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def services_start(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from invenio-cli")
+    ] = False,
+) -> None:
+    """Start Docker services.
+
+    Delegates to ``invenio-cli services start``. Any extra arguments are
+    passed through verbatim.
+    """
+    _run_services_subcommand(ctx, "start", quiet=quiet)
+
+
+@services_app.command("stop", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def services_stop(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from invenio-cli")
+    ] = False,
+) -> None:
+    """Stop Docker services.
+
+    Delegates to ``invenio-cli services stop``. Any extra arguments are
+    passed through verbatim.
+    """
+    _run_services_subcommand(ctx, "stop", quiet=quiet)
+
+
+@services_app.command("destroy", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def services_destroy(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from invenio-cli")
+    ] = False,
+) -> None:
+    """Destroy Docker services.
+
+    Delegates to ``invenio-cli services destroy``. Any extra arguments are
+    passed through verbatim.
+    """
+    _run_services_subcommand(ctx, "destroy", quiet=quiet)
 
 
 def _install_repository(context: ProjectContext, *, quiet: bool) -> None:

--- a/tests/integration/test_repository_services.py
+++ b/tests/integration/test_repository_services.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `repository services` subcommands (setup/start/stop/destroy).
+
+Each subcommand is a pure passthrough to `invenio-cli services <subcommand>
+...` (mirroring repository_runner.sh's services() function), so these
+tests mock discover_context() and run_invenio_cli() to verify the
+delegation, argument forwarding, and exit-code propagation without needing
+a real project or invenio-cli installation -- unlike
+test_repository_install.py/test_repository_upgrade.py, there's no
+meaningful "real" behavior to exercise here beyond command construction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services import process
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SUBCOMMANDS = ["setup", "start", "stop", "destroy"]
+
+
+@pytest.fixture
+def mock_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() so no real project is needed."""
+    context = Mock()
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    return context
+
+
+def _fake_run_invenio_cli(calls: list[dict[str, object]], return_code: int = 0):
+    def fake(context, args: Sequence[str], *, quiet: bool = False, check: bool = True, _env=None):
+        calls.append({"context": context, "args": list(args), "quiet": quiet, "check": check})
+        return process.ProcessResult(
+            return_code=return_code,
+            stdout="",
+            stderr="",
+            command=["invenio-cli", *args],
+            cwd=Path(),
+            duration_ms=0,
+        )
+
+    return fake
+
+
+@pytest.mark.parametrize("subcommand", SUBCOMMANDS)
+def test_services_subcommand_delegates_to_invenio_cli(
+    subcommand: str, mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each services subcommand calls `invenio-cli services <subcommand>` with check=False
+    (so the subcommand's own exit code can be propagated, rather than being collapsed by
+    run_invenio_cli's default check=True -> ProcessExecutionError -> exit 1)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", _fake_run_invenio_cli(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", subcommand])
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["context"] is mock_context
+    assert calls[0]["args"] == ["services", subcommand]
+    assert calls[0]["check"] is False
+
+
+@pytest.mark.parametrize("subcommand", SUBCOMMANDS)
+def test_services_subcommand_passes_through_extra_args(
+    subcommand: str,
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Extra arguments after the subcommand are forwarded to invenio-cli verbatim."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", _fake_run_invenio_cli(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", subcommand, "-N", "--foo", "bar"])
+
+    assert result.exit_code == 0
+    assert calls[0]["args"] == ["services", subcommand, "-N", "--foo", "bar"]
+
+
+@pytest.mark.parametrize("subcommand", SUBCOMMANDS)
+def test_services_subcommand_propagates_exit_code(
+    subcommand: str,
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The delegated command's own exit code is propagated exactly, not collapsed to 0/1."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        _fake_run_invenio_cli(calls, return_code=42),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", subcommand])
+
+    assert result.exit_code == 42
+
+
+def test_services_setup_quiet_flag_forwarded(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--quiet is consumed as the quiet= kwarg, not forwarded as an extra positional arg."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", _fake_run_invenio_cli(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", "setup", "--quiet"])
+
+    assert result.exit_code == 0
+    assert calls[0]["quiet"] is True
+    assert calls[0]["args"] == ["services", "setup"]
+
+
+def test_services_subcommand_help_reaches_invenio_cli(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--help is forwarded to invenio-cli rather than intercepted by Typer/Click,
+    so the user sees invenio-cli's own help for the delegated subcommand."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", _fake_run_invenio_cli(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", "setup", "--help"])
+
+    assert result.exit_code == 0
+    assert calls[0]["args"] == ["services", "setup", "--help"]
+
+
+def test_services_subcommand_reports_context_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context-discovery failure (e.g. no pyproject.toml) is reported cleanly, exit code 1."""
+
+    def raise_config_error():
+        raise ConfigurationError("pyproject.toml not found")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", raise_config_error)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "services", "setup"])
+
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- Implements `oarepo-cli repository services setup/start/stop/destroy`, mirroring `repository_runner.sh`'s `services()` function: each subcommand is a pure passthrough to `invenio-cli services <subcommand> [args...]`.
- invenio-cli's own exit code is propagated exactly (`check=False` + `raise typer.Exit(code=result.return_code)`), not collapsed to 0/1 the way `install`/`upgrade` do — matching the bash version, which under `set -e` just exits with whatever invenio-cli returned.
- Mounted as a `services_app` sub-Typer group on `repository_app` (same pattern already used for `library`'s own `services_app`).
- `context_settings` (`allow_extra_args`, `ignore_unknown_options`, `help_option_names: []`) mirror the existing `library invenio` passthrough command, so extra flags (e.g. invenio-cli's own `-N`/`--no-demo-data`, `-f`/`--force`) and `--help` reach invenio-cli itself rather than being intercepted by Typer/Click.
- README.md and `implementation-steps.md` updated.

## Test plan
- [x] `uv run pytest tests/integration/test_repository_services.py -v` — 15/15 passed (mocked `discover_context`/`run_invenio_cli`; a pure passthrough wrapper has no real side effects of its own beyond command construction, unlike `install`/`upgrade`)
- [x] Manually verified against the real `tests/testrepo` fixture: `repository services setup --help` prints invenio-cli's own real help text (`-f`/`--force`, `-N`/`--no-demo-data`, `--stop-services`, `-s`/`--services`)
- [x] `uv run pytest tests/unit tests/core tests/services -q` — 239 passed, no regressions
- [x] `make check` (ruff check / format / ty) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)