### PR TITLE
Step 4.9: Repository run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`services`](#repository-services) | Manage Docker services | ✅ Implemented |
 | [`model`](#repository-model) | Create/update record models | ✅ Implemented |
 | [`local`](#repository-local) | Manage local package dependencies | ✅ Implemented |
-| `run` | Start repository server | 🔜 Step 4.9 |
+| [`run`](#repository-run) | Start repository server | ✅ Implemented |
 | `cli` | Delegate to invenio-cli | 🔜 Step 4.10 |
 | `translations` | Compile backend translations | 🔜 Step 4.10 |
 | `index` | Rebuild search index | 🔜 Step 4.10 |
@@ -669,9 +669,38 @@ oarepo-cli repository local remove --all
 - `0`: Package(s) added/removed successfully
 - `1`: Operation failed (e.g. no `pyproject.toml` at `<path>`, unknown package name, neither/both of a name and `--all` given, project context could not be discovered)
 
+### `repository run`
+
+Starts the repository's development server: starts Docker services (unless `--no-services`), then hands off to either `invenio-cli run` (which manages Celery itself) or, with `--no-celery`, the venv's own `invenio run` directly.
+
+```bash
+oarepo-cli repository run
+oarepo-cli repository run --no-services
+oarepo-cli repository run --no-celery
+```
+
+This command **replaces the current process** (`os.execve`/`os.execvpe`) with the server once Docker services are started — it never returns on success, so a terminal Ctrl+C hits invenio-cli/invenio directly, exactly as if it had been run by hand. Docker services are deliberately *not* stopped when the server exits — run `repository services stop` explicitly when done.
+
+**Options:**
+- `--no-services`: Don't start Docker services first
+- `--no-celery`: Run the venv's own `invenio run` directly, without Celery/invenio-cli
+- `--quiet` / `-q`: Suppress output from starting Docker services
+
+Any extra arguments/options (e.g. `-p 5001`) are forwarded to the underlying `invenio-cli run`/`invenio run` command.
+
+**Examples:**
+```bash
+oarepo-cli repository run
+oarepo-cli repository run --no-celery -- -p 5001
+```
+
+**Exit codes:**
+- Whatever invenio-cli/invenio itself exits with, once running
+- `1`: Starting Docker services failed, or project context could not be discovered
+
 ### Other Repository Commands
 
-_Commands below are to be implemented in Phase 4 (steps 4.8-4.10)._
+_Commands below are to be implemented in Phase 4 (step 4.10)._
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1201,17 +1201,32 @@ neither or both).
 ### Step 4.9: Repository `run` Command
 **Goal**: Implement `oarepo-cli repository run` command.
 
-- [ ] Implement `repository_run()` function
-- [ ] Options: `--no-services`, `--no-celery`
-- [ ] Delegate to `ServerRunner`
+- [x] Implement `repository_run()` function
+- [x] Options: `--no-services`, `--no-celery`
+- [x] Delegate to `ServerRunner`
+
+**Deviation from the original plan**: also forwards unrecognized
+args/options (e.g. `-p 5001`) to the underlying `invenio-cli run`/`invenio
+run` command as `extra_args`, mirroring `repository_runner.sh`'s
+`run_server()`'s `extra_options` -- not called out in the checklist above,
+but dropping it would be a real regression from bash's actual behavior.
+Unlike the `services` subcommands' passthrough context settings, `--help`
+is *not* forwarded/swallowed here (`help_option_names` left at its
+default): `run` has its own real options, so `--help` shows oarepo-cli's
+own help, not invenio-cli's.
 
 **Deliverables**:
 - Running command
 
 **Tests** (`tests/integration/test_repository_run.py`):
-- [ ] Test run with services
-- [ ] Test run without celery
-- [ ] Test signal handling
+- [x] Test run with services
+- [x] Test run without celery
+- [x] Test signal handling -- superseded, same rationale as Step 4.8: no
+  signal-handling code left in this layer to test (invenio-cli/invenio
+  handle it themselves post-exec). Covered instead by
+  `test_run_real_exec_replaces_process`, a real, isolated-subprocess test
+  driving the full CLI -> `discover_context` -> `ServerRunner` -> exec
+  stack against a fake `invenio-cli` binary.
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -15,6 +15,7 @@ from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
 from oarepo_cli.services import invenio_cli, repository
 from oarepo_cli.services.local_packages import LocalPackageManager
 from oarepo_cli.services.models import ModelManager
+from oarepo_cli.services.server import ServerRunner
 from oarepo_cli.ui import ConsoleOutput
 
 # Create the repository subcommand group
@@ -59,6 +60,18 @@ _SERVICES_CONTEXT_SETTINGS = {
     "allow_interspersed_args": True,
     "ignore_unknown_options": True,
     "help_option_names": [],
+}
+
+# `repository run` forwards unrecognized args/options to the underlying
+# invenio-cli/invenio run command (e.g. `-p 5001`), like
+# repository_runner.sh's run_server()'s extra_options -- but unlike the
+# services subcommands above, `--help` should still show oarepo-cli's own
+# help (--no-services/--no-celery/--quiet are real options here, not a pure
+# passthrough), so help_option_names is left at its default.
+_RUN_CONTEXT_SETTINGS = {
+    "allow_extra_args": True,
+    "allow_interspersed_args": True,
+    "ignore_unknown_options": True,
 }
 
 
@@ -428,4 +441,61 @@ def local_remove(
     except (OARepoError, ProcessExecutionError) as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Local package removal failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@repository_app.command("run", context_settings=_RUN_CONTEXT_SETTINGS)
+def run_command(
+    ctx: typer.Context,
+    no_services: Annotated[
+        bool,
+        typer.Option("--no-services", help="Don't start Docker services first"),
+    ] = False,
+    no_celery: Annotated[
+        bool,
+        typer.Option(
+            "--no-celery",
+            help="Run the venv's own `invenio run` directly, without Celery/invenio-cli",
+        ),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from starting Docker services",
+        ),
+    ] = False,
+) -> None:
+    """Start the repository's development server.
+
+    See ``services.server.ServerRunner.run`` for the individual steps. Any
+    extra arguments/options (e.g. ``-p 5001``) are forwarded to the
+    underlying ``invenio-cli run``/``invenio run`` command.
+
+    This command replaces the current process (``os.execve``/``os.execvpe``)
+    with the server once Docker services are started -- it never returns on
+    success, so a terminal Ctrl+C hits invenio-cli/invenio directly, exactly
+    as if it had been run directly.
+
+    Examples:
+        $ oarepo-cli repository run
+        $ oarepo-cli repository run --no-services
+        $ oarepo-cli repository run --no-celery -- -p 5001
+
+    Exit codes:
+        Whatever invenio-cli/invenio itself exits with, once running
+        1: Starting Docker services failed, or project context could not be
+           discovered
+    """
+    try:
+        context = discover_context()
+        ServerRunner(context, quiet=quiet).run(
+            no_services=no_services,
+            no_celery=no_celery,
+            extra_args=ctx.args,
+        )
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ Failed to start server: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e

--- a/tests/integration/test_repository_run.py
+++ b/tests/integration/test_repository_run.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `repository run`.
+
+Delegation, argument wiring, and error/exit-code handling are covered here
+by mocking `discover_context()`/`ServerRunner` (mirroring
+test_repository_local.py's approach for the other "thin CLI wrapper over a
+service" repository subcommands) -- the real `os.execve`/`os.execvpe`
+process-replacement mechanics, argv/env construction, and signal-handoff
+behavior are already covered thoroughly, against real (isolated-subprocess)
+child processes, by test_server_runner.py.
+`test_run_real_exec_replaces_process` additionally drives the full CLI ->
+discover_context -> ServerRunner -> exec stack once, end to end, in its own
+isolated subprocess (since a real exec would otherwise replace the pytest
+worker itself), against a tiny fake `invenio-cli` binary.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.core.errors import ConfigurationError, ProcessExecutionError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+@pytest.fixture
+def mock_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() so no real project is needed."""
+    context = Mock()
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    return context
+
+
+def _fake_server_runner(calls: list[dict[str, object]]) -> type:
+    class FakeServerRunner:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            calls.append({"context": context, "quiet": quiet})
+
+        def run(
+            self,
+            *,
+            no_services: bool = False,
+            no_celery: bool = False,
+            extra_args: Sequence[str] = (),
+        ) -> None:
+            calls.append(
+                {
+                    "method": "run",
+                    "no_services": no_services,
+                    "no_celery": no_celery,
+                    "extra_args": list(extra_args),
+                }
+            )
+
+    return FakeServerRunner
+
+
+def test_run_delegates_to_server_runner(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository run` constructs a ServerRunner and calls run() with defaults."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ServerRunner", _fake_server_runner(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": False}
+    assert calls[1] == {
+        "method": "run",
+        "no_services": False,
+        "no_celery": False,
+        "extra_args": [],
+    }
+
+
+def test_run_passes_no_services_and_no_celery(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-services/--no-celery are forwarded to ServerRunner.run()."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ServerRunner", _fake_server_runner(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run", "--no-services", "--no-celery"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[1]["no_services"] is True
+    assert calls[1]["no_celery"] is True
+
+
+def test_run_passes_quiet_to_server_runner_constructor(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--quiet is consumed as the quiet= kwarg on the ServerRunner constructor."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ServerRunner", _fake_server_runner(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0] == {"context": mock_context, "quiet": True}
+
+
+def test_run_forwards_extra_args(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrecognized args/options (e.g. -p 5001) are forwarded to ServerRunner.run() as
+    extra_args, mirroring repository_runner.sh's run_server()'s extra_options."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr("oarepo_cli.cli.repository.ServerRunner", _fake_server_runner(calls))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run", "--no-celery", "-p", "5001", "--debugger"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[1]["no_celery"] is True
+    assert calls[1]["extra_args"] == ["-p", "5001", "--debugger"]
+
+
+def test_run_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure (e.g. no pyproject.toml) is reported cleanly, exit code 1."""
+
+    def raise_config_error() -> None:
+        raise ConfigurationError("pyproject.toml not found")
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", raise_config_error)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run"])
+
+    assert result.exit_code == 1
+
+
+def test_run_reports_server_runner_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ProcessExecutionError raised while starting Docker services is reported cleanly."""
+
+    class RaisingServerRunner:
+        def __init__(self, context: object, *, quiet: bool = False) -> None:
+            pass
+
+        def run(self, **_kwargs: object) -> None:
+            raise ProcessExecutionError(
+                message="docker compose up failed",
+                command=["docker", "compose", "up"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+
+    monkeypatch.setattr("oarepo_cli.cli.repository.ServerRunner", RaisingServerRunner)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run"])
+
+    assert result.exit_code == 1
+    assert "Failed to start server" in result.output
+
+
+def test_run_help_shows_oarepo_clis_own_help(mock_context: Mock) -> None:  # noqa: ARG001
+    """--help shows oarepo-cli's own help (--no-services/--no-celery/--quiet), unlike the
+    services subcommands, which forward --help to invenio-cli's own help instead."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "run", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--no-services" in result.output
+    assert "--no-celery" in result.output
+    assert "--quiet" in result.output
+
+
+FAKE_INVENIO_CLI_SCRIPT = """#!/bin/sh
+echo "CWD:$(pwd)"
+echo "ARGV:$@"
+echo "CERT:$INVENIO_SITE_CERT_PATH"
+exit 42
+"""
+
+
+def _make_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def test_run_real_exec_replaces_process(tmp_path: Path) -> None:
+    """End-to-end: `oarepo-cli repository run` really discovers the project, starts no
+    services (--no-services), and execve()s into invenio-cli -- driven via the real CLI
+    entry point, in its own isolated subprocess (a real exec would otherwise replace the
+    pytest worker), against a tiny fake invenio-cli substituted in for this one process."""
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text(
+        '[project]\nname = "myrepo"\nrequires-python = ">=3.14,<3.15"\n'
+        "\n[tool.oarepo-cli]\noarepo = { version = 14 }\n"
+    )
+
+    fake_invenio_cli = tmp_path / "fake-invenio-cli"
+    _make_executable(fake_invenio_cli, FAKE_INVENIO_CLI_SCRIPT)
+
+    driver = f"""
+import sys
+import oarepo_cli.services.invenio_cli as invenio_cli_module
+
+invenio_cli_module._invenio_cli_path = lambda: {str(fake_invenio_cli)!r}
+
+from oarepo_cli.cli.main import app
+
+sys.argv = ["oarepo-cli", "repository", "run", "--no-services", "--", "--debugger"]
+app()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", driver],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 42, result.stderr
+    assert f"CWD:{project_root}" in result.stdout
+    assert "ARGV:run --debugger" in result.stdout
+    assert f"CERT:{project_root / 'docker' / 'development.crt'}" in result.stdout


### PR DESCRIPTION
## Summary
- Implements `oarepo-cli repository run`, delegating to Step 4.8's `ServerRunner`. Options: `--no-services`, `--no-celery`, `--quiet`.
- Also forwards unrecognized args/options (e.g. `-p 5001`) to the underlying `invenio-cli run`/`invenio run` command as `extra_args`, mirroring `repository_runner.sh`'s `run_server()`'s `extra_options` — not called out explicitly in `implementation-steps.md`'s checklist, but dropping it would be a real regression from bash's actual behavior.
- Unlike the `services` subcommands' pure-passthrough context settings, `--help` is **not** forwarded to invenio-cli here: `run` has its own real options, so `--help` shows oarepo-cli's own help (verified: `--no-services`/`--no-celery`/`--quiet` all appear).
- Updated `README.md` with a `repository run` section and fixed the command-overview table/Phase numbering.

## Test plan
- [x] `make check`
- [x] `tests/integration/test_repository_run.py` (8 tests: delegation/argument wiring, `--no-services`/`--no-celery`/`--quiet`, extra-args forwarding, error handling/exit codes, `--help` behavior, and one real end-to-end test driving the full CLI → `discover_context` → `ServerRunner` → `os.execve` stack in an isolated subprocess against a fake `invenio-cli` binary)
- [x] Full `make test` suite: 452 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)