### PR TITLE
Step 4.7: Repository local command

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,14 +499,14 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`install`](#repository-install) | Install repository in virtual environment | ✅ Implemented |
 | [`upgrade`](#repository-upgrade) | Clean cache and reinstall | ✅ Implemented |
 | [`services`](#repository-services) | Manage Docker services | ✅ Implemented |
-| `model` | Create/update record models | 🔜 Phase 4.4 |
-| `local` | Manage local package dependencies | 🔜 Phase 4.5 |
-| `run` | Start repository server | 🔜 Phase 4.6 |
-| `cli` | Delegate to invenio-cli | 🔜 Phase 4.7 |
-| `translations` | Compile backend translations | 🔜 Phase 4.8 |
-| `index` | Rebuild search index | 🔜 Phase 4.9 |
-| `reset` | Full reset with confirmation | 🔜 Phase 4.10 |
-| `info` | Show Python version and models | 🔜 Phase 4.11 |
+| [`model`](#repository-model) | Create/update record models | ✅ Implemented |
+| [`local`](#repository-local) | Manage local package dependencies | ✅ Implemented |
+| `run` | Start repository server | 🔜 Step 4.9 |
+| `cli` | Delegate to invenio-cli | 🔜 Step 4.10 |
+| `translations` | Compile backend translations | 🔜 Step 4.10 |
+| `index` | Rebuild search index | 🔜 Step 4.10 |
+| `reset` | Full reset with confirmation | 🔜 Step 4.10 |
+| `info` | Show Python version and models | 🔜 Step 4.10 |
 
 ### `repository install`
 
@@ -640,9 +640,38 @@ oarepo-cli repository model update my_model model_config.yaml
 - `0`: Model created/updated successfully
 - `1`: Model creation/update failed (e.g. missing config file, non-existent model, project context could not be discovered)
 
+### `repository local`
+
+Manages locally-developed packages as editable `[tool.uv.sources]` entries in `pyproject.toml`, for developing a dependency (e.g. a custom `oarepo`/`invenio` extension) alongside the repository. Both subcommands edit `pyproject.toml` in place (preserving comments/formatting/ordering elsewhere in the file) and then trigger a full [`repository upgrade`](#repository-upgrade) — unconditionally, unlike `repository model create`'s conditional reinstall.
+
+```bash
+oarepo-cli repository local add <path>
+oarepo-cli repository local remove <name>
+oarepo-cli repository local remove --all
+```
+
+**Subcommands:**
+- `add <path>`: Adds the package at `<path>` (which must contain its own `pyproject.toml`) as an editable local source — `<path>` is resolved relative to the repository root and written to `[tool.uv.sources]`, and the package's name is appended to `[project].dependencies` (skipped if already present). Re-adding an already-present package updates its `[tool.uv.sources]` entry in place.
+- `remove <name>`: Removes the named local package from both `[tool.uv.sources]` and `[project].dependencies`.
+- `remove --all`: Removes every local package added via `add` in a single repository upgrade (rather than one upgrade per package). Only touches `[tool.uv.sources]` entries with a `path` key — unrelated entries (e.g. the CESNET-patched `invenio-cli`'s own `{ index = "cesnet" }` override) are left untouched. Mutually exclusive with passing a `<name>`.
+
+**Options** (each subcommand):
+- `--quiet` / `-q`: Suppress output from subprocesses (invenio-cli, etc.)
+
+**Examples:**
+```bash
+oarepo-cli repository local add ../my-local-package
+oarepo-cli repository local remove my-local-package
+oarepo-cli repository local remove --all
+```
+
+**Exit codes:**
+- `0`: Package(s) added/removed successfully
+- `1`: Operation failed (e.g. no `pyproject.toml` at `<path>`, unknown package name, neither/both of a name and `--all` given, project context could not be discovered)
+
 ### Other Repository Commands
 
-_Commands below are to be implemented in Phase 4 (steps 4.6-4.11)._
+_Commands below are to be implemented in Phase 4 (steps 4.8-4.10)._
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1068,15 +1068,28 @@ support, so this fills that gap.
 ### Step 4.7: Repository `local` Command
 **Goal**: Implement `oarepo-cli repository local` command.
 
-- [ ] Implement `repository_local()` with `add` and `remove` subcommands
-- [ ] Delegate to `LocalPackageManager`
+- [x] Implement `repository_local()` with `add` and `remove` subcommands
+- [x] Delegate to `LocalPackageManager`
+
+**Deviation from the original plan**: `00-main-architecture.md`'s
+compatibility matrix (§1) documents `local remove <name>|--all`, not just
+`<name>` -- the implementation-steps checklist above predates that detail.
+Added `LocalPackageManager.list_local_packages()` (filters
+`[tool.uv.sources]` to path-based/editable entries only, so an unrelated
+entry like the CESNET-patched `invenio-cli`'s `{ index = "cesnet" }`
+override is never touched) and `remove_all_packages()` (removes every local
+package but triggers exactly one `upgrade_repository` call at the end, via
+a new `remove_package(..., upgrade=False)` keyword rather than one full
+upgrade per package) to back `local remove --all`. `local remove` requires
+exactly one of a `<name>` positional or `--all` (errors, exit 1, on
+neither or both).
 
 **Deliverables**:
 - Local command
 
 **Tests** (`tests/integration/test_repository_local.py`):
-- [ ] Test add subcommand
-- [ ] Test remove subcommand
+- [x] Test add subcommand
+- [x] Test remove subcommand
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -13,6 +13,7 @@ import typer
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
 from oarepo_cli.services import invenio_cli, repository
+from oarepo_cli.services.local_packages import LocalPackageManager
 from oarepo_cli.services.models import ModelManager
 from oarepo_cli.ui import ConsoleOutput
 
@@ -37,9 +38,17 @@ model_app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register services and model as subcommands of repository
+# Create the local subcommand group
+local_app = typer.Typer(
+    name="local",
+    help="Local, editable package management (tool.uv.sources)",
+    no_args_is_help=True,
+)
+
+# Register services, model and local as subcommands of repository
 repository_app.add_typer(services_app)
 repository_app.add_typer(model_app)
+repository_app.add_typer(local_app)
 
 # Each services subcommand is a pure passthrough to invenio-cli: extra
 # arguments/options are forwarded verbatim, and --help must reach
@@ -66,6 +75,11 @@ def services_callback() -> None:
 @model_app.callback()
 def model_callback() -> None:
     """Repository model command group."""
+
+
+@local_app.callback()
+def local_callback() -> None:
+    """Repository local package command group."""
 
 
 def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool) -> None:
@@ -330,4 +344,88 @@ def model_update(
     except (OARepoError, ProcessExecutionError) as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Model update failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@local_app.command("add")
+def local_add(
+    path: Annotated[Path, typer.Argument(help="Path to the local package's own project directory")],
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from subprocesses (invenio-cli, etc.)",
+        ),
+    ] = False,
+) -> None:
+    r"""Add a local, editable package to \[tool.uv.sources].
+
+    See ``services.local_packages.LocalPackageManager.add_package`` for the
+    individual steps.
+
+    Examples:
+        $ oarepo-cli repository local add ../my-local-package
+
+    Exit codes:
+        0: Package added successfully
+        1: Package addition failed
+    """
+    try:
+        context = discover_context()
+        LocalPackageManager(context, quiet=quiet).add_package(path)
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Local package addition failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@local_app.command("remove")
+def local_remove(
+    name: Annotated[str | None, typer.Argument(help="Name of the local package to remove")] = None,
+    all_packages: Annotated[bool, typer.Option("--all", help="Remove all local packages")] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from subprocesses (invenio-cli, etc.)",
+        ),
+    ] = False,
+) -> None:
+    r"""Remove a local package from \[tool.uv.sources], or all of them with --all.
+
+    See ``services.local_packages.LocalPackageManager.remove_package``/
+    ``remove_all_packages`` for the individual steps.
+
+    Examples:
+        $ oarepo-cli repository local remove my-package
+        $ oarepo-cli repository local remove --all
+
+    Exit codes:
+        0: Package(s) removed successfully
+        1: Removal failed (e.g. unknown package name, neither/both of a name
+           and --all given)
+    """
+    if name is None and not all_packages:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error("\n✗ Specify a package name to remove, or --all.\n", fg=typer.colors.RED)
+        raise typer.Exit(1)
+    if name is not None and all_packages:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(
+            "\n✗ Specify either a package name or --all, not both.\n", fg=typer.colors.RED
+        )
+        raise typer.Exit(1)
+
+    try:
+        context = discover_context()
+        manager = LocalPackageManager(context, quiet=quiet)
+        if all_packages:
+            manager.remove_all_packages()
+        elif name is not None:
+            manager.remove_package(name)
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Local package removal failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e

--- a/oarepo_cli/services/local_packages.py
+++ b/oarepo_cli/services/local_packages.py
@@ -42,7 +42,11 @@ class LocalPackageManager:
     ``local remove`` was never implemented (it just tells the user to edit
     ``pyproject.toml`` by hand and run ``upgrade``); this fills that gap,
     per ``00-main-architecture.md``'s compatibility matrix, which lists
-    ``local remove <name>`` as a command the rewrite must actually support.
+    ``local remove <name>|--all`` as a command the rewrite must actually
+    support. ``remove_all_packages()`` backs the ``--all`` case: it removes
+    every local package but triggers only a single ``upgrade_repository``
+    call at the end (via ``remove_package(..., upgrade=False)`` per
+    package), rather than one full upgrade per package.
     """
 
     def __init__(self, context: ProjectContext, *, quiet: bool = False) -> None:
@@ -100,12 +104,16 @@ class LocalPackageManager:
 
         console.success(f"✓ Local package '{name}' added successfully.\n")
 
-    def remove_package(self, name: str) -> None:
+    def remove_package(self, name: str, *, upgrade: bool = True) -> None:
         """Remove a local package from ``[tool.uv.sources]``.
 
         Args:
             name: Package name (as it appears in ``[tool.uv.sources]``;
                 normalized the same way ``uv``/``add_package`` do)
+            upgrade: If False, skip the repository upgrade that normally
+                follows -- used by ``remove_all_packages()`` to trigger a
+                single upgrade after removing every package, rather than
+                one per package
 
         Raises:
             ConfigurationError: If ``name`` isn't a known local package
@@ -130,10 +138,42 @@ class LocalPackageManager:
 
         self._write_document(document)
 
-        console.info("→ Upgrading repository after removing the local package\n")
-        upgrade_repository(self._context, quiet=self._quiet)
+        if upgrade:
+            console.info("→ Upgrading repository after removing the local package\n")
+            upgrade_repository(self._context, quiet=self._quiet)
 
         console.success(f"✓ Local package '{canonical_name}' removed successfully.\n")
+
+    def list_local_packages(self) -> list[str]:
+        """Return the canonical names of all locally-added editable packages.
+
+        Only ``[tool.uv.sources]`` entries with a ``path`` key are
+        considered "local packages" managed by ``add_package()`` --
+        excludes unrelated entries like the CESNET-patched ``invenio-cli``'s
+        ``{ index = "cesnet" }`` override, which ``repository local remove
+        --all`` must never touch.
+        """
+        document = self._read_document()
+        sources = document.get("tool", {}).get("uv", {}).get("sources", {})
+        return [name for name, source in sources.items() if "path" in source]
+
+    def remove_all_packages(self) -> list[str]:
+        """Remove every locally-added editable package, in a single repository upgrade.
+
+        Returns:
+            The canonical names of the packages that were removed (possibly
+            empty)
+        """
+        names = self.list_local_packages()
+        for name in names:
+            self.remove_package(name, upgrade=False)
+
+        if names:
+            console = ConsoleOutput(quiet=self._quiet)
+            console.info("→ Upgrading repository after removing all local packages\n")
+            upgrade_repository(self._context, quiet=self._quiet)
+
+        return names
 
     def _read_document(self) -> TOMLDocument:
         return tomlkit.parse(self._context.pyproject_path.read_text(encoding="utf-8"))

--- a/tests/integration/test_local_packages.py
+++ b/tests/integration/test_local_packages.py
@@ -289,3 +289,74 @@ def test_remove_package_unknown_name_raises(
 
     assert context.pyproject_path.read_text() == original_content
     assert mock_upgrade == []
+
+
+def test_remove_package_upgrade_false_skips_upgrade(
+    repo_root: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """remove_package(upgrade=False) still removes the entries, but doesn't upgrade."""
+    _add_local_source(repo_root / "pyproject.toml", "mypkg", "../mypkg")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    manager.remove_package("mypkg", upgrade=False)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mypkg" not in document["project"]["dependencies"]
+    assert mock_upgrade == []
+
+
+def test_list_local_packages_excludes_non_path_sources(
+    repo_root: Path,
+    tmp_path: Path,
+    mock_upgrade: list[dict[str, Any]],  # noqa: ARG001 -- fixture prevents a real upgrade
+) -> None:
+    """list_local_packages() only returns [tool.uv.sources] entries with a path key,
+    excluding e.g. an index-based override like invenio-cli's CESNET registry pin."""
+    document = tomlkit.parse((repo_root / "pyproject.toml").read_text())
+    tool = document.setdefault("tool", tomlkit.table())
+    uv = tool.setdefault("uv", tomlkit.table())
+    sources = uv.setdefault("sources", tomlkit.table())
+    sources["invenio-cli"] = {"index": "cesnet"}
+    (repo_root / "pyproject.toml").write_text(tomlkit.dumps(document))
+
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+    manager.add_package(make_local_package(tmp_path, "mypkg"))
+
+    names = manager.list_local_packages()
+
+    assert names == ["mypkg"]
+
+
+def test_remove_all_packages_removes_everything_in_one_upgrade(
+    repo_root: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """remove_all_packages() removes every local source and triggers exactly one upgrade,
+    regardless of how many packages were removed."""
+    _add_local_source(repo_root / "pyproject.toml", "pkg-a", "../pkg-a")
+    _add_local_source(repo_root / "pyproject.toml", "pkg-b", "../pkg-b")
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    removed = manager.remove_all_packages()
+
+    assert sorted(removed) == ["pkg-a", "pkg-b"]
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "pkg-a" not in document["project"]["dependencies"]
+    assert "pkg-b" not in document["project"]["dependencies"]
+    assert "tool" not in document or "sources" not in document.get("tool", {}).get("uv", {})
+    assert len(mock_upgrade) == 1
+
+
+def test_remove_all_packages_with_none_present_skips_upgrade(
+    repo_root: Path, mock_upgrade: list[dict[str, Any]]
+) -> None:
+    """remove_all_packages() is a no-op (no upgrade triggered) when there's nothing to remove."""
+    context = make_context(repo_root)
+    manager = LocalPackageManager(context, quiet=True)
+
+    removed = manager.remove_all_packages()
+
+    assert removed == []
+    assert mock_upgrade == []

--- a/tests/integration/test_repository_local.py
+++ b/tests/integration/test_repository_local.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `repository local add`/`repository local remove`.
+
+Delegation, argument wiring, and error/exit-code handling are covered here
+by mocking `discover_context()`/`LocalPackageManager` (mirroring
+test_repository_model.py's approach for the other "thin CLI wrapper over a
+service" repository subcommands) -- pyproject.toml read/modify/write
+semantics are already covered thoroughly by test_local_packages.py.
+`test_local_add_and_remove_against_real_pyproject` and
+`test_local_remove_all_against_real_pyproject` additionally drive the full
+stack once, end to end, against real pyproject.toml files (with
+upgrade_repository mocked out, per test_local_packages.py's own rationale:
+no slow external tool involved here to justify a real run).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock
+
+import pytest
+import tomlkit
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.core.config import CliConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def mock_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() so no real project is needed."""
+    context = Mock()
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    return context
+
+
+def _fake_local_package_manager(calls: list[dict[str, object]]) -> type:
+    class FakeLocalPackageManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            calls.append({"context": context, "quiet": quiet})
+            self._calls = calls
+
+        def add_package(self, path: object) -> None:
+            self._calls.append({"method": "add_package", "path": path})
+
+        def remove_package(self, name: str) -> None:
+            self._calls.append({"method": "remove_package", "name": name})
+
+        def remove_all_packages(self) -> list[str]:
+            self._calls.append({"method": "remove_all_packages"})
+            return []
+
+    return FakeLocalPackageManager
+
+
+def test_local_add_delegates_to_local_package_manager(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`repository local add <path>` constructs a LocalPackageManager and calls add_package()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.LocalPackageManager", _fake_local_package_manager(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "add", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {"method": "add_package", "path": tmp_path}
+
+
+def test_local_add_passes_quiet(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--quiet is forwarded to the LocalPackageManager constructor."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.LocalPackageManager", _fake_local_package_manager(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "add", str(tmp_path), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": True}
+
+
+def test_local_add_reports_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A ConfigurationError raised by LocalPackageManager is reported cleanly, exit code 1."""
+
+    class RaisingLocalPackageManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            pass
+
+        def add_package(self, path: object) -> None:
+            raise ConfigurationError(f"No pyproject.toml in {path}")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.LocalPackageManager", RaisingLocalPackageManager)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "add", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Local package addition failed" in result.output
+
+
+def test_local_add_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure (e.g. no pyproject.toml) is reported cleanly, exit code 1."""
+
+    def raise_config_error() -> None:
+        raise ConfigurationError("pyproject.toml not found")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", raise_config_error)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "add", "somewhere"])
+
+    assert result.exit_code == 1
+
+
+def test_local_remove_delegates_to_local_package_manager(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository local remove <name>` constructs a LocalPackageManager and calls
+    remove_package()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.LocalPackageManager", _fake_local_package_manager(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "remove", "mypkg"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {"method": "remove_package", "name": "mypkg"}
+
+
+def test_local_remove_all_delegates_to_remove_all_packages(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository local remove --all` calls remove_all_packages(), not remove_package()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.LocalPackageManager", _fake_local_package_manager(calls)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "remove", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {"method": "remove_all_packages"}
+
+
+def test_local_remove_neither_name_nor_all_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+) -> None:
+    """Neither a name nor --all is an error, not silently a no-op."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "remove"])
+
+    assert result.exit_code == 1
+    assert "Specify a package name to remove, or --all" in result.output
+
+
+def test_local_remove_both_name_and_all_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+) -> None:
+    """Both a name and --all together is an error, not an implicit choice of one."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "remove", "mypkg", "--all"])
+
+    assert result.exit_code == 1
+    assert "not both" in result.output
+
+
+def test_local_remove_reports_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ConfigurationError raised by LocalPackageManager is reported cleanly, exit code 1."""
+
+    class RaisingLocalPackageManager:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            pass
+
+        def remove_package(self, name: str) -> None:  # noqa: ARG002
+            raise ConfigurationError(f"No local package named '{name}' found in [tool.uv.sources].")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.LocalPackageManager", RaisingLocalPackageManager)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "local", "remove", "mypkg"])
+
+    assert result.exit_code == 1
+    assert "Local package removal failed" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["repository", "local", "--help"],
+        ["repository", "local", "add", "--help"],
+        ["repository", "local", "remove", "--help"],
+    ],
+)
+def test_local_help_text(args: list[str]) -> None:
+    """--help works for the local group and both subcommands, without a real project."""
+    runner = CliRunner()
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    assert "[tool.uv.sources]" in result.output
+
+
+def make_context(root: Path) -> ProjectContext:
+    return ProjectContext(
+        root_directory=root,
+        pyproject_path=root / "pyproject.toml",
+        venv_path=root / ".venv",
+        python_binary=root / ".venv" / "bin" / "python",
+        oarepo_version=14,
+        config=CliConfig(),
+    )
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "myrepo"\ndependencies = ["oarepo>=14.0.0,<15.0.0"]\n'
+    )
+    return root
+
+
+def make_local_package(tmp_path: Path, name: str) -> Path:
+    pkg_dir = tmp_path / name
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text(f'[project]\nname = "{name}"\n')
+    return pkg_dir
+
+
+@pytest.fixture
+def mock_upgrade(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Mock services.local_packages.upgrade_repository, recording calls."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.local_packages.upgrade_repository",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+    return calls
+
+
+def test_local_add_and_remove_against_real_pyproject(
+    repo_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_upgrade: list[dict[str, Any]],
+) -> None:
+    """End-to-end: `repository local add`/`remove` are wired correctly through to a real,
+    on-disk pyproject.toml, via the real LocalPackageManager."""
+    context = make_context(repo_root)
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    package_dir = make_local_package(tmp_path, "mypkg")
+
+    runner = CliRunner()
+    add_result = runner.invoke(
+        app, ["repository", "local", "add", str(package_dir), "--quiet"], catch_exceptions=False
+    )
+    assert add_result.exit_code == 0, add_result.output
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mypkg" in document["project"]["dependencies"]
+    assert "mypkg" in document["tool"]["uv"]["sources"]
+
+    remove_result = runner.invoke(
+        app, ["repository", "local", "remove", "mypkg", "--quiet"], catch_exceptions=False
+    )
+    assert remove_result.exit_code == 0, remove_result.output
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mypkg" not in document["project"]["dependencies"]
+
+    assert len(mock_upgrade) == 2
+
+
+def test_local_remove_all_against_real_pyproject(
+    repo_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_upgrade: list[dict[str, Any]],
+) -> None:
+    """End-to-end: `repository local remove --all` removes every local package in one go,
+    leaving unrelated [tool.uv.sources] entries (e.g. an index override) untouched."""
+    context = make_context(repo_root)
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    tool = document.setdefault("tool", tomlkit.table())
+    uv = tool.setdefault("uv", tomlkit.table())
+    sources = uv.setdefault("sources", tomlkit.table())
+    sources["invenio-cli"] = {"index": "cesnet"}
+    context.pyproject_path.write_text(tomlkit.dumps(document))
+
+    runner = CliRunner()
+    for name in ("pkg-a", "pkg-b"):
+        package_dir = make_local_package(tmp_path, name)
+        result = runner.invoke(
+            app, ["repository", "local", "add", str(package_dir), "--quiet"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+    mock_upgrade.clear()
+
+    remove_result = runner.invoke(
+        app, ["repository", "local", "remove", "--all", "--quiet"], catch_exceptions=False
+    )
+    assert remove_result.exit_code == 0, remove_result.output
+
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "pkg-a" not in document["project"]["dependencies"]
+    assert "pkg-b" not in document["project"]["dependencies"]
+    assert "invenio-cli" in document["tool"]["uv"]["sources"]
+    assert "pkg-a" not in document["tool"]["uv"]["sources"]
+    assert "pkg-b" not in document["tool"]["uv"]["sources"]
+
+    assert len(mock_upgrade) == 1


### PR DESCRIPTION
## Summary
- Implements `oarepo-cli repository local add <path>` and `repository local remove <name>|--all`, delegating to Step 4.6's `LocalPackageManager`.
- `00-main-architecture.md`'s compatibility matrix documents `local remove <name>|--all` (the `implementation-steps.md` checklist predated that detail), so `local remove` requires exactly one of a `<name>` positional or `--all` (errors, exit 1, on neither or both).
- Extends `LocalPackageManager` with `list_local_packages()` (filters `[tool.uv.sources]` to path-based/editable entries only, so an unrelated entry like the CESNET-patched `invenio-cli`'s own `{ index = "cesnet" }` override is never touched by `--all`) and `remove_all_packages()` (removes every local package but triggers exactly one `upgrade_repository` call at the end, via a new `remove_package(..., upgrade=False)` keyword, rather than one full upgrade per package).
- Fixed a pre-existing Rich-markup bug hit while writing this command's docstrings: literal `[tool.uv.sources]` in Typer command help text was being silently swallowed (Rich interprets `[...]` as style tags) — escaped with `\[` in the new docstrings. (The same issue exists elsewhere in `cli/library.py`'s older docstrings; left alone here as out of scope, but worth a follow-up.)
- Updated `README.md`: added a `repository local` section, and fixed the repository command-overview table, which was stale (still showed `model`/`local` as "🔜 Phase 4.4/4.5" despite `model` already being implemented, and referenced a `Phase 4.x` numbering that no longer matches `implementation-steps.md`'s actual step numbers).

## Test plan
- [x] `make check`
- [x] `tests/integration/test_repository_local.py` (14 tests: add/remove delegation and argument wiring, `--all` dispatch, mutual-exclusivity/required-argument validation, error handling/exit codes, `--help` text, two real end-to-end runs through the full CLI→LocalPackageManager→pyproject.toml stack)
- [x] `tests/integration/test_local_packages.py` extended with 4 new tests for `list_local_packages()`/`remove_all_packages()`/`remove_package(upgrade=False)`
- [x] Full `make test` suite: 434 passed, 0 failed (an earlier run hit 3 unrelated `docker compose` failures caused by already-running local Docker services; clean after stopping them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)