### PR TITLE
Step 4.5.1: Fix pre-existing test failures uncovered by the Step 4.5 full-suite run

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -998,29 +998,30 @@ takes only a `name` positional and an optional `config_file`/
 ### Step 4.5.1: Fix pre-existing test failures uncovered by the Step 4.5 full-suite run
 **Goal**: Fix two `make test` failures, unrelated to Step 4.5, discovered while
 running the full suite (not just the changed files) after implementing it.
-Left unfixed for now -- deliberately out of scope for Step 4.5's PR -- but
-tracked here so they're not lost.
 
-- [ ] `tests/integration/test_repository_upgrade.py::test_upgrade_removes_venv_and_lock`
+- [x] `tests/integration/test_repository_upgrade.py::test_upgrade_removes_venv_and_lock`
   and `::test_upgrade_cleans_uv_cache_with_force`: both `monkeypatch.setattr(
   "oarepo_cli.cli.repository._install_repository", ...)`, but that name hasn't
   existed since Step 4.4 (#124), which extracted it out of `cli/repository.py`
-  into the public `oarepo_cli.services.repository.install_repository`. Fix:
-  update both monkeypatch targets (and the `repository.install_repository`
-  import alias used in the patched module) to
-  `"oarepo_cli.services.repository.install_repository"` (or patch it via
-  `oarepo_cli.cli.repository.repository.install_repository`, matching how
-  `cli/repository.py` imports the `repository` service module -- see how
-  `upgrade`/`install` call it there).
-- [ ] `tests/integration/test_library_venv_sync.py::test_uv_lock_added_to_gitignore`:
-  fails only when the full suite runs (passed in isolation during Step 4.5's
-  own test runs), asserting `"uv.lock" not in content_before` against a
-  `.gitignore` that already contains `uv.lock` -- looks like state leaking in
-  from another test sharing the same fixture/module scope. Investigate
-  `clean_testlib`'s fixture scope and whether an earlier test in the same
-  module (or a module-scoped fixture reused across tests) is mutating a
-  shared `.gitignore` before this test runs; fix by isolating/resetting the
-  fixture's state per-test rather than reusing a mutated one.
+  into the public `oarepo_cli.services.repository.install_repository`. Fixed
+  by retargeting both monkeypatches to
+  `"oarepo_cli.cli.repository.repository.install_repository"`, matching how
+  `cli/repository.py` itself calls it (via its `from oarepo_cli.services
+  import ... repository` import) and how `test_repository_services.py`
+  patches through the same kind of imported-submodule reference.
+- [x] `tests/integration/test_library_venv_sync.py::test_uv_lock_added_to_gitignore`:
+  not test-order pollution as originally suspected -- it fails even in
+  isolation, on a clean checkout. Root cause: the real, checked-in
+  `tests/testlib/.gitignore` fixture file already lists `uv.lock` (added
+  deliberately in a later step, since testlib is a member of this repo's
+  own root uv workspace and has its own real lock), but the test's premise
+  (`assert "uv.lock" not in content_before`) assumed a fixture `.gitignore`
+  that never mentions `uv.lock` yet. Fixed with a new
+  `testlib_without_gitignored_uv_lock` fixture (wraps `clean_testlib`):
+  strips any existing `uv.lock` line from the real `.gitignore` before the
+  test runs (so the dynamic-add behavior can be verified for real, not
+  mocked) and restores the original content afterward, leaving the
+  committed fixture file untouched on disk once the test finishes.
 
 **Deliverables**:
 - Both failures fixed, `make test` green end to end (not just per-file)

--- a/tests/integration/test_library_venv_sync.py
+++ b/tests/integration/test_library_venv_sync.py
@@ -17,6 +17,7 @@ from typer.testing import CliRunner
 from oarepo_cli.cli.main import app
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -24,6 +25,28 @@ if TYPE_CHECKING:
 def runner() -> CliRunner:
     """Provide a Typer CLI runner."""
     return CliRunner()
+
+
+@pytest.fixture
+def testlib_without_gitignored_uv_lock(clean_testlib: Path) -> Iterator[Path]:
+    """Temporarily strip any ``uv.lock`` line from testlib's real, checked-in
+    .gitignore, restoring the original content afterward.
+
+    testlib's own .gitignore already lists ``uv.lock`` (it's a member of
+    this repo's root uv workspace), so ``test_uv_lock_added_to_gitignore``
+    needs a .gitignore that doesn't have it yet to verify `library venv`
+    adds it dynamically, without permanently mutating the committed fixture.
+    """
+    gitignore = clean_testlib / ".gitignore"
+    original_content = gitignore.read_text()
+    stripped_content = "\n".join(
+        line for line in original_content.splitlines() if line.strip() != "uv.lock"
+    )
+    gitignore.write_text(stripped_content + "\n")
+    try:
+        yield clean_testlib
+    finally:
+        gitignore.write_text(original_content)
 
 
 def test_venv_creates_uv_lock_file(
@@ -52,13 +75,13 @@ def test_venv_creates_uv_lock_file(
 
 def test_uv_lock_added_to_gitignore(
     runner: CliRunner,
-    clean_testlib: Path,
+    testlib_without_gitignored_uv_lock: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that uv.lock is automatically added to .gitignore."""
-    monkeypatch.chdir(clean_testlib)
+    monkeypatch.chdir(testlib_without_gitignored_uv_lock)
 
-    gitignore = clean_testlib / ".gitignore"
+    gitignore = testlib_without_gitignored_uv_lock / ".gitignore"
 
     # Verify .gitignore exists but doesn't have uv.lock yet
     assert gitignore.exists()

--- a/tests/integration/test_repository_upgrade.py
+++ b/tests/integration/test_repository_upgrade.py
@@ -4,7 +4,7 @@
 """Integration tests for `repository upgrade` against a real scaffolded repository.
 
 ``test_upgrade_removes_venv_and_lock`` and ``test_upgrade_cleans_uv_cache_with_force``
-mock out ``_install_repository`` (already covered end-to-end by
+mock out ``repository.install_repository`` (already covered end-to-end by
 ``test_repository_install.py``) and the actual ``uv cache clean`` invocation
 (global, machine-wide state -- not something to exercise for real on every
 run) so they run fast and deterministically, per AGENTS.md's guidance to use
@@ -40,7 +40,7 @@ def test_upgrade_removes_venv_and_lock(
     """`repository upgrade` removes the existing .venv and uv.lock before reinstalling."""
     monkeypatch.chdir(clean_testrepo)
     monkeypatch.setattr(
-        "oarepo_cli.cli.repository._install_repository", lambda *_args, **_kwargs: None
+        "oarepo_cli.cli.repository.repository.install_repository", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.process.run",
@@ -70,7 +70,7 @@ def test_upgrade_cleans_uv_cache_with_force(
     which omits --force), mirroring repository_runner.sh's upgrade_repository."""
     monkeypatch.chdir(clean_testrepo)
     monkeypatch.setattr(
-        "oarepo_cli.cli.repository._install_repository", lambda *_args, **_kwargs: None
+        "oarepo_cli.cli.repository.repository.install_repository", lambda *_args, **_kwargs: None
     )
 
     calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- `test_repository_upgrade.py`: retarget two stale `monkeypatch.setattr("oarepo_cli.cli.repository._install_repository", ...)` calls to `oarepo_cli.cli.repository.repository.install_repository` — that private name was removed by Step 4.4's refactor (#124), which extracted it into the public `services.repository.install_repository`.
- `test_library_venv_sync.py::test_uv_lock_added_to_gitignore`: turned out to fail even in isolation, not just as part of the full suite as originally suspected — the real, checked-in `tests/testlib/.gitignore` fixture already lists `uv.lock` (testlib is itself a member of the repo's root uv workspace). Added a `testlib_without_gitignored_uv_lock` fixture that strips the line before the test and restores the original content after, so the dynamic-add behavior is still verified against the real file without permanently mutating the committed fixture.

## Test plan
- [x] `make check`
- [x] Both previously-failing tests pass individually and repeatedly (checked idempotency/order-independence)
- [x] Full `make test` suite: 404 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)