### PR TITLE
Step 4.10: Repository cli/translations/index/reset/info commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,11 +502,11 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`model`](#repository-model) | Create/update record models | ✅ Implemented |
 | [`local`](#repository-local) | Manage local package dependencies | ✅ Implemented |
 | [`run`](#repository-run) | Start repository server | ✅ Implemented |
-| `cli` | Delegate to invenio-cli | 🔜 Step 4.10 |
-| `translations` | Compile backend translations | 🔜 Step 4.10 |
-| `index` | Rebuild search index | 🔜 Step 4.10 |
-| `reset` | Full reset with confirmation | 🔜 Step 4.10 |
-| `info` | Show Python version and models | 🔜 Step 4.10 |
+| [`cli`](#repository-cli) | Delegate to invenio-cli | ✅ Implemented |
+| [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
+| [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
+| [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
+| [`info`](#repository-info) | Show Python version and models | ✅ Implemented |
 
 ### `repository install`
 
@@ -698,9 +698,85 @@ oarepo-cli repository run --no-celery -- -p 5001
 - Whatever invenio-cli/invenio itself exits with, once running
 - `1`: Starting Docker services failed, or project context could not be discovered
 
-### Other Repository Commands
+### `repository cli`
 
-_Commands below are to be implemented in Phase 4 (step 4.10)._
+Pure passthrough to invenio-cli: replaces this process (`os.execve`/`os.execvpe`) with `invenio-cli <args>`, so `--help` reaches invenio-cli's own help (not oarepo-cli's), and the exit code is preserved exactly.
+
+```bash
+oarepo-cli repository cli [invenio-cli_args...]
+```
+
+**Examples:**
+```bash
+oarepo-cli repository cli services status
+oarepo-cli repository cli --help
+```
+
+**Exit codes:**
+- Whatever invenio-cli itself exits with
+- `1`: Project context could not be discovered
+
+### `repository translations`
+
+Extracts, merges and compiles translations (backend + JS) via oarepo-tools, or just compiles backend translations with `compile`.
+
+```bash
+oarepo-cli repository translations
+oarepo-cli repository translations compile
+```
+
+`repository translations compile` delegates to `invenio-cli translations compile` (backend only, no extraction). Any other invocation (including no args) runs oarepo-tools' `make-translations`, with all given args forwarded to it verbatim.
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Exit codes:**
+- `0`: Success
+- `1`: Failure (translations compile/make-translations failed, or project context could not be discovered)
+
+### `repository index rebuild`
+
+Destroys and re-creates the search index, then rebuilds all records and custom fields.
+
+```bash
+oarepo-cli repository index rebuild
+```
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Exit codes:**
+- `0`: Success
+- `1`: Failure (a step failed, or project context could not be discovered)
+
+### `repository reset`
+
+Performs a full reset of the repository: destroys Docker services, removes the virtual environment/`uv.lock`/`.invenio.private`, cleans the uv cache, reinstalls the repository, sets up services again, and creates an administration role and a demo user (`user@demo.org`, password from `DEMO_USER_PASSWORD`, default `123456`).
+
+```bash
+oarepo-cli repository reset
+```
+
+Prompts for confirmation (exactly `yes`) before proceeding, since this **PURGES ALL EXISTING DATA** in your containers. Anything other than exactly `yes` cancels the reset without error.
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Exit codes:**
+- `0`: Reset completed, or cancelled by the user
+- `1`: Reset failed partway through, or project context could not be discovered
+
+### `repository info`
+
+Shows the resolved Python version and discovered record models (any directory under `models/` with both `.copier-answers.yml` and `model.py`).
+
+```bash
+oarepo-cli repository info
+```
+
+**Exit codes:**
+- `0`: Success
+- `1`: Project context could not be discovered
 
 ## Configuration
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1233,20 +1233,88 @@ own help, not invenio-cli's.
 ### Step 4.10: Repository `cli`, `translations`, `index`, `reset`, `info` Commands
 **Goal**: Implement remaining repository commands.
 
-- [ ] Implement `repository_cli()` → passthrough to `invenio-cli`
-- [ ] Implement `repository_translations()` → extract/compile
-- [ ] Implement `repository_index_rebuild()` → destroy/init/rebuild indices
-- [ ] Implement `repository_reset()` → full reset with confirmation prompt
-- [ ] Implement `repository_info()` → show Python version and models
+- [x] Implement `repository_cli()` → passthrough to `invenio-cli`
+- [x] Implement `repository_translations()` → extract/compile
+- [x] Implement `repository_index_rebuild()` → destroy/init/rebuild indices
+- [x] Implement `repository_reset()` → full reset with confirmation prompt
+- [x] Implement `repository_info()` → show Python version and models
+
+**Deviations from the original plan**:
+- `repository cli` reuses Step 4.8's `invenio_cli.exec_invenio_cli()`
+  (`os.execve`/`os.execvpe` process replacement) rather than a blocking
+  call: it's a one-shot passthrough with nothing to do afterward, exactly
+  like `cli/library.py`'s `library_invenio`, so the exit code is preserved
+  exactly and `--help` reaches invenio-cli's own help (via the same
+  `_SERVICES_CONTEXT_SETTINGS` the `services` subcommands already use).
+- `repository translations` mirrors `repository_runner.sh`'s
+  `translations()`'s exact dispatch logic directly (first positional arg
+  ``== "compile"`` → `invenio-cli translations compile`; anything else,
+  including no args, → oarepo-tools `make-translations` with all args
+  forwarded) rather than a Typer subcommand group, since bash's dispatch
+  isn't a clean subcommand split (any arbitrary first arg is valid
+  `make-translations` input, not just a fixed set of subcommands).
+- `repository index` *is* a Typer subcommand group (`index rebuild`), since
+  bash only ever accepts exactly `rebuild` there (unlike `translations`) --
+  matches the `model`/`local`/`services` groups' existing pattern.
+- Added `services/repository.py`: `get_invenio_binary()` (also now reused
+  by `services/server.py`'s `--no-celery` exec path, replacing its former
+  inline `get_platform_detector()` call -- same binary resolution, one
+  fewer duplicate), `rebuild_index()`, `reset_repository()` (confirmation
+  prompt is the CLI layer's responsibility -- mirrors how `local remove`'s
+  validation stays in the CLI layer while the work stays in the service),
+  `get_python_version()`, and `list_repository_models()`/`ModelInfo` for
+  `info`'s model discovery.
+- Found and fixed a pre-existing bug while wiring `reset`'s demo password:
+  `core/config.py`'s `SecurityConfig.demo_user_password` read from
+  `OAREPO_SECURITY_DEMO_PASSWORD`, but both `00-main-architecture.md`'s env
+  var table and `03-migration-guide.md`'s compatibility table (and
+  `repository_runner.sh` itself, via `${DEMO_USER_PASSWORD:-123456}`)
+  document plain `DEMO_USER_PASSWORD` -- i.e. `reset` would have silently
+  ignored the documented, bash-compatible env var. Fixed both `_get_str()`
+  call sites (`from_env()`) and the "using default password" warning
+  message to use `DEMO_USER_PASSWORD`; no existing test referenced the old
+  name.
+- `repository_runner.sh` also has an undocumented `run.sh invenio <args>`
+  bare-invenio passthrough (distinct from `cli`, which maps to
+  `run_invenio_cli`) -- but unlike `library invenio`, it appears nowhere in
+  `00-main-architecture.md`'s or `03-migration-guide.md`'s repository
+  command tables, so (matching how `self-update` was deliberately dropped)
+  it's treated as out of scope for the rewrite, not implemented.
+- Found and fixed a second, unrelated pre-existing bug while manually
+  smoke-testing `repository cli`/`info` against a throwaway project: the
+  `ConfigurationError` raised when no OARepo version can be resolved still
+  said "Add to pyproject.toml `[tool.oarepo-cli]`" -- stale guidance from
+  before Step 3.13 replaced that key with dependency-scanning. Worse,
+  `core/config.py`'s `CliConfig.from_pyproject()` was still actually
+  *reading* `[tool.oarepo-cli].oarepo.version` into `config.oarepo.version`
+  (checked before dependency-scanning in `ContextBuilder.build()`), directly
+  contradicting `PyProjectData.oarepo_versions`'s own warning that the key
+  "is deprecated and ignored" -- it was deprecated but not actually
+  ignored. Fixed by dropping that pyproject-reading block entirely (`oarepo
+  = OARepoConfig()`, unconditionally); `OAREPO_VERSION` (`from_env()`) is
+  now the only remaining manual override, matching
+  `03-migration-guide.md`'s documented behavior. Updated the error message
+  to point at `[project].dependencies` instead. Updated/fixed fixtures that
+  relied on the now-inert pyproject key across `tests/unit/test_context.py`
+  (15 occurrences), `tests/unit/test_config.py` (assertion flipped to
+  `is None`), `tests/integration/test_repository_run.py`,
+  `tests/integration/conftest.py`'s `lint_project` template, and the real
+  `tests/testlib/pyproject.toml` fixture (dependencies already declared
+  `oarepo[rdm,tests]>=14.2.1b10.dev7,<15.0.0`, so the redundant/dead
+  `[tool.oarepo-cli]` block was simply removed there).
 
 **Deliverables**:
 - Complete repository command set
 
-**Tests** (`tests/integration/test_repository_misc.py`):
-- [ ] Test each command executes
-- [ ] Test reset confirmation prompt
-- [ ] Test info output format
-- [ ] Characterization tests
+**Tests** (`tests/integration/test_repository_misc.py`, plus new
+`services/repository.py` coverage in `tests/unit/test_repository_service.py`):
+- [x] Test each command executes
+- [x] Test reset confirmation prompt
+- [x] Test info output format
+- [x] Characterization tests -- via `tests/unit/test_repository_service.py`'s
+  `rebuild_index`/`reset_repository` tests, which assert the exact
+  subcommand sequence against a mocked `process.run`/`invenio_cli`, mirroring
+  bash's own command-by-command sequence
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -12,7 +12,7 @@ import typer
 
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
-from oarepo_cli.services import invenio_cli, repository
+from oarepo_cli.services import invenio_cli, repository, translations
 from oarepo_cli.services.local_packages import LocalPackageManager
 from oarepo_cli.services.models import ModelManager
 from oarepo_cli.services.server import ServerRunner
@@ -46,10 +46,18 @@ local_app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register services, model and local as subcommands of repository
+# Create the index subcommand group
+index_app = typer.Typer(
+    name="index",
+    help="Search index management",
+    no_args_is_help=True,
+)
+
+# Register services, model, local and index as subcommands of repository
 repository_app.add_typer(services_app)
 repository_app.add_typer(model_app)
 repository_app.add_typer(local_app)
+repository_app.add_typer(index_app)
 
 # Each services subcommand is a pure passthrough to invenio-cli: extra
 # arguments/options are forwarded verbatim, and --help must reach
@@ -93,6 +101,11 @@ def model_callback() -> None:
 @local_app.callback()
 def local_callback() -> None:
     """Repository local package command group."""
+
+
+@index_app.callback()
+def index_callback() -> None:
+    """Repository search index command group."""
 
 
 def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool) -> None:
@@ -499,3 +512,167 @@ def run_command(
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Failed to start server: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
+
+
+@repository_app.command("cli", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def cli_command(ctx: typer.Context) -> None:
+    """Run an arbitrary invenio-cli command in the repository.
+
+    Pure passthrough to invenio-cli: replaces this process (``os.execve``/
+    ``os.execvpe``) with ``invenio-cli <args>``, so ``--help`` reaches
+    invenio-cli's own help (not oarepo-cli's), and the exit code is
+    preserved exactly.
+
+    Examples:
+        $ oarepo-cli repository cli services status
+        $ oarepo-cli repository cli --help
+
+    Exit codes:
+        Whatever invenio-cli itself exits with
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository cli failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    invenio_cli.exec_invenio_cli(context, ctx.args)
+
+
+@repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def translations_command(
+    ctx: typer.Context,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Extract, merge and compile translations (BE + JS) via oarepo-tools.
+
+    Mirrors ``repository_runner.sh``'s ``translations()``: ``repository
+    translations compile`` delegates to ``invenio-cli translations compile``
+    (backend only, no extraction); any other invocation (including no args)
+    runs oarepo-tools' ``make-translations``, with all given args forwarded
+    to it verbatim.
+
+    Examples:
+        $ oarepo-cli repository translations
+        $ oarepo-cli repository translations compile
+
+    Exit codes:
+        0: Success
+        1: Failure (translations compile/make-translations failed, or
+           project context could not be discovered)
+    """
+    try:
+        context = discover_context()
+        if ctx.args and ctx.args[0] == "compile":
+            invenio_cli.run_invenio_cli(context, ["translations", "compile"], quiet=quiet)
+        else:
+            translations.run_translations(context, extra_args=ctx.args, quiet=quiet).check()
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ Translations failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@index_app.command("rebuild")
+def index_rebuild(
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Destroy and rebuild the search index (and custom fields).
+
+    See ``services.repository.rebuild_index`` for the individual steps.
+
+    Exit codes:
+        0: Success
+        1: Failure (a step failed, or project context could not be discovered)
+    """
+    try:
+        context = discover_context()
+        repository.rebuild_index(context, quiet=quiet)
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ Index rebuild failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@repository_app.command("reset")
+def reset_command(
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Perform a full reset of the repository: wipe all data, reinstall, and reseed demo data.
+
+    See ``services.repository.reset_repository`` for the individual steps.
+    Prompts for confirmation (exactly ``yes``) before proceeding, since this
+    **PURGES ALL EXISTING DATA** in your containers, mirroring
+    ``repository_runner.sh``'s ``reset_repository()``.
+
+    Examples:
+        $ oarepo-cli repository reset
+
+    Exit codes:
+        0: Reset completed, or cancelled by the user
+        1: Reset failed partway through, or project context could not be
+           discovered
+    """
+    console = ConsoleOutput(quiet=False)
+    console.warning("\n⚠️  Performing full reset of the repository...\n")
+    console.info("This will remove all data, virtual environment, and reinstall the repository.")
+    console.warning("Please make sure that server is not running at the moment\n")
+    answer = typer.prompt("Are you sure you want to continue? (yes/no)")
+    if answer != "yes":
+        console.warning("Reset cancelled.\n")
+        raise typer.Exit(0)
+
+    try:
+        context = discover_context()
+        repository.reset_repository(context, quiet=quiet)
+        console.success(
+            "\n✓ Repository reset completed successfully.\n",
+            fg=typer.colors.BRIGHT_GREEN,
+            bold=True,
+        )
+        console.info(
+            "Please run `oarepo-cli repository run` to start the server "
+            "and wait for the initial data to be loaded.\n"
+        )
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ Reset failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
+@repository_app.command("info")
+def info_command() -> None:
+    """Show the resolved Python version and discovered record models.
+
+    See ``services.repository.list_repository_models`` for model discovery.
+
+    Exit codes:
+        0: Success
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except (OARepoError, ProcessExecutionError) as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository info failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    typer.echo(f"Python version: {context.python_binary}")
+    typer.echo(repository.get_python_version(context))
+    typer.echo("")
+    typer.echo("Models:")
+
+    models = repository.list_repository_models(context)
+    if not models:
+        typer.echo("  No models found.")
+    else:
+        for model in models:
+            typer.echo(f"  - {model.name}: {model.version}")

--- a/oarepo_cli/core/config.py
+++ b/oarepo_cli/core/config.py
@@ -181,7 +181,7 @@ class CliConfig:
             ),
             license=LicenseConfig(organization=_get_str("OAREPO_LICENSE_ORG", "CESNET z.s.p.o")),
             security=SecurityConfig(
-                demo_user_password=_get_str("OAREPO_SECURITY_DEMO_PASSWORD", "123456"),
+                demo_user_password=_get_str("DEMO_USER_PASSWORD", "123456"),
             ),
         )
 
@@ -241,10 +241,12 @@ class CliConfig:
         python_binary = python_data.get("binary")
         python = PythonConfig(binary=python_binary if python_binary else None)
 
-        # OARepo config
-        oarepo_data = get_nested(tool_data, "oarepo", default={})
-        oarepo_version = oarepo_data.get("version")
-        oarepo = OARepoConfig(version=int(oarepo_version) if oarepo_version is not None else None)
+        # OARepo version is deliberately never read from pyproject.toml here:
+        # [tool.oarepo-cli].oarepo.version is deprecated (see
+        # PyProjectData.oarepo_versions's own warning) -- the version is
+        # extracted from [project].dependencies instead, with OAREPO_VERSION
+        # (from_env(), merged over this) as the only remaining override.
+        oarepo = OARepoConfig()
 
         # Services config
         services_data = get_nested(tool_data, "services", default={})
@@ -442,7 +444,7 @@ class CliConfig:
             import warnings
 
             warnings.warn(
-                "Using default demo user password. Consider changing OAREPO_SECURITY_DEMO_PASSWORD",
+                "Using default demo user password. Consider changing DEMO_USER_PASSWORD",
                 UserWarning,
                 stacklevel=2,
             )

--- a/oarepo_cli/core/context.py
+++ b/oarepo_cli/core/context.py
@@ -289,8 +289,9 @@ class ContextBuilder:
             oarepo_version = pyproject_data.oarepo_versions[0]
         else:
             raise ConfigurationError(
-                "OARepo version not specified. Add to pyproject.toml [tool.oarepo-cli] "
-                "or set OAREPO_VERSION environment variable"
+                "OARepo version not specified. Add an 'oarepo' dependency to "
+                "[project].dependencies (or [project.optional-dependencies]) in "
+                "pyproject.toml, or set the OAREPO_VERSION environment variable"
             )
 
         # Validate venv path exists or can be created

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -7,14 +7,18 @@ from __future__ import annotations
 
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import invenio_cli, process, translations
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from oarepo_cli.core.context import ProjectContext
 
 
@@ -337,3 +341,190 @@ def upgrade_repository(context: ProjectContext, *, quiet: bool = False) -> None:
 
     console.info("→ Reinstalling repository...\n")
     install_repository(context, quiet=quiet)
+
+
+def get_invenio_binary(context: ProjectContext) -> Path:
+    """Resolve the path to the venv's own ``invenio`` binary (bare, not ``invenio-cli``)."""
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    return context.venv_path / bin_dir / "invenio"
+
+
+def _run_invenio(context: ProjectContext, args: Sequence[str], *, quiet: bool = False) -> None:
+    """Run a bare ``invenio`` subcommand in the venv, waiting for it to complete.
+
+    Unlike ``ServerRunner``, which ``exec``s the final long-running ``invenio
+    run``, callers here (``rebuild_index``, ``reset_repository``) need to run
+    several one-shot commands in sequence, so this blocks and raises on
+    failure like any other subprocess call in this module.
+    """
+    process.run(
+        [str(get_invenio_binary(context)), *args],
+        cwd=context.root_directory,
+        check=True,
+        interactive=not quiet,
+    )
+
+
+def rebuild_index(context: ProjectContext, *, quiet: bool = False) -> None:
+    """Destroy and re-create the search index, then rebuild all records/custom fields.
+
+    Mirrors ``repository_runner.sh``'s ``rebuild_index()``: a sequence of bare
+    ``invenio`` subcommands (not ``invenio-cli``), run directly against the venv.
+
+    Args:
+        context: Project context with paths and configuration
+        quiet: If True, suppress status/progress messages
+
+    Raises:
+        ProcessExecutionError: If any of the ``invenio`` subcommands fail
+    """
+    console = ConsoleOutput(quiet=quiet)
+
+    console.info("→ Destroying search index...\n")
+    _run_invenio(context, ["index", "destroy", "--yes-i-know"], quiet=quiet)
+
+    console.info("→ Initializing search index...\n")
+    _run_invenio(context, ["index", "init"], quiet=quiet)
+
+    console.info("→ Initializing custom fields...\n")
+    _run_invenio(context, ["rdm-records", "custom-fields", "init"], quiet=quiet)
+    _run_invenio(context, ["communities", "custom-fields", "init"], quiet=quiet)
+
+    console.info("→ Rebuilding all indices...\n")
+    _run_invenio(context, ["rdm", "rebuild-all-indices"], quiet=quiet)
+
+    console.success("✓ Search index was destroyed and re-created\n")
+    console.info(
+        "Please run the server with workers (oarepo-cli repository run) to complete the indexing.\n"
+    )
+
+
+def reset_repository(context: ProjectContext, *, quiet: bool = False) -> None:
+    """Full reset: destroy services, wipe venv/lock/local config, reinstall, reseed demo data.
+
+    Mirrors ``repository_runner.sh``'s ``reset_repository()`` (the confirmation
+    prompt is the caller's responsibility, e.g. ``cli/repository.py``'s
+    ``reset`` command -- this always proceeds unconditionally). Docker
+    service destruction failure (e.g. nothing was running) is deliberately
+    ignored, matching bash's ``services destroy || true``; every other step
+    raises on failure.
+
+    Args:
+        context: Project context with paths and configuration
+        quiet: If True, suppress status/progress messages
+
+    Raises:
+        ProcessExecutionError: If reinstalling, setting up services, or
+            seeding the demo admin/user fails
+    """
+    console = ConsoleOutput(quiet=quiet)
+
+    console.info("→ Stopping and removing services (if running)...\n")
+    invenio_cli.run_invenio_cli(context, ["services", "destroy"], quiet=quiet, check=False)
+
+    venv_manager = VirtualEnvironmentManager(context.config, context.root_directory)
+    if context.venv_path.exists():
+        console.info("→ Removing virtual environment...\n")
+    venv_manager.cleanup()
+
+    uv_lock = context.root_directory / "uv.lock"
+    if uv_lock.exists():
+        console.info("→ Removing uv.lock...\n")
+        uv_lock.unlink()
+
+    invenio_private = context.root_directory / ".invenio.private"
+    if invenio_private.exists():
+        console.info("→ Removing local invenio settings...\n")
+        invenio_private.unlink()
+
+    console.info("→ Cleaning uv cache...\n")
+    process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
+
+    console.info("→ Reinstalling repository...\n")
+    install_repository(context, quiet=quiet)
+
+    console.info("→ Setting up services...\n")
+    invenio_cli.run_invenio_cli(context, ["services", "setup", "-N"], quiet=quiet, check=True)
+
+    console.info("→ Creating administration group and a sample user@demo.org...\n")
+    _run_invenio(context, ["roles", "create", "administration"], quiet=quiet)
+    _run_invenio(
+        context,
+        ["access", "allow", "administration-access", "role", "administration"],
+        quiet=quiet,
+    )
+    _run_invenio(
+        context,
+        ["access", "allow", "administration-moderation", "role", "administration"],
+        quiet=quiet,
+    )
+    _run_invenio(
+        context,
+        [
+            "users",
+            "create",
+            "-a",
+            "-c",
+            "user@demo.org",
+            "--password",
+            context.config.security.demo_user_password,
+        ],
+        quiet=quiet,
+    )
+    _run_invenio(context, ["roles", "add", "user@demo.org", "administration"], quiet=quiet)
+
+
+def get_python_version(context: ProjectContext) -> str:
+    """Return the resolved Python interpreter's version string (e.g. "Python 3.14.4").
+
+    Mirrors ``repository_runner.sh``'s ``show_info()``: ``"$PYTHON" --version``.
+    """
+    result = process.run(
+        [str(context.python_binary), "--version"],
+        check=False,
+        capture_output=True,
+    )
+    return (result.stdout or result.stderr).strip()
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """A discovered record model: name and version extracted from its ``model.py``."""
+
+    name: str
+    version: str
+
+
+_MODEL_VERSION_PATTERN = re.compile(r"""version\s*=\s*["']([^"']+)["']""")
+
+
+def list_repository_models(context: ProjectContext) -> list[ModelInfo]:
+    """List record models under ``models/``, with their version from ``model.py``.
+
+    Mirrors ``repository_runner.sh``'s ``show_info()``'s model discovery: a
+    directory under ``models/`` counts as a model only if it has both
+    ``.copier-answers.yml`` and ``model.py``; version is the first
+    ``version = "..."`` match in ``model.py``, or ``"unknown"`` if none.
+    """
+    models_dir = context.root_directory / "models"
+    if not models_dir.is_dir():
+        return []
+
+    models = []
+    for entry in sorted(models_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if not (entry / ".copier-answers.yml").exists() or not (entry / "model.py").exists():
+            continue
+        models.append(
+            ModelInfo(name=entry.name, version=_extract_model_version(entry / "model.py"))
+        )
+    return models
+
+
+def _extract_model_version(model_py: Path) -> str:
+    for line in model_py.read_text().splitlines():
+        match = _MODEL_VERSION_PATTERN.search(line)
+        if match:
+            return match.group(1)
+    return "unknown"

--- a/oarepo_cli/services/server.py
+++ b/oarepo_cli/services/server.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, NoReturn
 
-from oarepo_cli.core.platform import get_platform_detector
-from oarepo_cli.services import invenio_cli
+from oarepo_cli.services import invenio_cli, repository
 from oarepo_cli.ui import ConsoleOutput
 
 if TYPE_CHECKING:
@@ -124,8 +123,7 @@ class ServerRunner:
         binary directly with ``--cert``/``--key``.
         """
         os.chdir(self._context.root_directory)
-        bin_dir = get_platform_detector().get_venv_bin_dir()
-        invenio_path = self._context.venv_path / bin_dir / "invenio"
+        invenio_path = repository.get_invenio_binary(self._context)
         argv = [
             str(invenio_path),
             "run",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,9 +33,7 @@ PYPROJECT_TOML = """\
 name = "{name}"
 version = "0.1.0"
 requires-python = ">=3.14,<3.15"
-
-[tool.oarepo-cli]
-oarepo = {{ version = 14 }}
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Tests for `repository cli`/`translations`/`index rebuild`/`reset`/`info`.
+
+Delegation, argument wiring, and error/exit-code handling are covered here
+by mocking `discover_context()` and the specific service function/module
+each subcommand delegates to (mirroring test_repository_local.py's/
+test_repository_run.py's approach for the other "thin CLI wrapper over a
+service" repository subcommands) -- the underlying subprocess sequencing
+for `index rebuild`/`reset` is already covered by
+tests/unit/test_repository_service.py's `rebuild_index`/`reset_repository`
+tests, and invenio-cli process replacement is already covered by
+test_server_runner.py/test_repository_run.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+from oarepo_cli.core.errors import ConfigurationError, ProcessExecutionError
+from oarepo_cli.services import process
+from oarepo_cli.services.repository import ModelInfo
+
+
+@pytest.fixture
+def mock_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() so no real project is needed."""
+    context = Mock()
+    monkeypatch.setattr("oarepo_cli.cli.repository.discover_context", lambda: context)
+    return context
+
+
+def _fake_process_result(**overrides: object) -> process.ProcessResult:
+    defaults: dict[str, object] = {
+        "return_code": 0,
+        "stdout": "",
+        "stderr": "",
+        "command": [],
+        "cwd": Path(),
+        "duration_ms": 0,
+    }
+    defaults.update(overrides)
+    return process.ProcessResult(**defaults)  # type: ignore[arg-type]
+
+
+# --- repository cli ---------------------------------------------------
+
+
+def test_cli_delegates_to_exec_invenio_cli(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository cli <args>` execs invenio-cli with the given args verbatim."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.exec_invenio_cli",
+        lambda context, args, **_kwargs: calls.append({"context": context, "args": list(args)}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "cli", "services", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "args": ["services", "status"]}]
+
+
+def test_cli_help_forwarded_to_invenio_cli(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--help is forwarded to invenio-cli rather than intercepted by Typer/Click."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.exec_invenio_cli",
+        lambda _context, args, **_kwargs: calls.append({"args": list(args)}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "cli", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"args": ["--help"]}]
+
+
+def test_cli_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "cli", "services", "status"])
+
+    assert result.exit_code == 1
+
+
+# --- repository translations -------------------------------------------
+
+
+def test_translations_no_args_runs_make_translations(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository translations` (no args) runs make-translations with no extra args."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.translations.run_translations",
+        lambda context, **kwargs: (
+            calls.append({"context": context, **kwargs}) or _fake_process_result()
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "translations"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "extra_args": [], "quiet": False}]
+
+
+def test_translations_compile_delegates_to_invenio_cli(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository translations compile` delegates to `invenio-cli translations compile`,
+    not make-translations."""
+    make_translations_calls: list[object] = []
+    invenio_cli_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.translations.run_translations",
+        lambda *_args, **_kwargs: make_translations_calls.append(True) or _fake_process_result(),
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda context, args, **kwargs: invenio_cli_calls.append(
+            {"context": context, "args": list(args), **kwargs}
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "translations", "compile"])
+
+    assert result.exit_code == 0, result.output
+    assert make_translations_calls == []
+    assert invenio_cli_calls == [
+        {"context": mock_context, "args": ["translations", "compile"], "quiet": False}
+    ]
+
+
+def test_translations_other_args_forwarded_to_make_translations(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Any first arg other than exactly "compile" is forwarded to make-translations,
+    mirroring repository_runner.sh's translations()'s exact-match check."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.translations.run_translations",
+        lambda context, **kwargs: (
+            calls.append({"context": context, **kwargs}) or _fake_process_result()
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "translations", "--verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "extra_args": ["--verbose"], "quiet": False}]
+
+
+def test_translations_reports_failure_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing make-translations run is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.translations.run_translations",
+        lambda *_args, **_kwargs: _fake_process_result(return_code=1),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "translations"])
+
+    assert result.exit_code == 1
+    assert "Translations failed" in result.output
+
+
+def test_translations_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "translations"])
+
+    assert result.exit_code == 1
+
+
+# --- repository index rebuild -------------------------------------------
+
+
+def test_index_rebuild_delegates_to_service(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository index rebuild` delegates to services.repository.rebuild_index."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.rebuild_index",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "index", "rebuild", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "quiet": True}]
+
+
+def test_index_rebuild_reports_error_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ProcessExecutionError from rebuild_index is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.rebuild_index",
+        Mock(
+            side_effect=ProcessExecutionError(
+                message="invenio index destroy failed",
+                command=["invenio", "index", "destroy"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "index", "rebuild"])
+
+    assert result.exit_code == 1
+    assert "Index rebuild failed" in result.output
+
+
+# --- repository reset ----------------------------------------------------
+
+
+def test_reset_cancelled_without_exact_yes(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anything other than exactly "yes" cancels the reset without error, exit code 0,
+    and without calling reset_repository -- mirrors repository_runner.sh's exact-match
+    `[ "$answer" != "yes" ]` check (not a fuzzy y/N confirm)."""
+    calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.reset_repository",
+        lambda *_args, **_kwargs: calls.append(True),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "reset"], input="no\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Reset cancelled" in result.output
+    assert calls == []
+
+
+def test_reset_confirmed_calls_reset_repository(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Answering exactly "yes" proceeds with the reset."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.reset_repository",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "reset", "--quiet"], input="yes\n")
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "quiet": True}]
+    assert "reset completed successfully" in result.output
+
+
+def test_reset_reports_failure_and_exits_1(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ProcessExecutionError partway through reset is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.reset_repository",
+        Mock(
+            side_effect=ProcessExecutionError(
+                message="reinstall failed",
+                command=["uv", "sync"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "reset"], input="yes\n")
+
+    assert result.exit_code == 1
+    assert "Reset failed" in result.output
+
+
+# --- repository info -------------------------------------------------
+
+
+def test_info_prints_python_version_and_models(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository info` prints the Python version and discovered models, matching
+    repository_runner.sh's show_info()'s exact output format."""
+    mock_context.python_binary = "/usr/bin/python3.14"
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.get_python_version",
+        lambda context: "Python 3.14.4",  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.list_repository_models",
+        lambda context: [  # noqa: ARG005
+            ModelInfo(name="my_model", version="1.0.0"),
+            ModelInfo(name="other_model", version="unknown"),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "info"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == (
+        "Python version: /usr/bin/python3.14\n"
+        "Python 3.14.4\n"
+        "\n"
+        "Models:\n"
+        "  - my_model: 1.0.0\n"
+        "  - other_model: unknown\n"
+    )
+
+
+def test_info_prints_no_models_found_when_empty(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No discovered models -> "No models found.", not an empty list/error."""
+    mock_context.python_binary = "/usr/bin/python3.14"
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.get_python_version",
+        lambda context: "Python 3.14.4",  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.list_repository_models",
+        lambda context: [],  # noqa: ARG005
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "info"])
+
+    assert result.exit_code == 0, result.output
+    assert "No models found." in result.output
+
+
+def test_info_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "info"])
+
+    assert result.exit_code == 1

--- a/tests/integration/test_repository_run.py
+++ b/tests/integration/test_repository_run.py
@@ -211,7 +211,7 @@ def test_run_real_exec_replaces_process(tmp_path: Path) -> None:
     project_root.mkdir()
     (project_root / "pyproject.toml").write_text(
         '[project]\nname = "myrepo"\nrequires-python = ">=3.14,<3.15"\n'
-        "\n[tool.oarepo-cli]\noarepo = { version = 14 }\n"
+        'dependencies = ["oarepo>=14.0.0,<15.0.0"]\n'
     )
 
     fake_invenio_cli = tmp_path / "fake-invenio-cli"

--- a/tests/testlib/pyproject.toml
+++ b/tests/testlib/pyproject.toml
@@ -24,9 +24,6 @@ oarepo14 = [
     "oarepo[rdm,tests]>=14.2.1b10.dev7,<15.0.0",
 ]
 
-[tool.oarepo-cli]
-oarepo = { version = "14" }
-
 [tool.pytest.ini_options]
 # Anchors pytest's rootdir/conftest discovery here so `library test` runs
 # (this project is nested under oarepo-cli/tests/) don't climb up into

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -96,7 +96,11 @@ security = { demo_user_password = "secure-password" }
     assert config.test.skip_services is True
     assert config.venv.path == Path("/custom/venv")
     assert config.python.binary == "python3.11"
-    assert config.oarepo.version == 14
+    # [tool.oarepo-cli].oarepo.version is deliberately ignored (deprecated --
+    # see PyProjectData.oarepo_versions): the version comes from
+    # [project].dependencies instead, with OAREPO_VERSION as the only
+    # remaining override.
+    assert config.oarepo.version is None
     assert config.services.skip is True
     assert config.services.db == "mysql"
     assert config.services.search == "elasticsearch"

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -22,9 +22,7 @@ def test_context_discovery_from_valid_project(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -63,9 +61,7 @@ def test_computed_properties_code_directories_src_layout(tmp_path: Path) -> None
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
     (tmp_path / "src").mkdir()
@@ -83,9 +79,7 @@ def test_computed_properties_code_directories_package_layout(tmp_path: Path) -> 
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
     (tmp_path / "test_project").mkdir()
@@ -102,9 +96,7 @@ def test_computed_properties_code_directories_hatch_wheel_packages(tmp_path: Pat
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["custom_pkg"]
@@ -124,9 +116,7 @@ def test_computed_properties_code_directories_raises_when_not_found(tmp_path: Pa
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -143,9 +133,7 @@ def test_computed_properties_instance_path_exists(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
     (tmp_path / "instance").mkdir()
@@ -162,9 +150,7 @@ def test_computed_properties_instance_path_none(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -180,9 +166,7 @@ def test_computed_properties_assets_path_exists(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
     (tmp_path / "assets").mkdir()
@@ -199,9 +183,7 @@ def test_computed_properties_assets_path_none(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -217,9 +199,9 @@ def test_builder_pattern_with_overrides(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 
 [tool.oarepo-cli]
-oarepo = { version = 14 }
 venv = { path = "/custom/venv" }
 """
     )
@@ -255,9 +237,7 @@ def test_validation_fails_for_incompatible_versions() -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -276,9 +256,7 @@ def test_context_is_immutable() -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -297,9 +275,7 @@ def test_discover_context_convenience_function(
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -318,9 +294,7 @@ def test_context_discovery_searches_parent_directories(tmp_path: Path) -> None:
 [project]
 name = "test-project"
 requires-python = ">=3.12,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 
@@ -378,9 +352,7 @@ def test_python_autodetect_ignores_active_venv(
 [project]
 name = "test-project"
 requires-python = ">=3.14,<3.15"
-
-[tool.oarepo-cli]
-oarepo = { version = 14 }
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
 """
     )
 

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -10,8 +10,10 @@ from unittest.mock import Mock
 
 import pytest
 
+from oarepo_cli.core.config import CliConfig, SecurityConfig
 from oarepo_cli.core.context import ProjectContext
-from oarepo_cli.services import repository
+from oarepo_cli.core.platform import get_platform_detector
+from oarepo_cli.services import process, repository
 
 
 @pytest.fixture
@@ -173,3 +175,187 @@ def test_ensure_instance_structure_idempotent(tmp_path: Path) -> None:
     # Should not raise
     assert instance_path.exists()
     assert (instance_path / "invenio.cfg").exists()
+
+
+def _fake_process_result(**overrides: object) -> process.ProcessResult:
+    defaults: dict[str, object] = {
+        "return_code": 0,
+        "stdout": "",
+        "stderr": "",
+        "command": [],
+        "cwd": Path(),
+        "duration_ms": 0,
+    }
+    defaults.update(overrides)
+    return process.ProcessResult(**defaults)  # type: ignore[arg-type]
+
+
+def test_get_invenio_binary_resolves_venv_bin_dir(tmp_path: Path) -> None:
+    """get_invenio_binary() resolves <venv>/<bin_dir>/invenio, platform-aware."""
+    context = Mock(spec=ProjectContext)
+    context.venv_path = tmp_path / ".venv"
+
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    assert repository.get_invenio_binary(context) == tmp_path / ".venv" / bin_dir / "invenio"
+
+
+def test_rebuild_index_runs_expected_invenio_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rebuild_index() runs the exact invenio subcommand sequence
+    repository_runner.sh's rebuild_index() does, via the bare venv invenio binary."""
+    context = Mock(spec=ProjectContext)
+    context.venv_path = tmp_path / ".venv"
+    context.root_directory = tmp_path
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_run)
+
+    repository.rebuild_index(context, quiet=True)
+
+    invenio = str(repository.get_invenio_binary(context))
+    assert calls == [
+        [invenio, "index", "destroy", "--yes-i-know"],
+        [invenio, "index", "init"],
+        [invenio, "rdm-records", "custom-fields", "init"],
+        [invenio, "communities", "custom-fields", "init"],
+        [invenio, "rdm", "rebuild-all-indices"],
+    ]
+
+
+def test_reset_repository_runs_expected_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """reset_repository() destroys services (ignoring failure), wipes venv/lock/private
+    config, cleans the uv cache, reinstalls, sets up services, and seeds a demo admin."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    context.config = CliConfig(security=SecurityConfig(demo_user_password="testpass123"))
+
+    invenio_cli_calls: list[dict[str, object]] = []
+    process_calls: list[list[str]] = []
+    install_calls: list[object] = []
+    cleanup_calls: list[object] = []
+
+    def fake_run_invenio_cli(_context: object, args: list[str], **kwargs: object) -> None:
+        invenio_cli_calls.append({"args": list(args), **kwargs})
+
+    def fake_process_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        process_calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.invenio_cli.run_invenio_cli", fake_run_invenio_cli
+    )
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_process_run)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.install_repository",
+        lambda _context, **kwargs: install_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.VirtualEnvironmentManager.cleanup",
+        lambda _self: cleanup_calls.append(True),
+    )
+
+    (tmp_path / "uv.lock").write_text("old lock")
+    (tmp_path / ".invenio.private").write_text("old settings")
+
+    repository.reset_repository(context, quiet=True)
+
+    # services destroy runs with check=False (failure ignored, like `services destroy || true`)
+    assert invenio_cli_calls[0]["args"] == ["services", "destroy"]
+    assert invenio_cli_calls[0]["check"] is False
+
+    assert cleanup_calls == [True]
+    assert not (tmp_path / "uv.lock").exists()
+    assert not (tmp_path / ".invenio.private").exists()
+    assert ["uv", "cache", "clean", "--force"] in process_calls
+
+    assert install_calls == [{"quiet": True}]
+
+    # services setup -N runs with check=True (must succeed, aborts reset otherwise)
+    assert invenio_cli_calls[1]["args"] == ["services", "setup", "-N"]
+    assert invenio_cli_calls[1]["check"] is True
+
+    invenio = str(repository.get_invenio_binary(context))
+    assert [invenio, "roles", "create", "administration"] in process_calls
+    assert [
+        invenio,
+        "access",
+        "allow",
+        "administration-access",
+        "role",
+        "administration",
+    ] in process_calls
+    assert [
+        invenio,
+        "users",
+        "create",
+        "-a",
+        "-c",
+        "user@demo.org",
+        "--password",
+        "testpass123",
+    ] in process_calls
+    assert [invenio, "roles", "add", "user@demo.org", "administration"] in process_calls
+
+
+def test_list_repository_models_finds_valid_models(tmp_path: Path) -> None:
+    """list_repository_models() only counts dirs with both .copier-answers.yml and
+    model.py, extracting the version from the first `version = "..."` match."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+
+    valid = tmp_path / "models" / "valid_model"
+    valid.mkdir(parents=True)
+    (valid / ".copier-answers.yml").write_text("_src_path: x\n")
+    (valid / "model.py").write_text('METADATA = {}\nversion = "1.2.3"\n')
+
+    no_version = tmp_path / "models" / "no_version_model"
+    no_version.mkdir(parents=True)
+    (no_version / ".copier-answers.yml").write_text("_src_path: x\n")
+    (no_version / "model.py").write_text("METADATA = {}\n")
+
+    missing_answers = tmp_path / "models" / "missing_answers"
+    missing_answers.mkdir(parents=True)
+    (missing_answers / "model.py").write_text('version = "9.9.9"\n')
+
+    not_a_model_dir = tmp_path / "models" / "just_a_dir"
+    not_a_model_dir.mkdir(parents=True)
+
+    models = repository.list_repository_models(context)
+
+    # missing_answers (no .copier-answers.yml) and just_a_dir (neither file) are excluded;
+    # remaining two are sorted by directory name.
+    assert models == [
+        repository.ModelInfo(name="no_version_model", version="unknown"),
+        repository.ModelInfo(name="valid_model", version="1.2.3"),
+    ]
+
+
+def test_list_repository_models_returns_empty_without_models_dir(tmp_path: Path) -> None:
+    """No models/ directory at all -> empty list, not an error."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+
+    assert repository.list_repository_models(context) == []
+
+
+def test_get_python_version_returns_stripped_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_python_version() runs `<python_binary> --version` and returns the stripped
+    output, mirroring repository_runner.sh's show_info()'s `"$PYTHON" --version`."""
+    context = Mock(spec=ProjectContext)
+    context.python_binary = Path("/usr/bin/python3.14")
+
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.process.run",
+        lambda *_args, **_kwargs: _fake_process_result(stdout="Python 3.14.4\n"),
+    )
+
+    assert repository.get_python_version(context) == "Python 3.14.4"


### PR DESCRIPTION
## Summary
- Implements the last five repository commands, completing Phase 4's command set: `cli` (invenio-cli passthrough), `translations` (compile / make-translations dispatch), `index rebuild`, `reset` (confirmation prompt), and `info` (Python version + discovered models).
- Adds `services/repository.py` helpers: `get_invenio_binary()` (also reused by `ServerRunner`'s `--no-celery` exec path), `rebuild_index()`, `reset_repository()`, `get_python_version()`, `list_repository_models()`/`ModelInfo`.
- Fixes two pre-existing bugs found along the way:
  - `SecurityConfig.demo_user_password` was reading from `OAREPO_SECURITY_DEMO_PASSWORD` instead of the documented, bash-compatible `DEMO_USER_PASSWORD`.
  - `core/context.py`/`core/config.py` still read the deprecated `[tool.oarepo-cli].oarepo.version` key into `config.oarepo.version`, contradicting the "deprecated and ignored" contract; removed that path — `OAREPO_VERSION` is now the only manual override.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] `make test` — 474 passed