### PR TITLE
Step 4.5: Repository model command

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,9 +611,38 @@ oarepo-cli repository services setup --help
 - Whatever `invenio-cli services <subcommand>` returns (propagated exactly, not collapsed to 0/1)
 - `1`: Project context could not be discovered (e.g. no `pyproject.toml`)
 
+### `repository model`
+
+Creates and updates record models via [copier](https://copier.readthedocs.io/), rendering the configured model template (`[tool.oarepo-cli.model] template_url`/`template_version` in `pyproject.toml`, or the `MODEL_TEMPLATE`/`MODEL_TEMPLATE_VERSION` env vars — default [`nrp-model-copier`](https://github.com/oarepo/nrp-model-copier) @ `rdm-14`) into `models/<name>/`. Template/version are not CLI flags — only configurable via `pyproject.toml`/env vars, matching `repository_runner.sh`.
+
+```bash
+oarepo-cli repository model create <name> [config_file]
+oarepo-cli repository model update <name> [answers_file]
+```
+
+**Subcommands:**
+- `create <name> [config_file]`: Renders the model template into `models/<name>/`. If `config_file` (a YAML file) is given, it seeds *all* answers non-interactively and must supply `model_name` itself; if omitted, only `model_name` is passed and the template's own defaults apply. Reinstalls the repository afterwards if a virtual environment already exists (a new model changes `pyproject.toml` entry points/dependencies).
+- `update <name> [answers_file]`: Updates an existing model (`models/<name>` must already exist) from its recorded `.copier-answers.yml`, or from `answers_file` if given. Requires a git-tracked, clean repository (copier's own requirement); conflicts are written inline for review via `git diff`.
+
+**Options** (each subcommand):
+- `--quiet` / `-q`: Suppress output from subprocesses (copier, invenio-cli, etc.)
+
+**Examples:**
+```bash
+oarepo-cli repository model create my_model
+oarepo-cli repository model create my_model model_config.yaml
+
+oarepo-cli repository model update my_model
+oarepo-cli repository model update my_model model_config.yaml
+```
+
+**Exit codes:**
+- `0`: Model created/updated successfully
+- `1`: Model creation/update failed (e.g. missing config file, non-existent model, project context could not be discovered)
+
 ### Other Repository Commands
 
-_Commands below are to be implemented in Phase 4 (steps 4.4-4.11)._
+_Commands below are to be implemented in Phase 4 (steps 4.6-4.11)._
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -968,17 +968,62 @@ must resolve inside `dst_path`, never a parent/sibling.
 ### Step 4.5: Repository `model` Command
 **Goal**: Implement `oarepo-cli repository model` command.
 
-- [ ] Implement `repository_model()` with `create` and `update` subcommands
-- [ ] Options: template URL, version, config file
-- [ ] Delegate to `ModelManager`
+- [x] Implement `repository_model()` with `create` and `update` subcommands
+- [x] Options: template URL, version, config file
+- [x] Delegate to `ModelManager`
+
+**Deviation from the original plan**: template URL/version are not exposed
+as CLI flags on `model create`/`model update` -- per `03-migration-guide.md`
+(`oarepo-cli repository model create <name> [config_file]`, `... update
+<name> [answers_file]`), they're only ever configured via
+`[tool.oarepo-cli] model.template_url`/`.template_version` in
+`pyproject.toml` or the `MODEL_TEMPLATE`/`MODEL_TEMPLATE_VERSION` env vars
+(already resolved into `context.config.model` by `core/config.py`, see
+Step 4.4), matching `repository_runner.sh`'s `create_model`/`update_model`,
+which never took `--template`/`--version` flags either. Each subcommand
+takes only a `name` positional and an optional `config_file`/
+`answers_file` positional, plus `--quiet` (consistent with `install`/
+`upgrade`).
 
 **Deliverables**:
 - Model command
 
 **Tests** (`tests/integration/test_repository_model.py`):
-- [ ] Test model create subcommand
-- [ ] Test model update subcommand
-- [ ] Test help text
+- [x] Test model create subcommand
+- [x] Test model update subcommand
+- [x] Test help text
+
+---
+
+### Step 4.5.1: Fix pre-existing test failures uncovered by the Step 4.5 full-suite run
+**Goal**: Fix two `make test` failures, unrelated to Step 4.5, discovered while
+running the full suite (not just the changed files) after implementing it.
+Left unfixed for now -- deliberately out of scope for Step 4.5's PR -- but
+tracked here so they're not lost.
+
+- [ ] `tests/integration/test_repository_upgrade.py::test_upgrade_removes_venv_and_lock`
+  and `::test_upgrade_cleans_uv_cache_with_force`: both `monkeypatch.setattr(
+  "oarepo_cli.cli.repository._install_repository", ...)`, but that name hasn't
+  existed since Step 4.4 (#124), which extracted it out of `cli/repository.py`
+  into the public `oarepo_cli.services.repository.install_repository`. Fix:
+  update both monkeypatch targets (and the `repository.install_repository`
+  import alias used in the patched module) to
+  `"oarepo_cli.services.repository.install_repository"` (or patch it via
+  `oarepo_cli.cli.repository.repository.install_repository`, matching how
+  `cli/repository.py` imports the `repository` service module -- see how
+  `upgrade`/`install` call it there).
+- [ ] `tests/integration/test_library_venv_sync.py::test_uv_lock_added_to_gitignore`:
+  fails only when the full suite runs (passed in isolation during Step 4.5's
+  own test runs), asserting `"uv.lock" not in content_before` against a
+  `.gitignore` that already contains `uv.lock` -- looks like state leaking in
+  from another test sharing the same fixture/module scope. Investigate
+  `clean_testlib`'s fixture scope and whether an earlier test in the same
+  module (or a module-scoped fixture reused across tests) is mutating a
+  shared `.gitignore` before this test runs; fix by isolating/resetting the
+  fixture's state per-test rather than reusing a mutated one.
+
+**Deliverables**:
+- Both failures fixed, `make test` green end to end (not just per-file)
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path  # noqa: TCH003
 from typing import Annotated
 
 import typer
@@ -12,6 +13,7 @@ import typer
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
 from oarepo_cli.services import invenio_cli, process, repository
+from oarepo_cli.services.models import ModelManager
 from oarepo_cli.services.venv import VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
@@ -29,8 +31,16 @@ services_app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register services as a subcommand of repository
+# Create the model subcommand group
+model_app = typer.Typer(
+    name="model",
+    help="Record model management (create/update from copier templates)",
+    no_args_is_help=True,
+)
+
+# Register services and model as subcommands of repository
 repository_app.add_typer(services_app)
+repository_app.add_typer(model_app)
 
 # Each services subcommand is a pure passthrough to invenio-cli: extra
 # arguments/options are forwarded verbatim, and --help must reach
@@ -52,6 +62,11 @@ def repository_callback() -> None:
 @services_app.callback()
 def services_callback() -> None:
     """Repository services command group."""
+
+
+@model_app.callback()
+def model_callback() -> None:
+    """Repository model command group."""
 
 
 def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool) -> None:
@@ -243,4 +258,88 @@ def upgrade(
     except (OARepoError, ProcessExecutionError) as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Upgrade failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@model_app.command("create")
+def model_create(
+    name: Annotated[str, typer.Argument(help="Name of the model to create")],
+    config_file: Annotated[
+        Path | None,
+        typer.Argument(
+            help=(
+                "Optional YAML file whose content seeds all answers "
+                "non-interactively (must supply model_name itself)"
+            ),
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from subprocesses (copier, invenio-cli, etc.)",
+        ),
+    ] = False,
+) -> None:
+    """Create a new record model from the configured model copier template.
+
+    See ``services.models.ModelManager.create_model`` for the individual steps.
+
+    Examples:
+        $ oarepo-cli repository model create my_model
+        $ oarepo-cli repository model create my_model model_config.yaml
+
+    Exit codes:
+        0: Model created successfully
+        1: Model creation failed
+    """
+    try:
+        context = discover_context()
+        ModelManager(context, quiet=quiet).create_model(name, config_file=config_file)
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Model creation failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@model_app.command("update")
+def model_update(
+    name: Annotated[str, typer.Argument(help="Name of the model to update")],
+    answers_file: Annotated[
+        Path | None,
+        typer.Argument(
+            help=(
+                "Optional YAML answers file to update from (defaults to the "
+                "model's recorded models/<name>/.copier-answers.yml)"
+            ),
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from subprocesses (copier, invenio-cli, etc.)",
+        ),
+    ] = False,
+) -> None:
+    """Update an existing record model from its recorded (or given) template answers.
+
+    See ``services.models.ModelManager.update_model`` for the individual steps.
+
+    Examples:
+        $ oarepo-cli repository model update my_model
+        $ oarepo-cli repository model update my_model model_config.yaml
+
+    Exit codes:
+        0: Model updated successfully
+        1: Model update failed
+    """
+    try:
+        context = discover_context()
+        ModelManager(context, quiet=quiet).update_model(name, answers_file=answers_file)
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Model update failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e

--- a/tests/integration/test_repository_model.py
+++ b/tests/integration/test_repository_model.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `repository model create`/`repository model update`.
+
+Delegation, argument wiring, and error/exit-code handling are covered here
+by mocking `discover_context()`/`ModelManager` (mirroring
+test_repository_services.py's approach for the other passthrough-style
+repository subcommands) -- copier's own rendering/update behavior is
+already covered thoroughly, against real templates, by
+test_model_manager.py. `test_model_create_and_update_against_real_template`
+additionally drives the full stack once, end to end, against a small local
+template, to check the command group is wired up correctly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.core.config import CliConfig, ModelConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+COPIER_YML = """\
+model_name:
+  type: str
+  help: Model name
+  when: false
+
+greeting:
+  type: str
+  default: hello
+"""
+
+ANSWERS_FILE_SETTING = '\n_answers_file: "models/{{model_name}}/.copier-answers.yml"\n'
+MODEL_FILE_TEMPLATE = 'GREETING = "{{ greeting }}"\n'
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def local_template(tmp_path: Path) -> Path:
+    """A small, real, git-tracked copier template (model_name + greeting)."""
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    (template_dir / "copier.yml").write_text(COPIER_YML + ANSWERS_FILE_SETTING)
+    model_dir = template_dir / "models" / "{{model_name}}"
+    model_dir.mkdir(parents=True)
+    (model_dir / "model.py.jinja").write_text(MODEL_FILE_TEMPLATE)
+    (template_dir / "{{_copier_conf.answers_file}}.jinja").write_text(
+        "{{ _copier_answers|to_nice_yaml }}\n"
+    )
+    _git("init", "-q", cwd=template_dir)
+    _git("add", "-A", cwd=template_dir)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=template_dir,
+    )
+    return template_dir
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """An empty, git-tracked repository root to render model templates into."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git("init", "-q", cwd=root)
+    return root
+
+
+@pytest.fixture
+def mock_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() so no real project is needed."""
+    context = Mock()
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    return context
+
+
+def _fake_model_manager(calls: list[dict[str, object]]) -> type:
+    class FakeModelManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            calls.append({"context": context, "quiet": quiet})
+            self._calls = calls
+
+        def create_model(self, name: str, config_file: object = None) -> None:
+            self._calls.append({"method": "create_model", "name": name, "config_file": config_file})
+
+        def update_model(self, name: str, answers_file: object = None) -> None:
+            self._calls.append(
+                {"method": "update_model", "name": name, "answers_file": answers_file}
+            )
+
+    return FakeModelManager
+
+
+def test_model_create_delegates_to_model_manager(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository model create <name>` constructs a ModelManager and calls create_model()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", _fake_model_manager(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "model", "create", "my_model"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {"method": "create_model", "name": "my_model", "config_file": None}
+
+
+def test_model_create_passes_config_file_and_quiet(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A given config_file positional arg and --quiet are both forwarded."""
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("model_name: my_model\n")
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", _fake_model_manager(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["repository", "model", "create", "my_model", str(config_file), "--quiet"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": True}
+    assert calls[1] == {
+        "method": "create_model",
+        "name": "my_model",
+        "config_file": config_file,
+    }
+
+
+def test_model_create_reports_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ConfigurationError raised by ModelManager is reported cleanly, exit code 1."""
+
+    class RaisingModelManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            pass
+
+        def create_model(self, name: str, config_file: object = None) -> None:  # noqa: ARG002
+            raise ConfigurationError(f"Missing model config file: {config_file}")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", RaisingModelManager)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "model", "create", "my_model", "missing.yml"])
+
+    assert result.exit_code == 1
+    assert "Model creation failed" in result.output
+
+
+def test_model_create_reports_context_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context-discovery failure (e.g. no pyproject.toml) is reported cleanly, exit code 1."""
+
+    def raise_config_error() -> None:
+        raise ConfigurationError("pyproject.toml not found")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", raise_config_error)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "model", "create", "my_model"])
+
+    assert result.exit_code == 1
+
+
+def test_model_update_delegates_to_model_manager(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository model update <name>` constructs a ModelManager and calls update_model()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", _fake_model_manager(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "model", "update", "my_model"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {"method": "update_model", "name": "my_model", "answers_file": None}
+
+
+def test_model_update_passes_answers_file_and_quiet(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A given answers_file positional arg and --quiet are both forwarded."""
+    answers_file = tmp_path / "answers.yml"
+    answers_file.write_text("model_name: my_model\n")
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", _fake_model_manager(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["repository", "model", "update", "my_model", str(answers_file), "--quiet"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": True}
+    assert calls[1] == {
+        "method": "update_model",
+        "name": "my_model",
+        "answers_file": answers_file,
+    }
+
+
+def test_model_update_reports_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ConfigurationError raised by ModelManager is reported cleanly, exit code 1."""
+
+    class RaisingModelManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            pass
+
+        def update_model(self, name: str, answers_file: object = None) -> None:  # noqa: ARG002
+            raise ConfigurationError(f"Model directory 'models/{name}' does not exist.")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.ModelManager", RaisingModelManager)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "model", "update", "my_model"])
+
+    assert result.exit_code == 1
+    assert "Model update failed" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["repository", "model", "--help"],
+        ["repository", "model", "create", "--help"],
+        ["repository", "model", "update", "--help"],
+    ],
+)
+def test_model_help_text(args: list[str]) -> None:
+    """--help works for the model group and both subcommands, without a real project."""
+    runner = CliRunner()
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    assert "model" in result.output.lower()
+
+
+def test_model_create_and_update_against_real_template(
+    repo_root: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: the `model` command group is wired correctly through to real copier,
+    for both create and update, against a small local template.
+
+    A config_file is passed to `create` (seeding all answers, including the
+    visible `greeting` question) so copier never needs an interactive
+    terminal to confirm it -- see ModelManager's class docstring.
+    """
+    config = CliConfig(model=ModelConfig(template_url=str(local_template), template_version="HEAD"))
+    context = ProjectContext(
+        root_directory=repo_root,
+        pyproject_path=repo_root / "pyproject.toml",
+        venv_path=repo_root / ".venv",
+        python_binary=repo_root / ".venv" / "bin" / "python",
+        oarepo_version=14,
+        config=config,
+    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("model_name: my_model\ngreeting: hello\n")
+
+    runner = CliRunner()
+    create_result = runner.invoke(
+        app,
+        ["repository", "model", "create", "my_model", str(config_file), "--quiet"],
+        catch_exceptions=False,
+    )
+    assert create_result.exit_code == 0, create_result.output
+
+    rendered = repo_root / "models" / "my_model" / "model.py"
+    assert rendered.exists()
+    assert rendered.read_text() == 'GREETING = "hello"\n'
+
+    # copier update only works on git-tracked, clean destinations.
+    _git("add", "-A", cwd=repo_root)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=repo_root,
+    )
+
+    update_result = runner.invoke(
+        app, ["repository", "model", "update", "my_model", "--quiet"], catch_exceptions=False
+    )
+    assert update_result.exit_code == 0, update_result.output


### PR DESCRIPTION
## Summary
- Implements `oarepo-cli repository model create <name> [config_file]` and `oarepo-cli repository model update <name> [answers_file]`, delegating to Step 4.4's `ModelManager`.
- Template URL/version stay config-only (`pyproject.toml` / `MODEL_TEMPLATE`/`MODEL_TEMPLATE_VERSION` env vars) — no `--template`/`--version` CLI flags, matching `repository_runner.sh` and `03-migration-guide.md`'s documented CLI surface.
- Documents Step 4.5.1 in `implementation-steps.md`: two pre-existing `make test` failures (stale `_install_repository` monkeypatch target left over from Step 4.4's refactor, and an order-dependent `.gitignore` fixture leak in `test_library_venv_sync.py`) surfaced while running the full suite. Deliberately left unfixed here, tracked for a follow-up.

## Test plan
- [x] `make check` (lint + format + type-check)
- [x] `tests/integration/test_repository_model.py` (11 tests: delegation/argument wiring for create/update, config_file/answers_file + --quiet forwarding, error handling/exit codes, --help text, one real end-to-end run against a local copier template)
- [x] Full `make test` suite run — passes except the two pre-existing, unrelated failures noted above (confirmed via `git log` to predate this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)