### PR TITLE
Step 4.6.1: Skip uv cache clean on local package add/remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ oarepo-cli repository model update my_model model_config.yaml
 
 ### `repository local`
 
-Manages locally-developed packages as editable `[tool.uv.sources]` entries in `pyproject.toml`, for developing a dependency (e.g. a custom `oarepo`/`invenio` extension) alongside the repository. Both subcommands edit `pyproject.toml` in place (preserving comments/formatting/ordering elsewhere in the file) and then trigger a full [`repository upgrade`](#repository-upgrade) — unconditionally, unlike `repository model create`'s conditional reinstall.
+Manages locally-developed packages as editable `[tool.uv.sources]` entries in `pyproject.toml`, for developing a dependency (e.g. a custom `oarepo`/`invenio` extension) alongside the repository. Both subcommands edit `pyproject.toml` in place (preserving comments/formatting/ordering elsewhere in the file) and then trigger a full [`repository upgrade`](#repository-upgrade) — unconditionally, unlike `repository model create`'s conditional reinstall, but *without* clearing the uv cache (unlike a plain `repository upgrade`): a local package's own dependencies haven't changed, so there's nothing stale to purge.
 
 ```bash
 oarepo-cli repository local add <path>

--- a/docs/architecture/03-migration-guide.md
+++ b/docs/architecture/03-migration-guide.md
@@ -87,8 +87,8 @@ oarepo-cli library test
 | `./run.sh model create <name> <config>` | `oarepo-cli repository model create <name> <config>` | Identical behavior |
 | `./run.sh model update <name>` | `oarepo-cli repository model update <name>` | Identical behavior |
 | `./run.sh model update <name> <answers>` | `oarepo-cli repository model update <name> <answers>` | Identical behavior |
-| `./run.sh local add <path>` | `oarepo-cli repository local add <path>` | Identical behavior |
-| `./run.sh local remove <name>` | `oarepo-cli repository local remove <name>` | Identical behavior |
+| `./run.sh local add <path>` | `oarepo-cli repository local add <path>` | Deviation: the triggered repository upgrade no longer cleans the uv cache (see Step 4.6.1) |
+| `./run.sh local remove <name>` | `oarepo-cli repository local remove <name>` | Deviation: bash never implemented this (told users to edit `pyproject.toml` by hand); also skips the uv cache clean, like `local add` |
 | `./run.sh run` | `oarepo-cli repository run` | Identical behavior |
 | `./run.sh run --no-services` | `oarepo-cli repository run --no-services` | Same flag |
 | `./run.sh run --no-celery` | `oarepo-cli repository run --no-celery` | Same flag |

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1105,6 +1105,41 @@ support, so this fills that gap.
 
 ---
 
+### Step 4.6.1: Skip uv Cache Clean on Local Package Add/Remove
+**Goal**: Correction to Step 4.6 -- adding/removing a local package must not
+clean the uv cache.
+
+- [x] Add a `clean_cache: bool = True` keyword to
+  `services.repository.upgrade_repository()`, guarding the `uv cache clean
+  --force` step
+- [x] `LocalPackageManager.add_package()`/`remove_package()`/
+  `remove_all_packages()` call `upgrade_repository(..., clean_cache=False)`
+- [x] `repository upgrade` (the CLI command) keeps the default
+  (`clean_cache=True`), unchanged
+
+**Rationale**: unlike `repository upgrade` (which exists precisely to force
+a fresh resolve of every dependency), adding or removing a local, editable
+package doesn't change any other package's pinned version -- so purging the
+entire uv cache and forcing a full re-download of everything else on the
+next install buys nothing and is slow. This is a deliberate deviation from
+`repository_runner.sh`'s `local_sources_cmd`, which called the same
+unconditional, cache-clearing `upgrade_repository()` bash function as
+`./run.sh upgrade` (`local remove` has no bash equivalent to deviate from --
+see Step 4.6's own deviation note).
+
+**Deliverables**:
+- `local add`/`local remove`/`local remove --all` no longer clean the uv
+  cache; `repository upgrade` is unaffected
+
+**Tests**:
+- `tests/unit/test_repository_service.py`: `upgrade_repository(...,
+  clean_cache=False)` does not run `uv cache clean`; default
+  (`clean_cache=True`) behavior unchanged
+- `tests/integration/test_local_packages.py`: `add_package`/`remove_package`/
+  `remove_all_packages` call `upgrade_repository` with `clean_cache=False`
+
+---
+
 ### Step 4.7: Repository `local` Command
 **Goal**: Implement `oarepo-cli repository local` command.
 

--- a/oarepo_cli/services/local_packages.py
+++ b/oarepo_cli/services/local_packages.py
@@ -47,6 +47,11 @@ class LocalPackageManager:
     every local package but triggers only a single ``upgrade_repository``
     call at the end (via ``remove_package(..., upgrade=False)`` per
     package), rather than one full upgrade per package.
+
+    Unlike bash, every ``upgrade_repository()`` call here passes
+    ``clean_cache=False``: adding/removing a local package doesn't change
+    any other package's version, so purging the uv cache -- and forcing a
+    full re-download of everything else -- buys nothing and is slow.
     """
 
     def __init__(self, context: ProjectContext, *, quiet: bool = False) -> None:
@@ -100,7 +105,7 @@ class LocalPackageManager:
         self._write_document(document)
 
         console.info("→ Upgrading repository with the new local package\n")
-        upgrade_repository(self._context, quiet=self._quiet)
+        upgrade_repository(self._context, quiet=self._quiet, clean_cache=False)
 
         console.success(f"✓ Local package '{name}' added successfully.\n")
 
@@ -140,7 +145,7 @@ class LocalPackageManager:
 
         if upgrade:
             console.info("→ Upgrading repository after removing the local package\n")
-            upgrade_repository(self._context, quiet=self._quiet)
+            upgrade_repository(self._context, quiet=self._quiet, clean_cache=False)
 
         console.success(f"✓ Local package '{canonical_name}' removed successfully.\n")
 
@@ -171,7 +176,7 @@ class LocalPackageManager:
         if names:
             console = ConsoleOutput(quiet=self._quiet)
             console.info("→ Upgrading repository after removing all local packages\n")
-            upgrade_repository(self._context, quiet=self._quiet)
+            upgrade_repository(self._context, quiet=self._quiet, clean_cache=False)
 
         return names
 

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -302,26 +302,33 @@ def install_repository(context: ProjectContext, *, quiet: bool = False) -> None:
         console.warning("⚠️  Warning: invenio-cli failed to compile backend translations!")
 
 
-def upgrade_repository(context: ProjectContext, *, quiet: bool = False) -> None:
-    """Upgrade repository: clean venv/cache and reinstall from scratch.
+def upgrade_repository(
+    context: ProjectContext, *, quiet: bool = False, clean_cache: bool = True
+) -> None:
+    """Upgrade repository: clean venv (and, by default, cache) and reinstall from scratch.
 
     Mirrors ``repository_runner.sh``'s ``upgrade_repository`` function:
     1. Removes the virtual environment (if present)
     2. Removes uv.lock (if present)
-    3. Cleans the uv cache (``uv cache clean --force``)
+    3. Cleans the uv cache (``uv cache clean --force``), unless ``clean_cache`` is False
     4. Reinstalls the repository (see ``install_repository`` above)
 
-    Shared by ``repository upgrade`` and ``LocalPackageManager`` (which
-    triggers a full upgrade after adding/removing a local package,
-    unconditionally -- mirroring repository_runner.sh's
-    ``local_sources_cmd``'s unconditional call to ``upgrade_repository``
-    after ``uv add``, unlike ``ModelManager.create_model()``'s conditional
-    reinstall). Callers are responsible for their own top-level success
-    message and ``(OARepoError, ProcessExecutionError)`` handling.
+    Shared by ``repository upgrade`` (``clean_cache=True``, matching bash) and
+    ``LocalPackageManager`` (which triggers a full upgrade after adding/removing
+    a local package, unconditionally -- mirroring repository_runner.sh's
+    ``local_sources_cmd``'s unconditional call to ``upgrade_repository`` after
+    ``uv add``, unlike ``ModelManager.create_model()``'s conditional reinstall
+    -- but with ``clean_cache=False``: a local package's own dependencies
+    haven't changed, so purging already-downloaded wheels for everything else
+    just to reinstall the same versions is wasted time, unlike a real
+    ``repository upgrade``, which explicitly wants to force a fresh resolve).
+    Callers are responsible for their own top-level success message and
+    ``(OARepoError, ProcessExecutionError)`` handling.
 
     Args:
         context: Project context with paths and configuration
         quiet: If True, suppress status/progress messages
+        clean_cache: If False, skip the ``uv cache clean --force`` step
 
     Raises:
         ProcessExecutionError: If ``uv cache clean`` or ``install_repository``
@@ -336,8 +343,9 @@ def upgrade_repository(context: ProjectContext, *, quiet: bool = False) -> None:
         console.info("→ Removing uv.lock...\n")
     venv_manager.cleanup()
 
-    console.info("→ Cleaning uv cache...\n")
-    process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
+    if clean_cache:
+        console.info("→ Cleaning uv cache...\n")
+        process.run(["uv", "cache", "clean", "--force"], check=True, interactive=not quiet)
 
     console.info("→ Reinstalling repository...\n")
     install_repository(context, quiet=quiet)

--- a/tests/integration/test_local_packages.py
+++ b/tests/integration/test_local_packages.py
@@ -7,8 +7,9 @@ LocalPackageManager only ever touches a project's pyproject.toml (via
 tomlkit) and, on success, calls services.repository.upgrade_repository --
 there's no slow external tool (uv, copier, invenio-cli) to run for real
 here, so these tests exercise the real tomlkit read/modify/write path
-against real tmp_path files and mock out upgrade_repository (a full
-venv-wipe + uv-cache-clean + reinstall cycle, already covered end to end by
+against real tmp_path files and mock out upgrade_repository (a venv-wipe +
+reinstall cycle -- with the uv cache clean step skipped here via
+clean_cache=False, see Step 4.6.1 -- already covered end to end by
 test_repository_upgrade.py), per AGENTS.md's guidance to fake slow external
 tools rather than re-run them at this layer.
 """
@@ -112,7 +113,7 @@ def test_add_package_triggers_repository_upgrade(
     manager.add_package(package_dir)
 
     assert len(mock_upgrade) == 1
-    assert mock_upgrade[0] == {"context": context, "quiet": True}
+    assert mock_upgrade[0] == {"context": context, "quiet": True, "clean_cache": False}
 
 
 def test_add_package_missing_pyproject_raises(
@@ -240,7 +241,7 @@ def test_remove_package_triggers_repository_upgrade(
 
     manager.remove_package("mypkg")
 
-    assert mock_upgrade == [{"context": context, "quiet": True}]
+    assert mock_upgrade == [{"context": context, "quiet": True, "clean_cache": False}]
 
 
 def test_remove_package_leaves_other_sources_untouched(

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -190,6 +190,68 @@ def _fake_process_result(**overrides: object) -> process.ProcessResult:
     return process.ProcessResult(**defaults)  # type: ignore[arg-type]
 
 
+def test_upgrade_repository_cleans_cache_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """upgrade_repository() runs `uv cache clean --force` when clean_cache is left at its
+    default (True) -- matches `repository upgrade`'s bash-compatible behavior."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    context.config = CliConfig()
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_run)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.VirtualEnvironmentManager.cleanup", lambda _self: None
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.install_repository", lambda *_args, **_kwargs: None
+    )
+
+    repository.upgrade_repository(context, quiet=True)
+
+    assert ["uv", "cache", "clean", "--force"] in calls
+
+
+def test_upgrade_repository_skips_cache_clean_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """upgrade_repository(clean_cache=False) -- used by LocalPackageManager -- never runs
+    `uv cache clean`, since adding/removing a local package doesn't change any other
+    package's version and purging the cache would just force a wasted re-download."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    context.config = CliConfig()
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_run)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.VirtualEnvironmentManager.cleanup", lambda _self: None
+    )
+    install_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.install_repository",
+        lambda *_args, **kwargs: install_calls.append(kwargs),
+    )
+
+    repository.upgrade_repository(context, quiet=True, clean_cache=False)
+
+    assert calls == []
+    assert install_calls == [{"quiet": True}]
+
+
 def test_get_invenio_binary_resolves_venv_bin_dir(tmp_path: Path) -> None:
     """get_invenio_binary() resolves <venv>/<bin_dir>/invenio, platform-aware."""
     context = Mock(spec=ProjectContext)


### PR DESCRIPTION
## Summary
- `upgrade_repository()` gains a `clean_cache: bool = True` keyword, guarding the `uv cache clean --force` step.
- `LocalPackageManager` (`add_package`/`remove_package`/`remove_all_packages`) now passes `clean_cache=False`: a local, editable package's own dependencies haven't changed, so purging the uv cache and forcing a full re-download of everything else just to reinstall the same versions is wasted time.
- `repository upgrade` (the CLI command) keeps the default (`clean_cache=True`), unchanged from `repository_runner.sh`'s unconditional cache clean.
- Documented as Step 4.6.1 in `implementation-steps.md`, plus updates to `README.md` and `03-migration-guide.md`'s compatibility table.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] Targeted tests pass: `tests/unit/test_repository_service.py`, `tests/integration/test_local_packages.py`, `tests/integration/test_repository_local.py`, and the two fast `test_repository_upgrade.py` cases (48 passed)
- [ ] Full `make test` not run — deliberately skipped per request, since some integration tests exercise real Docker services and a repository was running locally during this change