### PR TITLE
Step 4.6: Local Package Manager

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1031,19 +1031,37 @@ running the full suite (not just the changed files) after implementing it.
 ### Step 4.6: Local Package Manager
 **Goal**: Manage local packages in `tool.uv.sources`.
 
-- [ ] Implement `services/local_packages.py` with `LocalPackageManager` class
-- [ ] Method: `add_package(path)` → None
-- [ ] Method: `remove_package(name)` → None
-- [ ] Parse and modify pyproject.toml
-- [ ] Trigger repository upgrade after changes
+- [x] Implement `services/local_packages.py` with `LocalPackageManager` class
+- [x] Method: `add_package(path)` → None
+- [x] Method: `remove_package(name)` → None
+- [x] Parse and modify pyproject.toml
+- [x] Trigger repository upgrade after changes
+
+**Deviation from the original plan**: rather than shelling out to `uv add
+<path> --editable` (`repository_runner.sh`'s approach), `add_package`/
+`remove_package` edit `pyproject.toml` directly with `tomlkit` (a new
+dependency), which round-trips comments/key order/formatting elsewhere in
+the file -- unlike `tomllib` (read-only, used by `PyProjectReader`) or
+`tomli-w` (write-only, full-dict dump, used by copier's own templates).
+Both methods unconditionally call a newly-extracted
+`services.repository.upgrade_repository()` afterwards (moved out of
+`cli/repository.py`'s `upgrade` command, which now just calls it too) --
+mirroring `local_sources_cmd`'s unconditional call to `upgrade_repository`
+after `uv add`, in contrast to `ModelManager.create_model()`'s conditional
+reinstall (only if a venv already exists). `remove_package()` has no bash
+equivalent: `repository_runner.sh`'s `local remove` was never implemented
+(it just told the user to edit `pyproject.toml` by hand and run
+`./run.sh upgrade`), but `00-main-architecture.md`'s compatibility matrix
+lists `local remove <name>` as a command the rewrite must actually
+support, so this fills that gap.
 
 **Deliverables**:
 - Local package management
 
 **Tests** (`tests/integration/test_local_packages.py`):
-- [ ] Test package added to sources
-- [ ] Test package removed from sources
-- [ ] Test pyproject.toml updated correctly
+- [x] Test package added to sources
+- [x] Test package removed from sources
+- [x] Test pyproject.toml updated correctly
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -12,9 +12,8 @@ import typer
 
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
-from oarepo_cli.services import invenio_cli, process, repository
+from oarepo_cli.services import invenio_cli, repository
 from oarepo_cli.services.models import ModelManager
-from oarepo_cli.services.venv import VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
 # Create the repository subcommand group
@@ -236,18 +235,7 @@ def upgrade(
 
         console.info("\n→ Upgrading repository...\n")
 
-        venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
-        if context.venv_path.exists():
-            console.info("→ Removing virtual environment...\n")
-        if (context.root_directory / "uv.lock").exists():
-            console.info("→ Removing uv.lock...\n")
-        venv_manager.cleanup()
-
-        console.info("→ Cleaning uv cache...\n")
-        process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
-
-        console.info("→ Reinstalling repository...\n")
-        repository.install_repository(context, quiet=quiet)
+        repository.upgrade_repository(context, quiet=quiet)
 
         console.success(
             "\n✓ Upgrade completed successfully!\n",

--- a/oarepo_cli/services/local_packages.py
+++ b/oarepo_cli/services/local_packages.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Local, editable package management via ``[tool.uv.sources]``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import tomlkit
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services.pyproject_reader import PyProjectReader
+from oarepo_cli.services.repository import upgrade_repository
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tomlkit import TOMLDocument
+    from tomlkit.items import Array, Table
+
+    from oarepo_cli.core.context import ProjectContext
+
+
+class LocalPackageManager:
+    """Adds/removes locally-developed packages as editable ``[tool.uv.sources]`` entries.
+
+    Mirrors ``repository_runner.sh``'s ``local_sources_cmd``'s ``add`` case
+    (``uv add <path> --editable``, followed by an unconditional
+    ``upgrade_repository`` -- unlike ``ModelManager.create_model()``'s
+    conditional reinstall), but edits ``pyproject.toml`` directly with
+    ``tomlkit`` instead of shelling out to ``uv add``: unlike ``tomllib``
+    (read-only, used by ``PyProjectReader``) or ``tomli-w`` (write-only,
+    full-dict dump, used by copier's own templates), ``tomlkit`` is
+    round-trip-preserving, so comments/key order/formatting elsewhere in a
+    real, hand-edited ``pyproject.toml`` survive.
+
+    ``remove_package()`` has no bash equivalent -- ``repository_runner.sh``'s
+    ``local remove`` was never implemented (it just tells the user to edit
+    ``pyproject.toml`` by hand and run ``upgrade``); this fills that gap,
+    per ``00-main-architecture.md``'s compatibility matrix, which lists
+    ``local remove <name>`` as a command the rewrite must actually support.
+    """
+
+    def __init__(self, context: ProjectContext, *, quiet: bool = False) -> None:
+        """Initialize the local package manager.
+
+        Args:
+            context: Project context with paths and configuration
+            quiet: If True, suppress status/progress messages
+        """
+        self._context = context
+        self._quiet = quiet
+
+    def add_package(self, path: Path) -> None:
+        """Add a local, editable package to ``[tool.uv.sources]``.
+
+        Mirrors ``repository_runner.sh``'s ``local add <path>``: validates
+        ``path`` contains a ``pyproject.toml``, reads its package name from
+        there, then adds/updates a ``name = { path = ..., editable = true }``
+        entry in ``[tool.uv.sources]`` and appends ``name`` to
+        ``[project].dependencies`` (skipped if already present, matching
+        ``uv add``'s own idempotency). Re-adding an already-present package
+        (e.g. with a different path) overwrites its ``[tool.uv.sources]``
+        entry in place.
+
+        Args:
+            path: Path to the local package's own project directory
+
+        Raises:
+            ConfigurationError: If ``path`` has no ``pyproject.toml``
+        """
+        package_pyproject = path / "pyproject.toml"
+        if not package_pyproject.exists():
+            raise ConfigurationError(f"No pyproject.toml in {path}")
+
+        name = canonicalize_name(PyProjectReader().read(package_pyproject).name)
+
+        console = ConsoleOutput(quiet=self._quiet)
+        console.info(f"→ Adding local package '{name}' from {path}\n")
+
+        document = self._read_document()
+
+        dependencies = document["project"]["dependencies"]
+        if not _has_dependency(dependencies, name):
+            dependencies.append(name)
+
+        source = tomlkit.inline_table()
+        source["path"] = self._relative_to_root(path)
+        source["editable"] = True
+        self._uv_sources_table(document)[name] = source
+
+        self._write_document(document)
+
+        console.info("→ Upgrading repository with the new local package\n")
+        upgrade_repository(self._context, quiet=self._quiet)
+
+        console.success(f"✓ Local package '{name}' added successfully.\n")
+
+    def remove_package(self, name: str) -> None:
+        """Remove a local package from ``[tool.uv.sources]``.
+
+        Args:
+            name: Package name (as it appears in ``[tool.uv.sources]``;
+                normalized the same way ``uv``/``add_package`` do)
+
+        Raises:
+            ConfigurationError: If ``name`` isn't a known local package
+        """
+        canonical_name = canonicalize_name(name)
+        document = self._read_document()
+
+        sources = document.get("tool", {}).get("uv", {}).get("sources", {})
+        if canonical_name not in sources:
+            raise ConfigurationError(
+                f"No local package named '{canonical_name}' found in [tool.uv.sources]."
+            )
+
+        console = ConsoleOutput(quiet=self._quiet)
+        console.info(f"→ Removing local package '{canonical_name}'\n")
+
+        del sources[canonical_name]
+        if not sources:
+            del document["tool"]["uv"]["sources"]
+
+        _remove_dependency(document["project"]["dependencies"], canonical_name)
+
+        self._write_document(document)
+
+        console.info("→ Upgrading repository after removing the local package\n")
+        upgrade_repository(self._context, quiet=self._quiet)
+
+        console.success(f"✓ Local package '{canonical_name}' removed successfully.\n")
+
+    def _read_document(self) -> TOMLDocument:
+        return tomlkit.parse(self._context.pyproject_path.read_text(encoding="utf-8"))
+
+    def _write_document(self, document: TOMLDocument) -> None:
+        self._context.pyproject_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    def _uv_sources_table(self, document: TOMLDocument) -> Table:
+        tool = document.setdefault("tool", tomlkit.table())
+        uv = tool.setdefault("uv", tomlkit.table())
+        return uv.setdefault("sources", tomlkit.table())
+
+    def _relative_to_root(self, path: Path) -> str:
+        """Convert path to be relative to the project root, like a real ``uv add`` would.
+
+        ``walk_up=True`` handles a local package living outside the project
+        root too (e.g. a sibling directory), matching
+        ``services.models._relative_to_root``'s same rationale.
+        """
+        return str(path.resolve().relative_to(self._context.root_directory.resolve(), walk_up=True))
+
+
+def _dependency_name(dependency_spec: str) -> str | None:
+    """Return the canonicalized package name of a PEP 508 dependency specifier, or None."""
+    try:
+        return canonicalize_name(Requirement(dependency_spec).name)
+    except InvalidRequirement:
+        return None
+
+
+def _has_dependency(dependencies: Array, name: str) -> bool:
+    return any(_dependency_name(dep) == name for dep in dependencies)
+
+
+def _remove_dependency(dependencies: Array, name: str) -> None:
+    for index, dep in enumerate(list(dependencies)):
+        if _dependency_name(dep) == name:
+            del dependencies[index]

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from oarepo_cli.services import invenio_cli, translations
+from oarepo_cli.services import invenio_cli, process, translations
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
@@ -207,8 +207,8 @@ def install_repository(context: ProjectContext, *, quiet: bool = False) -> None:
     6. Configures local service ports in .invenio.private
     7. Compiles backend translations
 
-    Shared by ``repository install``, ``repository upgrade`` (which cleans
-    the venv and uv cache first, then reinstalls), and
+    Shared by ``repository install``, ``upgrade_repository`` (below, which
+    cleans the venv and uv cache first, then reinstalls), and
     ``ModelManager.create_model()`` (which reinstalls after adding a model,
     if a venv already exists) -- mirroring how repository_runner.sh's
     ``install_repository`` is called from ``install``, ``upgrade_repository``,
@@ -296,3 +296,44 @@ def install_repository(context: ProjectContext, *, quiet: bool = False) -> None:
 
     if not result.success:
         console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")
+
+
+def upgrade_repository(context: ProjectContext, *, quiet: bool = False) -> None:
+    """Upgrade repository: clean venv/cache and reinstall from scratch.
+
+    Mirrors ``repository_runner.sh``'s ``upgrade_repository`` function:
+    1. Removes the virtual environment (if present)
+    2. Removes uv.lock (if present)
+    3. Cleans the uv cache (``uv cache clean --force``)
+    4. Reinstalls the repository (see ``install_repository`` above)
+
+    Shared by ``repository upgrade`` and ``LocalPackageManager`` (which
+    triggers a full upgrade after adding/removing a local package,
+    unconditionally -- mirroring repository_runner.sh's
+    ``local_sources_cmd``'s unconditional call to ``upgrade_repository``
+    after ``uv add``, unlike ``ModelManager.create_model()``'s conditional
+    reinstall). Callers are responsible for their own top-level success
+    message and ``(OARepoError, ProcessExecutionError)`` handling.
+
+    Args:
+        context: Project context with paths and configuration
+        quiet: If True, suppress status/progress messages
+
+    Raises:
+        ProcessExecutionError: If ``uv cache clean`` or ``install_repository``
+            fails
+    """
+    console = ConsoleOutput(quiet=quiet)
+
+    venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
+    if context.venv_path.exists():
+        console.info("→ Removing virtual environment...\n")
+    if (context.root_directory / "uv.lock").exists():
+        console.info("→ Removing uv.lock...\n")
+    venv_manager.cleanup()
+
+    console.info("→ Cleaning uv cache...\n")
+    process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
+
+    console.info("→ Reinstalling repository...\n")
+    install_repository(context, quiet=quiet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ dependencies = [
     "pycountry>=24.0.0",
     "tomli>=2.0.0",
     "tomli-w>=1.0.0",
+    # Local package manager (services/local_packages.py): edits a target
+    # project's own pyproject.toml ([project].dependencies,
+    # [tool.uv.sources]) in place. Unlike tomllib (read-only) or tomli-w
+    # (write-only, full-dict dump), tomlkit is round-trip-preserving --
+    # comments, key order, and formatting elsewhere in the file survive.
+    "tomlkit>=0.13.0",
 ]
 requires-python = ">=3.14,<3.15"
 

--- a/tests/integration/test_local_packages.py
+++ b/tests/integration/test_local_packages.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for LocalPackageManager, against real pyproject.toml files.
+
+LocalPackageManager only ever touches a project's pyproject.toml (via
+tomlkit) and, on success, calls services.repository.upgrade_repository --
+there's no slow external tool (uv, copier, invenio-cli) to run for real
+here, so these tests exercise the real tomlkit read/modify/write path
+against real tmp_path files and mock out upgrade_repository (a full
+venv-wipe + uv-cache-clean + reinstall cycle, already covered end to end by
+test_repository_upgrade.py), per AGENTS.md's guidance to fake slow external
+tools rather than re-run them at this layer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import tomlkit
+
+from oarepo_cli.core.config import CliConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services.local_packages import LocalPackageManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+ROOT_PYPROJECT = """\
+# Root project pyproject.toml, hand-commented.
+[project]
+name = "myrepo"
+dependencies = [
+    "oarepo>=14.0.0,<15.0.0",
+]
+requires-python = ">=3.14,<3.15"
+
+[tool.uv.index]
+name = "cesnet"
+"""
+
+
+def make_context(root: Path) -> ProjectContext:
+    return ProjectContext(
+        root_directory=root,
+        pyproject_path=root / "pyproject.toml",
+        venv_path=root / ".venv",
+        python_binary=root / ".venv" / "bin" / "python",
+        oarepo_version=14,
+        config=CliConfig(),
+    )
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """A repository root with a real, hand-commented pyproject.toml."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(ROOT_PYPROJECT)
+    return root
+
+
+def make_local_package(tmp_path: Path, name: str, dirname: str | None = None) -> Path:
+    """A minimal local package directory with its own pyproject.toml."""
+    pkg_dir = tmp_path / (dirname or name)
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(f'[project]\nname = "{name}"\n')
+    return pkg_dir
+
+
+@pytest.fixture
+def mock_upgrade(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Mock services.local_packages.upgrade_repository, recording calls."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.local_packages.upgrade_repository",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+    return calls
+
+
+def test_add_package_writes_sources_and_dependency(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """add_package() adds a [tool.uv.sources] entry and a dependencies entry."""
+    package_dir = make_local_package(tmp_path, "mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mypkg" in document["project"]["dependencies"]
+    source = document["tool"]["uv"]["sources"]["mypkg"]
+    assert source["path"] == "../mypkg"
+    assert source["editable"] is True
+
+
+def test_add_package_triggers_repository_upgrade(
+    repo_root: Path, tmp_path: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """add_package() unconditionally triggers upgrade_repository, unlike
+    ModelManager.create_model()'s conditional reinstall."""
+    package_dir = make_local_package(tmp_path, "mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+
+    assert len(mock_upgrade) == 1
+    assert mock_upgrade[0] == {"context": context, "quiet": True}
+
+
+def test_add_package_missing_pyproject_raises(
+    repo_root: Path, tmp_path: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """A path without its own pyproject.toml raises ConfigurationError before any write."""
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+    original_content = context.pyproject_path.read_text()
+
+    with pytest.raises(ConfigurationError, match="No pyproject.toml in"):
+        manager.add_package(tmp_path / "does-not-exist")
+
+    assert context.pyproject_path.read_text() == original_content
+    assert mock_upgrade == []
+
+
+def test_add_package_is_idempotent_on_dependencies(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """Adding the same package twice doesn't duplicate its dependencies entry."""
+    package_dir = make_local_package(tmp_path, "mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+    manager.add_package(package_dir)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    dependencies = list(document["project"]["dependencies"])
+    assert dependencies.count("mypkg") == 1
+
+
+def test_add_package_normalizes_name(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """The package's [project].name is canonicalized (PEP 503), matching uv's own behavior."""
+    package_dir = make_local_package(tmp_path, "My_Package", dirname="my_package")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "my-package" in document["project"]["dependencies"]
+    assert "my-package" in document["tool"]["uv"]["sources"]
+
+
+def test_add_package_path_relative_to_root_outside_root(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """A package living outside the project root gets a walk_up-relative path."""
+    sibling_root = tmp_path / "siblings"
+    sibling_root.mkdir()
+    package_dir = make_local_package(sibling_root, "mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    source_path = document["tool"]["uv"]["sources"]["mypkg"]["path"]
+    assert (repo_root / source_path).resolve() == package_dir.resolve()
+
+
+def test_add_package_preserves_existing_formatting(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """Existing comments/tables in pyproject.toml survive the tomlkit round trip."""
+    package_dir = make_local_package(tmp_path, "mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.add_package(package_dir)
+
+    content = context.pyproject_path.read_text()
+    assert "# Root project pyproject.toml, hand-commented." in content
+    assert '[tool.uv.index]\nname = "cesnet"' in content
+
+
+def _add_local_source(pyproject_path: Path, name: str, path: str) -> None:
+    document = tomlkit.parse(pyproject_path.read_text())
+    document["project"]["dependencies"].append(name)
+    tool = document.setdefault("tool", tomlkit.table())
+    uv = tool.setdefault("uv", tomlkit.table())
+    sources = uv.setdefault("sources", tomlkit.table())
+    source = tomlkit.inline_table()
+    source["path"] = path
+    source["editable"] = True
+    sources[name] = source
+    pyproject_path.write_text(tomlkit.dumps(document))
+
+
+def test_remove_package_removes_sources_and_dependency(
+    repo_root: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """remove_package() removes both the [tool.uv.sources] entry and the dependency."""
+    _add_local_source(repo_root / "pyproject.toml", "mypkg", "../mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.remove_package("mypkg")
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mypkg" not in document["project"]["dependencies"]
+    assert "tool" not in document or "sources" not in document.get("tool", {}).get("uv", {})
+
+
+def test_remove_package_triggers_repository_upgrade(
+    repo_root: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """remove_package() also unconditionally triggers upgrade_repository."""
+    _add_local_source(repo_root / "pyproject.toml", "mypkg", "../mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.remove_package("mypkg")
+
+    assert mock_upgrade == [{"context": context, "quiet": True}]
+
+
+def test_remove_package_leaves_other_sources_untouched(
+    repo_root: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """Removing one local package doesn't disturb other [tool.uv.sources] entries."""
+    _add_local_source(repo_root / "pyproject.toml", "mypkg", "../mypkg")
+    _add_local_source(repo_root / "pyproject.toml", "otherpkg", "../otherpkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.remove_package("mypkg")
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "otherpkg" in document["project"]["dependencies"]
+    assert "otherpkg" in document["tool"]["uv"]["sources"]
+    assert "mypkg" not in document["tool"]["uv"]["sources"]
+
+
+def test_remove_package_normalizes_name(
+    repo_root: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """remove_package() canonicalizes its name argument the same way add_package() does."""
+    _add_local_source(repo_root / "pyproject.toml", "my-package", "../my_package")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.remove_package("My_Package")
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "my-package" not in document["project"]["dependencies"]
+
+
+def test_remove_package_unknown_name_raises(
+    repo_root: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """Removing a package that was never added raises ConfigurationError, no write attempted."""
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+    original_content = context.pyproject_path.read_text()
+
+    with pytest.raises(ConfigurationError, match="No local package named 'mypkg'"):
+        manager.remove_package("mypkg")
+
+    assert context.pyproject_path.read_text() == original_content
+    assert mock_upgrade == []

--- a/tests/integration/test_repository_upgrade.py
+++ b/tests/integration/test_repository_upgrade.py
@@ -40,10 +40,10 @@ def test_upgrade_removes_venv_and_lock(
     """`repository upgrade` removes the existing .venv and uv.lock before reinstalling."""
     monkeypatch.chdir(clean_testrepo)
     monkeypatch.setattr(
-        "oarepo_cli.cli.repository.repository.install_repository", lambda *_args, **_kwargs: None
+        "oarepo_cli.services.repository.install_repository", lambda *_args, **_kwargs: None
     )
     monkeypatch.setattr(
-        "oarepo_cli.cli.repository.process.run",
+        "oarepo_cli.services.repository.process.run",
         lambda cmd, **_kwargs: process.ProcessResult(
             return_code=0, stdout="", stderr="", command=cmd, cwd=clean_testrepo, duration_ms=0
         ),
@@ -70,7 +70,7 @@ def test_upgrade_cleans_uv_cache_with_force(
     which omits --force), mirroring repository_runner.sh's upgrade_repository."""
     monkeypatch.chdir(clean_testrepo)
     monkeypatch.setattr(
-        "oarepo_cli.cli.repository.repository.install_repository", lambda *_args, **_kwargs: None
+        "oarepo_cli.services.repository.install_repository", lambda *_args, **_kwargs: None
     )
 
     calls: list[list[str]] = []
@@ -81,7 +81,7 @@ def test_upgrade_cleans_uv_cache_with_force(
             return_code=0, stdout="", stderr="", command=cmd, cwd=clean_testrepo, duration_ms=0
         )
 
-    monkeypatch.setattr("oarepo_cli.cli.repository.process.run", spy_run)
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", spy_run)
 
     runner = CliRunner()
     result = runner.invoke(app, ["repository", "upgrade", "--quiet"], catch_exceptions=False)


### PR DESCRIPTION
## Summary
- Adds `LocalPackageManager` (`oarepo_cli/services/local_packages.py`) with `add_package(path)`/`remove_package(name)`, editing a project's `pyproject.toml` directly via `tomlkit` (new dependency — round-trip-preserving, unlike `tomllib`/`tomli-w`) to update `[project].dependencies` and `[tool.uv.sources]`.
- Both methods unconditionally trigger a full repository upgrade afterward, mirroring `repository_runner.sh`'s `local_sources_cmd` `add` case (`uv add <path> --editable` then `upgrade_repository`) — in contrast to `ModelManager.create_model()`'s conditional reinstall (only if a venv already exists).
- `remove_package()` has no bash equivalent: `repository_runner.sh`'s `local remove` was never implemented (it just told the user to edit `pyproject.toml` by hand). `00-main-architecture.md`'s compatibility matrix lists `local remove <name>` as something the rewrite must actually support, so this fills the gap.
- Extracts `upgrade_repository()` out of `cli/repository.py`'s `upgrade` command into `services/repository.py` (alongside `install_repository`, following the same precedent Step 4.4 set), since it's now shared by two callers: the `upgrade` command and `LocalPackageManager`. `cli/repository.py`'s `upgrade` command is otherwise unchanged in behavior.
- Note: this step only implements the service layer, per `implementation-steps.md`; the `repository local` CLI command is Step 4.7 (separate, not yet implemented).

## Test plan
- [x] `make check`
- [x] `tests/integration/test_local_packages.py` (12 tests: add/remove writing `[tool.uv.sources]`/dependencies correctly, name canonicalization, idempotency, path resolution outside the project root, formatting/comment preservation, error handling, `upgrade_repository` triggering)
- [x] `tests/integration/test_repository_upgrade.py` updated for the `upgrade_repository` extraction (retargeted monkeypatches), full file passes including the real end-to-end install-then-upgrade test
- [x] Full `make test` suite: 416 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)