### PR TITLE
Step 4.4: Model Manager

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -905,20 +905,63 @@ real help text (`-f`/`--force`, `-N`/`--no-demo-data`, `--stop-services`,
 ### Step 4.4: Model Manager
 **Goal**: Implement record model management via copier.
 
-- [ ] Implement `services/models.py` with `ModelManager` class
-- [ ] Method: `create_model(name, config_file=None)` → None
-- [ ] Method: `update_model(name, answers_file=None)` → None
-- [ ] Use `uvx copier copy` and `copier update`
-- [ ] Support GitHub templates and local paths
-- [ ] Reinstall repository after model changes
+- [x] Implement `services/models.py` with `ModelManager` class
+- [x] Method: `create_model(name, config_file=None)` → None
+- [x] Method: `update_model(name, answers_file=None)` → None
+- [x] Use `copier.run_copy`/`copier.run_update` (see deviation note below)
+- [x] Support GitHub templates and local paths
+- [x] Reinstall repository after model changes
+
+**Deviation from the original plan**: rather than shelling out to
+`uvx --with copier-template-extensions --with pycountry --with tomli
+--with tomli-w copier copy/update ...` for a fresh ephemeral environment on
+every call (`repository_runner.sh`'s approach, and this step's original
+"Use `uvx copier copy` and `copier update`" bullet), `copier`,
+`copier-template-extensions` (note: singular -- `copier-templates-extensions`
+is the deprecated old name, even though `repository_runner.sh`'s model
+commands use the old plural spelling), `pycountry`, `tomli`, and `tomli-w`
+are now regular oarepo-cli dependencies, and `ModelManager` calls
+`copier.run_copy`/`copier.run_update` directly as a library, in-process.
+`repository.install_repository()` was extracted from `cli/repository.py`
+(previously `_install_repository`, private to that module) into
+`services/repository.py` as a public function so both `install`/`upgrade`
+and `ModelManager.create_model()`'s post-creation reinstall share it,
+mirroring how `repository_runner.sh`'s `install_repository()` is called
+from `install`, `upgrade_repository`, and `create_model` alike.
+
+One further deliberate behavioral difference, discovered while writing
+real tests against real copier (see below): a given `config_file`/
+`answers_file` is loaded and passed to copier as `data` (like copier's own
+`--data-file`), not merely as `answers_file` (like bash's
+`--answers-file`). `answers_file` alone only pre-fills copier's
+interactive prompts with prior answers -- it still requires a live
+terminal to confirm each one, which defeats the entire point of passing a
+config file for scripted/non-interactive use. See `services/models.py`'s
+`ModelManager` docstring.
 
 **Deliverables**:
 - Model management service
 
 **Tests** (`tests/integration/test_model_manager.py`):
-- [ ] Test model creation against real `copier` (slow)
-- [ ] Test model update with answers file
-- [ ] Test template URL handling
+- [x] Test model creation against real `copier` (slow)
+- [x] Test model update with answers file
+- [x] Test template URL handling
+
+Since copier now runs in-process rather than as a subprocess, AGENTS.md's
+guidance to use `pytest-subprocess`'s `fake_process` for "services that
+shell out to slow external tools (uv, docker-services-cli, copier)" no
+longer applies to it specifically -- there's no subprocess to intercept.
+Instead, tests run copier for real against small local template fixtures
+(fast: no network, no ephemeral `uvx` bootstrap), which is both simpler
+and more faithful than mocking copier's Python API. Notable things learned
+along the way, now documented in the test file: copier never writes an
+answers file unless the template itself contains a file that renders the
+special `_copier_answers` context variable (this is *not* automatic --
+`nrp-app-copier`/`nrp-model-copier` do this via
+`{{_copier_conf.answers_file}}.copier`); `copier update` only works on
+git-tracked, clean destinations, and requires `overwrite=True` for those
+(safe, since the user can review via `git diff`); an `answers_file` path
+must resolve inside `dst_path`, never a parent/sibling.
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -5,15 +5,14 @@
 
 from __future__ import annotations
 
-import os
 from typing import Annotated
 
 import typer
 
-from oarepo_cli.core.context import ProjectContext, discover_context
+from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
-from oarepo_cli.services import invenio_cli, process, repository, translations
-from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
+from oarepo_cli.services import invenio_cli, process, repository
+from oarepo_cli.services.venv import VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
 # Create the repository subcommand group
@@ -146,98 +145,6 @@ def services_destroy(
     _run_services_subcommand(ctx, "destroy", quiet=quiet)
 
 
-def _install_repository(context: ProjectContext, *, quiet: bool) -> None:
-    """Run the install steps, without any top-level success/failure messaging.
-
-    Mirrors ``repository_runner.sh``'s ``install_repository`` function:
-    1. Creates/syncs virtual environment with uv
-    2. Copies translation overlays to site-packages
-    3. Resolves instance path (INVENIO_INSTANCE_PATH or <venv>/var/instance)
-    4. Creates instance directory and symlinks invenio.cfg
-    5. Runs invenio-cli install
-    6. Configures local service ports in .invenio.private
-    7. Compiles backend translations
-
-    Shared by both ``install`` and ``upgrade`` (which cleans the venv and uv
-    cache, then reinstalls), mirroring how ``repository_runner.sh``'s
-    ``upgrade_repository`` calls ``install_repository`` directly. Callers
-    are responsible for their own top-level success message and
-    ``(OARepoError, ProcessExecutionError)`` handling.
-    """
-    console = ConsoleOutput(quiet=quiet)
-
-    # Step 1: Ensure virtual environment exists and sync dependencies
-    console.info(f"→ Syncing dependencies in {context.config.venv.path}\n")
-
-    venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
-    requirements = VenvRequirements(
-        python_binary=str(context.python_binary),
-        oarepo_version=context.oarepo_version,
-        extras=[],  # No explicit extras for repositories; uv sync reads pyproject.toml
-        editable=True,  # Repositories are always editable installs
-    )
-    venv_manager.ensure_venv(requirements, quiet=quiet)
-
-    # Step 2: Copy translation overlays
-    console.info("→ Copying translation overlays\n")
-
-    collected_dir = os.environ.get("COLLECTED_TRANSLATIONS_DIR")
-    translations.copy_translations(
-        context,
-        collected_translations_dir=collected_dir,
-        quiet=quiet,
-    )
-
-    # Step 3: Get instance path from Invenio shell
-    console.info("→ Detecting instance path\n")
-
-    instance_path = repository.get_instance_path(context)
-
-    # Step 4: Ensure instance structure (directory + invenio.cfg symlink)
-    repository.ensure_instance_structure(context, instance_path, quiet=quiet)
-
-    # Step 5: Run invenio-cli install
-    console.info("→ Running invenio-cli install\n")
-
-    invenio_cli.run_invenio_cli(
-        context,
-        ["install"],
-        quiet=quiet,
-        check=True,
-    )
-
-    # Step 6: Configure local service ports
-    console.info("→ Configuring service ports\n")
-
-    repository.configure_local_ports(context, quiet=quiet)
-
-    # Step 7: Compile backend translations
-    # First, ensure translations directory structure exists (bootstrap if needed)
-    translations_dir = context.root_directory / "translations"
-    messages_pot = translations_dir / "messages.pot"
-    en_lc_messages = translations_dir / "en" / "LC_MESSAGES"
-
-    if not messages_pot.exists() or not en_lc_messages.exists():
-        console.info("→ Bootstrapping translations with make-translations\n")
-        # Try to run make-translations to bootstrap; don't fail if it errors
-        result = translations.run_translations(context, quiet=quiet)
-        if not result.success:
-            console.warning("⚠️  Warning: make-translations failed, translations not compiled!")
-
-    console.info("→ Compiling backend translations\n")
-
-    # Run invenio-cli translations compile
-    result = invenio_cli.run_invenio_cli(
-        context,
-        ["translations", "compile"],
-        quiet=quiet,
-        check=False,  # Don't fail if translations compile fails
-    )
-
-    if not result.success:
-        console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")
-
-
 @repository_app.command()
 def install(
     quiet: Annotated[
@@ -251,7 +158,7 @@ def install(
 ) -> None:
     """Install repository in virtual environment.
 
-    See ``_install_repository`` for the individual steps.
+    See ``services.repository.install_repository`` for the individual steps.
 
     Examples:
         $ oarepo-cli repository install
@@ -267,7 +174,7 @@ def install(
 
         console.info("\n→ Installing repository...\n")
 
-        _install_repository(context, quiet=quiet)
+        repository.install_repository(context, quiet=quiet)
 
         console.success(
             "\n✓ Repository installed successfully!\n",
@@ -325,7 +232,7 @@ def upgrade(
         process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
 
         console.info("→ Reinstalling repository...\n")
-        _install_repository(context, quiet=quiet)
+        repository.install_repository(context, quiet=quiet)
 
         console.success(
             "\n✓ Upgrade completed successfully!\n",

--- a/oarepo_cli/services/models.py
+++ b/oarepo_cli/services/models.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Record model management via copier, for OARepo repository projects."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import copier
+import yaml
+
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services.repository import install_repository
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from oarepo_cli.core.context import ProjectContext
+
+
+def _relative_to_root(path: Path, root: Path) -> Path:
+    """Convert an answers-file path to be relative to root, as copier requires.
+
+    copier's ``answers_file`` parameter must be relative to ``dst_path``
+    (it raises a validation error otherwise); callers of ``ModelManager``
+    may reasonably pass an absolute path or one relative to the current
+    working directory, so resolve both sides before computing the relative
+    path (``walk_up=True`` handles a config file living outside the
+    repository root too, e.g. in a temp directory).
+    """
+    return path.resolve().relative_to(root.resolve(), walk_up=True)
+
+
+def _load_yaml_data(path: Path) -> dict[str, Any]:
+    """Load a YAML answers/data file into a dict, the same way copier's own
+    ``--data-file`` CLI flag does (``copier._cli.py:data_file_switch``).
+
+    PyYAML isn't declared directly in oarepo-cli's own dependencies, but
+    it's a direct (not merely transitive) dependency of ``copier`` itself,
+    for this exact purpose -- if it ever went away, copier's own
+    ``--data-file`` would break too, so relying on it here is safe.
+    """
+    with path.open("rb") as f:
+        return yaml.safe_load(f) or {}
+
+
+class ModelManager:
+    """Creates and updates OARepo record models via the copier Python API.
+
+    Mirrors ``repository_runner.sh``'s ``create_model()``/``update_model()``
+    functions, but invokes copier directly as a library
+    (``copier.run_copy``/``copier.run_update``) using this venv's own
+    installed ``copier`` + ``copier-template-extensions`` rather than
+    shelling out to ``uvx --with ... copier ...`` for a fresh ephemeral
+    environment on every call.
+
+    One deliberate behavioral difference from the bash version: a given
+    config/answers file is loaded and passed to copier as ``data`` (like
+    copier's own ``--data-file``), not merely as ``answers_file`` (like
+    bash's ``--answers-file``). ``answers_file`` alone only pre-fills
+    copier's interactive prompts with prior answers -- it still requires a
+    live terminal to confirm each one. Since the entire point of passing a
+    config file here is scripted/non-interactive use, seeding ``data``
+    (which copier answers from directly, without prompting) is required for
+    that to actually work.
+    """
+
+    def __init__(self, context: ProjectContext, *, quiet: bool = False) -> None:
+        """Initialize the model manager.
+
+        Args:
+            context: Project context with paths and configuration
+            quiet: If True, suppress status/progress messages
+        """
+        self._context = context
+        self._quiet = quiet
+
+    def create_model(self, name: str, config_file: Path | None = None) -> None:
+        """Create a new record model from the model copier template.
+
+        Mirrors ``repository_runner.sh``'s ``create_model()``: renders the
+        configured model template (``[tool.oarepo-cli] model.template_url``/
+        ``.template_version``, default
+        https://github.com/oarepo/nrp-model-copier @ rdm-14) into the
+        repository root -- the template itself places generated files under
+        ``models/<name>/``. If a virtual environment already exists, the
+        repository is reinstalled afterwards (a new model changes entry
+        points/dependencies in ``pyproject.toml``).
+
+        Args:
+            name: Model name (passed to the template as ``model_name``)
+            config_file: Optional path to a YAML answers/data file. When
+                given, its content seeds all answers (it must supply
+                ``model_name`` itself, matching ``repository_runner.sh``,
+                which doesn't also pass ``-d model_name=`` in this case);
+                when omitted, only ``model_name`` is passed and the
+                template's own defaults/prompts apply.
+
+        Raises:
+            ConfigurationError: If config_file is given but doesn't exist
+        """
+        if config_file is not None and not config_file.exists():
+            raise ConfigurationError(f"Missing model config file: {config_file}")
+
+        console = ConsoleOutput(quiet=self._quiet)
+        template = self._context.config.model.template_url
+        version = self._context.config.model.template_version
+        is_github = template.startswith("https://")
+
+        console.info(f"→ Creating model '{name}' from {template}\n")
+
+        data = _load_yaml_data(config_file) if config_file is not None else {"model_name": name}
+        copier.run_copy(
+            template,
+            self._context.root_directory,
+            data=data,
+            vcs_ref=version if is_github else None,
+            unsafe=True,
+            quiet=self._quiet,
+        )
+
+        if self._context.venv_path.exists():
+            console.info("→ Reinstalling repository with the new model\n")
+            install_repository(self._context, quiet=self._quiet)
+
+        console.success(f"✓ Model '{name}' created successfully.\n")
+        console.warning(
+            "\nTo create the necessary database tables and search indices for "
+            "your new model, run: oarepo-cli repository reset\n"
+            "NOTE: this will PURGE ALL EXISTING DATA in your containers!\n"
+        )
+
+    def update_model(self, name: str, answers_file: Path | None = None) -> None:
+        """Update an existing record model from its recorded template.
+
+        Mirrors ``repository_runner.sh``'s ``update_model()``: copier's own
+        ``.copier-answers.yml`` (written under ``models/<name>/`` during
+        ``create_model``) records which template/ref/answers were used, so
+        update works from that alone unless a different answers file is
+        explicitly given (e.g. to point at a local template copy instead of
+        the originally recorded one). That file is used both to locate the
+        template/ref to update from (``answers_file``, as in the bash
+        version) and, unlike the bash version, to seed answers non-
+        interactively (``data``) -- see the class docstring for why.
+
+        Args:
+            name: Model name (must already exist under ``models/<name>``)
+            answers_file: Optional path to a different answers file
+
+        Raises:
+            ConfigurationError: If the model directory or answers file
+                doesn't exist
+        """
+        model_dir = self._context.root_directory / "models" / name
+        if not model_dir.is_dir():
+            raise ConfigurationError(f"Model directory 'models/{name}' does not exist.")
+
+        resolved_answers_file = model_dir / ".copier-answers.yml"
+        if answers_file is not None:
+            if not answers_file.exists():
+                raise ConfigurationError(f"Model config file does not exist: {answers_file}")
+            resolved_answers_file = answers_file
+
+        if not resolved_answers_file.exists():
+            raise ConfigurationError(f"Answers file '{resolved_answers_file}' does not exist.")
+
+        console = ConsoleOutput(quiet=self._quiet)
+        version = self._context.config.model.template_version
+
+        console.info(f"→ Updating model '{name}' with answers file {resolved_answers_file}\n")
+
+        copier.run_update(
+            self._context.root_directory,
+            data=_load_yaml_data(resolved_answers_file),
+            answers_file=_relative_to_root(resolved_answers_file, self._context.root_directory),
+            vcs_ref=version,
+            conflict="inline",
+            unsafe=True,
+            # copier requires this for git-tracked destinations (which a
+            # real OARepo repository always is): since the user can review
+            # the change via `git diff` / conflict markers (conflict=
+            # "inline") before committing, it's safe to skip its own
+            # confirmation prompt. Without it, run_update always raises
+            # "Enable overwrite to update a subproject."
+            overwrite=True,
+            quiet=self._quiet,
+        )
+
+        console.success(f"✓ Model '{name}' updated successfully.\n")

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -10,6 +10,10 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from oarepo_cli.services import invenio_cli, translations
+from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
+from oarepo_cli.ui import ConsoleOutput
+
 if TYPE_CHECKING:
     from oarepo_cli.core.context import ProjectContext
 
@@ -189,3 +193,106 @@ def ensure_instance_structure(
         import sys
 
         print("✓ Instance structure ready\n", file=sys.stderr)
+
+
+def install_repository(context: ProjectContext, *, quiet: bool = False) -> None:
+    """Install/reinstall a repository into its virtual environment.
+
+    Mirrors ``repository_runner.sh``'s ``install_repository`` function:
+    1. Creates/syncs virtual environment with uv
+    2. Copies translation overlays to site-packages
+    3. Resolves instance path (INVENIO_INSTANCE_PATH or <venv>/var/instance)
+    4. Creates instance directory and symlinks invenio.cfg
+    5. Runs invenio-cli install
+    6. Configures local service ports in .invenio.private
+    7. Compiles backend translations
+
+    Shared by ``repository install``, ``repository upgrade`` (which cleans
+    the venv and uv cache first, then reinstalls), and
+    ``ModelManager.create_model()`` (which reinstalls after adding a model,
+    if a venv already exists) -- mirroring how repository_runner.sh's
+    ``install_repository`` is called from ``install``, ``upgrade_repository``,
+    and ``create_model`` alike. Callers are responsible for their own
+    top-level success message and ``(OARepoError, ProcessExecutionError)``
+    handling.
+
+    Args:
+        context: Project context with paths and configuration
+        quiet: If True, suppress status/progress messages
+
+    Raises:
+        ProcessExecutionError: If a required step (uv sync, invenio-cli
+            install) fails
+    """
+    console = ConsoleOutput(quiet=quiet)
+
+    # Step 1: Ensure virtual environment exists and sync dependencies
+    console.info(f"→ Syncing dependencies in {context.config.venv.path}\n")
+
+    venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
+    requirements = VenvRequirements(
+        python_binary=str(context.python_binary),
+        oarepo_version=context.oarepo_version,
+        extras=[],  # No explicit extras for repositories; uv sync reads pyproject.toml
+        editable=True,  # Repositories are always editable installs
+    )
+    venv_manager.ensure_venv(requirements, quiet=quiet)
+
+    # Step 2: Copy translation overlays
+    console.info("→ Copying translation overlays\n")
+
+    collected_dir = os.environ.get("COLLECTED_TRANSLATIONS_DIR")
+    translations.copy_translations(
+        context,
+        collected_translations_dir=collected_dir,
+        quiet=quiet,
+    )
+
+    # Step 3: Get instance path from Invenio shell
+    console.info("→ Detecting instance path\n")
+
+    instance_path = get_instance_path(context)
+
+    # Step 4: Ensure instance structure (directory + invenio.cfg symlink)
+    ensure_instance_structure(context, instance_path, quiet=quiet)
+
+    # Step 5: Run invenio-cli install
+    console.info("→ Running invenio-cli install\n")
+
+    invenio_cli.run_invenio_cli(
+        context,
+        ["install"],
+        quiet=quiet,
+        check=True,
+    )
+
+    # Step 6: Configure local service ports
+    console.info("→ Configuring service ports\n")
+
+    configure_local_ports(context, quiet=quiet)
+
+    # Step 7: Compile backend translations
+    # First, ensure translations directory structure exists (bootstrap if needed)
+    translations_dir = context.root_directory / "translations"
+    messages_pot = translations_dir / "messages.pot"
+    en_lc_messages = translations_dir / "en" / "LC_MESSAGES"
+
+    if not messages_pot.exists() or not en_lc_messages.exists():
+        console.info("→ Bootstrapping translations with make-translations\n")
+        # Try to run make-translations to bootstrap; don't fail if it errors
+        result = translations.run_translations(context, quiet=quiet)
+        if not result.success:
+            console.warning("⚠️  Warning: make-translations failed, translations not compiled!")
+
+    console.info("→ Compiling backend translations\n")
+
+    # Run invenio-cli translations compile
+    result = invenio_cli.run_invenio_cli(
+        context,
+        ["translations", "compile"],
+        quiet=quiet,
+        check=False,  # Don't fail if translations compile fails
+    )
+
+    if not result.success:
+        console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,19 @@ dependencies = [
     "ty>=0.0.65",
     # Tools for library commands
     "oarepo-tools",  # make-translations command
+    # Model manager (services/models.py): run copier in-process from this
+    # venv rather than shelling out to `uvx copier`. copier-template-extensions
+    # (note: singular -- copier-templates-extensions is the deprecated old
+    # name) provides the `copier_templates_extensions` jinja extension the
+    # nrp-app-copier/nrp-model-copier templates load; pycountry/tomli/tomli-w
+    # are needed by those templates' own extensions and post-generation
+    # tasks (e.g. registering a new model in pyproject.toml/invenio.cfg),
+    # which run with copier's own interpreter -- i.e. this venv's.
+    "copier>=9.0.0",
+    "copier-template-extensions>=0.3.0",
+    "pycountry>=24.0.0",
+    "tomli>=2.0.0",
+    "tomli-w>=1.0.0",
 ]
 requires-python = ">=3.14,<3.15"
 

--- a/tests/integration/test_model_manager.py
+++ b/tests/integration/test_model_manager.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for ModelManager, against real copier and small local templates.
+
+Unlike most other external-tool integrations in this codebase, copier is
+invoked here as an in-process Python library (see services/models.py's
+module docstring) rather than shelled out to a subprocess, so
+pytest-subprocess's fake_process fixture doesn't apply -- there's no
+subprocess to intercept. Instead, these tests run copier for real against
+small local template fixtures (fast: no network, no ephemeral uvx
+environment to bootstrap), which is both simpler and a more faithful test
+than mocking copier's Python API would be.
+
+Two template fixtures are used:
+- ``static_template``: a single hidden (``when: false``) ``model_name``
+  question and static rendered content. Mirrors the "no config file"
+  create_model() call, which only ever supplies ``model_name`` via data --
+  copier never writes an answers file when every question is hidden (real,
+  observed copier 9.x behaviour), so this fixture is unsuitable for testing
+  update_model().
+- ``answered_template``: adds a second, *visible* ``greeting`` question, so
+  copier records a real ``.copier-answers.yml`` -- needed to exercise
+  create_model(config_file=...) and update_model().
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import copier
+import pytest
+
+from oarepo_cli.core.config import CliConfig, ModelConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services.models import ModelManager
+
+STATIC_COPIER_YML = """\
+model_name:
+  type: str
+  help: Model name
+  when: false
+"""
+
+ANSWERED_COPIER_YML = """\
+model_name:
+  type: str
+  help: Model name
+  when: false
+
+greeting:
+  type: str
+  default: hello
+"""
+
+ANSWERS_FILE_SETTING = '\n_answers_file: "models/{{model_name}}/.copier-answers.yml"\n'
+
+STATIC_TEMPLATE_FILE = 'GREETING = "hello"\n'
+ANSWERED_TEMPLATE_FILE = 'GREETING = "{{ greeting }}"\n'
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _write_template(template_dir: Path, copier_yml: str, model_file_content: str) -> None:
+    template_dir.mkdir()
+    (template_dir / "copier.yml").write_text(copier_yml + ANSWERS_FILE_SETTING)
+    model_dir = template_dir / "models" / "{{model_name}}"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.py.jinja").write_text(model_file_content)
+    # copier does NOT auto-write the answers file -- the template itself
+    # must contain a file that renders the special `_copier_answers`
+    # context variable (this is the exact mechanism nrp-app-copier/
+    # nrp-model-copier use too, via `{{_copier_conf.answers_file}}.copier`).
+    (template_dir / "{{_copier_conf.answers_file}}.jinja").write_text(
+        "{{ _copier_answers|to_nice_yaml }}\n"
+    )
+    # copier records the template's commit/ref in the answers file, which
+    # update_model() later needs to know what to update *from* -- so, like
+    # any real copier template, this one must be a real git repo.
+    _git("init", "-q", cwd=template_dir)
+    _git("add", "-A", cwd=template_dir)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=template_dir,
+    )
+
+
+@pytest.fixture
+def static_template(tmp_path: Path) -> Path:
+    """A template with only a hidden model_name question and static content."""
+    template_dir = tmp_path / "static_template"
+    _write_template(template_dir, STATIC_COPIER_YML, STATIC_TEMPLATE_FILE)
+    return template_dir
+
+
+@pytest.fixture
+def answered_template(tmp_path: Path) -> Path:
+    """A template with a hidden model_name question plus a real, recorded greeting question."""
+    template_dir = tmp_path / "answered_template"
+    _write_template(template_dir, ANSWERED_COPIER_YML, ANSWERED_TEMPLATE_FILE)
+    return template_dir
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """An empty repository root to render model templates into."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+def make_context(root: Path, template_dir: Path, *, version: str = "") -> ProjectContext:
+    config = CliConfig(model=ModelConfig(template_url=str(template_dir), template_version=version))
+    return ProjectContext(
+        root_directory=root,
+        pyproject_path=root / "pyproject.toml",
+        venv_path=root / ".venv",
+        python_binary=root / ".venv" / "bin" / "python",
+        oarepo_version=14,
+        config=config,
+    )
+
+
+def test_create_model_renders_local_template(repo_root: Path, static_template: Path) -> None:
+    """create_model() renders the template for real, using model_name as data."""
+    context = make_context(repo_root, static_template)
+    manager = ModelManager(context, quiet=True)
+
+    manager.create_model("my_model")
+
+    rendered = repo_root / "models" / "my_model" / "model.py"
+    assert rendered.exists()
+    assert rendered.read_text() == 'GREETING = "hello"\n'
+
+
+def test_create_model_with_config_file_seeds_answers(
+    repo_root: Path, answered_template: Path, tmp_path: Path
+) -> None:
+    """create_model(config_file=...) seeds all answers from that file (model_name included),
+    mirroring repository_runner.sh: when a config file is given, -d model_name is NOT also
+    passed -- the file must supply model_name itself."""
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("model_name: configured_model\ngreeting: hi there\n")
+
+    context = make_context(repo_root, answered_template)
+    manager = ModelManager(context, quiet=True)
+
+    manager.create_model("ignored_name", config_file=config_file)
+
+    rendered = repo_root / "models" / "configured_model" / "model.py"
+    assert rendered.exists()
+    assert rendered.read_text() == 'GREETING = "hi there"\n'
+    assert (repo_root / "models" / "configured_model" / ".copier-answers.yml").exists()
+
+
+def test_create_model_missing_config_file_raises(repo_root: Path, static_template: Path) -> None:
+    """A non-existent config_file raises ConfigurationError before copier ever runs."""
+    context = make_context(repo_root, static_template)
+    manager = ModelManager(context, quiet=True)
+
+    with pytest.raises(ConfigurationError, match="Missing model config file"):
+        manager.create_model("my_model", config_file=repo_root / "does-not-exist.yml")
+
+
+def test_create_model_reinstalls_when_venv_exists(
+    repo_root: Path, static_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If a venv already exists, the repository is reinstalled after model creation."""
+    (repo_root / ".venv").mkdir()
+
+    calls: list[tuple[ProjectContext, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.models.install_repository",
+        lambda context, **kwargs: calls.append((context, kwargs)),
+    )
+
+    context = make_context(repo_root, static_template)
+    manager = ModelManager(context, quiet=True)
+
+    manager.create_model("my_model")
+
+    assert len(calls) == 1
+    assert calls[0][0] is context
+    assert calls[0][1] == {"quiet": True}
+
+
+def test_create_model_skips_reinstall_without_venv(
+    repo_root: Path, static_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without an existing venv, no reinstall is attempted."""
+    calls: list[tuple[ProjectContext, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.models.install_repository",
+        lambda context, **kwargs: calls.append((context, kwargs)),
+    )
+
+    context = make_context(repo_root, static_template)
+    manager = ModelManager(context, quiet=True)
+
+    manager.create_model("my_model")
+
+    assert calls == []
+
+
+def test_template_url_handling_vcs_ref_only_for_github_urls(
+    repo_root: Path, static_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vcs_ref is only passed to copier for github:// template URLs, never for local paths
+    (mirrors repository_runner.sh's `if [[ "${MODEL_TEMPLATE}" == https://* ]]`)."""
+    calls: list[dict[str, Any]] = []
+    real_run_copy = copier.run_copy
+
+    def spy_run_copy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return real_run_copy(*args, **kwargs)
+
+    monkeypatch.setattr("oarepo_cli.services.models.copier.run_copy", spy_run_copy)
+
+    # Local template path: vcs_ref must be None even though template_version is set.
+    context = make_context(repo_root, static_template, version="some-ref")
+    ModelManager(context, quiet=True).create_model("my_model")
+
+    assert calls[0]["vcs_ref"] is None
+
+
+def test_update_model_calls_copier_update_correctly(
+    repo_root: Path, answered_template: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """update_model() calls copier.run_update() with the right destination, answers
+    file (relative to repo root, matching create_model()'s recorded location),
+    conflict/unsafe/overwrite settings, and succeeds against a real, git-tracked
+    project -- i.e. the wiring is correct. copier's own 3-way-merge update
+    semantics (what specifically changes on disk for a given template diff) are
+    that library's concern, not re-tested here.
+
+    copier only supports updating git-tracked, clean subprojects, matching real
+    usage (a real OARepo repository is always its own git repo -- see
+    repository_installer.sh's `git init` step), so repo_root is committed here,
+    like a real user's workflow would be.
+    """
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("model_name: my_model\ngreeting: hello\n")
+
+    context = make_context(repo_root, answered_template, version="HEAD")
+    manager = ModelManager(context, quiet=True)
+    manager.create_model("my_model", config_file=config_file)
+
+    _git("init", "-q", cwd=repo_root)
+    _git("add", "-A", cwd=repo_root)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=repo_root,
+    )
+
+    calls: list[dict[str, Any]] = []
+    real_run_update = copier.run_update
+
+    def spy_run_update(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return real_run_update(*args, **kwargs)
+
+    monkeypatch.setattr("oarepo_cli.services.models.copier.run_update", spy_run_update)
+
+    manager.update_model("my_model")
+
+    assert len(calls) == 1
+    assert calls[0]["answers_file"] == Path("models/my_model/.copier-answers.yml")
+    assert calls[0]["vcs_ref"] == "HEAD"
+    assert calls[0]["conflict"] == "inline"
+    assert calls[0]["unsafe"] is True
+    assert calls[0]["overwrite"] is True
+
+
+def test_update_model_missing_model_dir_raises(repo_root: Path, static_template: Path) -> None:
+    """update_model() on a model that was never created raises ConfigurationError."""
+    context = make_context(repo_root, static_template)
+    manager = ModelManager(context, quiet=True)
+
+    with pytest.raises(ConfigurationError, match="does not exist"):
+        manager.update_model("never_created")
+
+
+def test_update_model_missing_answers_file_raises(
+    repo_root: Path, answered_template: Path, tmp_path: Path
+) -> None:
+    """An explicitly given answers_file that doesn't exist raises ConfigurationError."""
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("model_name: my_model\ngreeting: hello\n")
+
+    context = make_context(repo_root, answered_template)
+    manager = ModelManager(context, quiet=True)
+    manager.create_model("my_model", config_file=config_file)
+
+    with pytest.raises(ConfigurationError, match="does not exist"):
+        manager.update_model("my_model", answers_file=repo_root / "missing.yml")


### PR DESCRIPTION
## Summary
- Implements `ModelManager` (`services/models.py`) with `create_model(name, config_file=None)` and `update_model(name, answers_file=None)`, for use by Step 4.5's `repository model` command (not yet implemented).
- **Requested improvement**: instead of shelling out to `uvx --with copier-template-extensions --with pycountry --with tomli --with tomli-w copier copy/update ...` for a fresh ephemeral environment on every call (`repository_runner.sh`'s approach), `copier`, `copier-template-extensions` (singular — the plural `copier-templates-extensions` is deprecated, even though `repository_runner.sh`'s model commands use the old plural spelling), `pycountry`, `tomli`, and `tomli-w` are now regular oarepo-cli dependencies, and `ModelManager` calls `copier.run_copy`/`copier.run_update` directly as a library, in-process.
- Extracted `repository.install_repository()` (previously `cli/repository.py`'s private `_install_repository`) into `services/repository.py` as a public function, so `install`/`upgrade` and `ModelManager.create_model()`'s post-creation reinstall share it — mirroring how `repository_runner.sh`'s `install_repository()` is called from `install`, `upgrade_repository`, and `create_model` alike.
- One further deliberate behavioral difference, discovered while writing real tests against real copier: a given `config_file`/`answers_file` is loaded and passed to copier as `data` (like copier's own `--data-file`), not merely as `answers_file` (like bash's `--answers-file`) — the latter only pre-fills copier's interactive prompts, still requiring a live terminal to confirm each one, which defeats the point of passing a config file for scripted use.

## Test plan
- [x] `uv run pytest tests/integration/test_model_manager.py -v` — 9/9 passed, running copier for real against small local template fixtures (fast: no network, no ephemeral `uvx` bootstrap) rather than mocking copier's API. Along the way, learned and documented some non-obvious copier behavior (see PR commit message / implementation-steps.md): it never writes an answers file unless the template itself renders `_copier_answers`; `copier update` requires a git-tracked, clean destination and `overwrite=True`; `answers_file` must resolve inside `dst_path`.
- [x] `uv run pytest tests/integration/test_repository_install.py -v` — 5/5 passed (real, slow, end-to-end — confirms the `install_repository()` extraction didn't break the real install flow)
- [x] `uv run pytest tests/unit tests/core tests/services tests/integration/test_repository_services.py tests/integration/test_model_manager.py -q` — 248 passed, no regressions
- [x] `make check` (ruff check / format / ty) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)