### PR TITLE
Steps 4.11-4.14: Fix verified library/repository parity bugs

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1357,12 +1357,12 @@ own help, not invenio-cli's.
 **Goal**: Fix a copy-paste bug found during the post-Phase-4 library/repository
 parity audit ([after_repository_cleanup.md](./after_repository_cleanup.md) §2.1).
 
-- [ ] Remove the duplicated "Display summary" if/else block in
+- [x] Remove the duplicated "Display summary" if/else block in
   `cli/library.py`'s `library_clean()` -- the entire block (deciding between
   `✨ ✓ Cleanup completed! Removed: ...` and `✨ ✓ Environment is already
   clean!`) appears twice verbatim, so every `library clean` run prints its
   summary message twice
-- [ ] Add/adjust a test asserting the summary is printed exactly once
+- [x] Add/adjust a test asserting the summary is printed exactly once
 
 **Deliverables**:
 - `library clean` prints its summary exactly once
@@ -1384,22 +1384,42 @@ correct** -- a broad `except Exception` silently turns real bugs (e.g. an
 `AttributeError`) into a clean, misleading "exit 1" instead of surfacing a
 traceback.
 
-- [ ] Change all top-level command `except Exception` blocks in
+- [x] Change all top-level command `except Exception` blocks in
   `cli/library.py` (17 sites) to `except (OARepoError, ProcessExecutionError)`,
   matching `cli/repository.py`'s pattern
-- [ ] Verify no `library.py` command actually relies on catching a
+- [x] Verify no `library.py` command actually relies on catching a
   non-`OARepoError` exception type (e.g. a raw `OSError`/`subprocess` error
   that isn't already wrapped) -- wrap it into an appropriate `OARepoError`
   subclass at the source (in `services/`) instead of widening the CLI-layer
   catch back out
-- [ ] While touching these sites, simplify `repository.py`'s
+- [x] While touching these sites, simplify `repository.py`'s
   `except (OARepoError, ProcessExecutionError)` to plain `except OARepoError`
   -- `ProcessExecutionError` already subclasses `OARepoError`
   (`core/errors.py`), so the tuple is redundant
-- [ ] Re-run the full test suite -- some tests may currently rely on the
+- [x] Re-run the full test suite -- some tests may currently rely on the
   broad catch (e.g. asserting a specific exit code for an exception type
   that isn't an `OARepoError`); fix the underlying exception type rather
   than the test if so
+
+**Deviations from the original plan**:
+- Of `library.py`'s 17 `except Exception` sites, only 12 are the "wrap a
+  whole command, print an error, exit 1" pattern this step targets --
+  `library_clean()`'s 3 step-by-step cleanup handlers and `library_upgrade()`'s
+  2 (stop services, clean cache) are a different, correct pattern:
+  best-effort, log-a-warning-and-continue steps in an idempotent multi-step
+  operation (e.g. `.unlink()` on `.env-services` can raise a raw `OSError`,
+  which must not abort the rest of the cleanup). Left broad on purpose, now
+  with a comment explaining why so a future audit doesn't re-flag them.
+- Landed as plain `except OARepoError` in both files directly (not
+  `except (OARepoError, ProcessExecutionError)` in `library.py` first, then
+  simplified) -- `ProcessExecutionError` already subclasses `OARepoError`,
+  so there was no intermediate state worth landing.
+- `library_test()`'s handler had a manual `if not isinstance(e, typer.Exit):
+  ... else: raise` guard, needed because `typer.Exit` subclasses
+  `RuntimeError`/`Exception`, so the old broad catch used to intercept its
+  own `raise typer.Exit(code=result.return_code)` on the success path. Under
+  `except OARepoError`, `typer.Exit` is never caught here at all, so the
+  guard was removed as dead code rather than kept.
 
 **Deliverables**:
 - Every CLI command in both modules uses the same, narrow exception-handling
@@ -1423,16 +1443,38 @@ parent-directory walk for `pyproject.toml` and wires up
 that exist only because they were never hoisted (not to break a circular
 import, the only sanctioned reason per AGENTS.md).
 
-- [ ] Before refactoring, confirm `discover_context()`'s failure mode still
+- [x] Before refactoring, confirm `discover_context()`'s failure mode still
   satisfies `oarepo-versions`' contract (it may need to work in places a
   fully-resolved `ProjectContext` can't be built -- e.g. no venv yet --
   since it only ever needed `pyproject.toml`); adjust `discover_context()`
   or fall back to a narrower helper if not
-- [ ] Rewrite `library_oarepo_versions()` to use `discover_context()` (or
+- [x] Rewrite `library_oarepo_versions()` to use `discover_context()` (or
   the confirmed narrower alternative) instead of its own directory walk
-- [ ] Move `json`, `Path`, `ConfigurationError`, `PyProjectReader`,
+- [x] Move `json`, `Path`, `ConfigurationError`, `PyProjectReader`,
   `VersionResolver` imports to module level
-- [ ] Verify the command's output/exit codes are unchanged
+- [x] Verify the command's output/exit codes are unchanged
+
+**Deviations from the original plan**:
+- Confirmed `discover_context()` does *not* fit: `ContextBuilder.validate()`
+  requires a resolvable OARepo version and an existing Python binary
+  (raising `ConfigurationError` for either), but `oarepo-versions` must keep
+  working for a project with no `oarepo` dependency at all --
+  `test_oarepo_versions_no_oarepo_extra` exercises exactly this and would
+  have broken. Used the "narrower helper" fallback the step anticipated
+  instead: extracted the upward `pyproject.toml` search into a new
+  `core.context.find_pyproject_toml()`, also adopted by
+  `ContextBuilder.from_cwd()` (dropping its own duplicate copy of the same
+  loop), so `library_oarepo_versions()` no longer hand-rolls it but still
+  doesn't need a full `ProjectContext`.
+- Widened the resolver's error handling from `except ConfigurationError` to
+  `except OARepoError`, matching Step 4.12's convention -- this also now
+  catches `VersionMismatchError`, which `resolve_from_pyproject()` can
+  raise but the old code never caught (would have crashed with a raw
+  traceback instead of a clean exit 1).
+- `Path` itself didn't need hoisting: `pathlib.Path` isn't imported at all
+  in `cli/library.py` (unlike `cli/repository.py`, which does need it for a
+  type annotation) -- the plan's checklist item is satisfied by simply no
+  longer needing it in this function.
 
 **Deliverables**:
 - `library oarepo-versions` uses the same context-discovery path as every
@@ -1451,11 +1493,15 @@ audit ([after_repository_cleanup.md](./after_repository_cleanup.md) §2.4):
 `library_shell()` has `import traceback  # noqa: TID251` inside its
 `except Exception` branch, not to break a circular import.
 
-- [ ] Move `import traceback` to module level in `cli/library.py` and drop
+- [x] Move `import traceback` to module level in `cli/library.py` and drop
   the `# noqa: TID251` suppression
-- [ ] Re-run `make lint` to confirm no new, unsuppressed violation appears
+- [x] Re-run `make lint` to confirm no new, unsuppressed violation appears
   (if one does, address the underlying cause rather than re-adding the
   suppression)
+
+**Deviation from the original plan**: `TID` (flake8-tidy-imports, the rule
+`TID251` belongs to) isn't in this project's `[tool.ruff.lint].select` list
+at all -- the suppression was already a no-op before this step removed it.
 
 **Deliverables**:
 - No function-local, non-circular-import imports remain in `cli/library.py`

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import traceback
 from typing import Annotated
 
 import typer
@@ -602,8 +603,6 @@ def library_shell(
             fg=typer.colors.BRIGHT_RED,
             bold=True,
         )
-        import traceback  # noqa: TID251
-
         traceback.print_exc()
         raise typer.Exit(code=1) from e
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -325,20 +325,6 @@ def library_clean(
             bold=True,
         )
 
-    # Display summary
-    if items_removed:
-        console.success(
-            f"✨ ✓ Cleanup completed! Removed: {', '.join(items_removed)}",
-            fg=typer.colors.BRIGHT_GREEN,
-            bold=True,
-        )
-    else:
-        console.success(
-            "✨ ✓ Environment is already clean!",
-            fg=typer.colors.BRIGHT_GREEN,
-            bold=True,
-        )
-
 
 @library_app.command("upgrade")
 def library_upgrade(

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -11,6 +11,7 @@ from typing import Annotated
 import typer
 
 from oarepo_cli.core.context import discover_context
+from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import process
 from oarepo_cli.services.js_tools import run_jslint, run_jstest
@@ -83,7 +84,7 @@ def _start_services_impl(*, quiet: bool = False) -> None:
                 f"  Environment variables written to {context.root_directory / '.env-services'}",
                 fg=typer.colors.GREEN,
             )
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error starting services: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -143,7 +144,7 @@ def _stop_services_impl(*, quiet: bool = False) -> None:
         console.success(
             "✨ ✓ Services stopped successfully!", fg=typer.colors.BRIGHT_GREEN, bold=True
         )
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error stopping services: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -257,6 +258,7 @@ def library_clean(
             services_mgr.stop_services()
             console.info("  ✓ Services stopped", fg=typer.colors.GREEN)
             items_removed.append("services")
+        # Best-effort cleanup step: keep going even on a non-OARepoError failure.
         except Exception as e:
             console.warning(
                 f"  ⚠ Warning: Failed to stop services: {e}",
@@ -273,6 +275,7 @@ def library_clean(
             env_services_file.unlink()
             console.info("  ✓ .env-services removed", fg=typer.colors.GREEN)
             items_removed.append(".env-services")
+        # Best-effort cleanup step: keep going even on a non-OARepoError failure.
         except Exception as e:
             console.warning(
                 f"  ⚠ Warning: Failed to remove .env-services: {e}",
@@ -301,6 +304,7 @@ def library_clean(
             if lock_existed:
                 console.info("  ✓ uv.lock file removed", fg=typer.colors.GREEN)
                 items_removed.append("uv.lock")
+        # Best-effort cleanup step: keep going even on a non-OARepoError failure.
         except Exception as e:
             console.warning(
                 f"  ⚠ Warning: Failed to remove venv/uv.lock: {e}",
@@ -358,6 +362,7 @@ def library_upgrade(
         try:
             services_mgr.stop_services()
             console.info("  ✓ Services stopped", fg=typer.colors.GREEN)
+        # Best-effort cleanup step: keep going even on a non-OARepoError failure.
         except Exception as e:
             console.warning(
                 f"  ⚠ Warning: Failed to stop services: {e}",
@@ -370,6 +375,7 @@ def library_upgrade(
     try:
         process.run(["uv", "cache", "clean"], check=True, interactive=not quiet)
         console.info("  ✓ Cache cleaned", fg=typer.colors.GREEN)
+    # Best-effort step: keep going even on a non-OARepoError failure.
     except Exception as e:
         console.warning(f"  ⚠ Warning: Failed to clean uv cache: {e}", fg=typer.colors.YELLOW)
 
@@ -539,16 +545,16 @@ def library_test(
         # Exit with pytest's exit code
         raise typer.Exit(code=result.return_code)
 
-    except Exception as e:
-        # Catch any orchestration errors (not pytest failures)
-        if not isinstance(e, typer.Exit):
-            console.error(
-                f"❌ Error running tests: {e}",
-                fg=typer.colors.BRIGHT_RED,
-                bold=True,
-            )
-            raise typer.Exit(code=1) from e
-        raise
+    except OARepoError as e:
+        # Catch any orchestration errors (not pytest failures, which are reported
+        # above via result.return_code) -- typer.Exit itself is never caught here
+        # since it isn't an OARepoError, so it always propagates untouched.
+        console.error(
+            f"❌ Error running tests: {e}",
+            fg=typer.colors.BRIGHT_RED,
+            bold=True,
+        )
+        raise typer.Exit(code=1) from e
 
 
 @library_app.command("shell")
@@ -587,7 +593,7 @@ def library_shell(
 
     try:
         venv_path = venv_mgr.ensure_venv_exists(requirements, quiet=True)
-    except Exception as e:
+    except OARepoError as e:
         console.error(
             f"❌ Error ensuring virtual environment: {e}",
             fg=typer.colors.BRIGHT_RED,
@@ -725,7 +731,7 @@ def library_invenio(
 
     try:
         venv_path = venv_mgr.ensure_venv_exists(requirements, quiet=True)
-    except Exception as e:
+    except OARepoError as e:
         console.error(
             f"❌ Error ensuring virtual environment: {e}",
             fg=typer.colors.BRIGHT_RED,
@@ -826,7 +832,7 @@ def library_lint(
 
     try:
         result = runner.run_lint(fix=fix)
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error running linters: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -884,7 +890,7 @@ def library_format(
 
     try:
         result = runner.run_format(fix=fix, extra_args=extra_args)
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error formatting code: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -921,7 +927,7 @@ def library_check(
 
     try:
         result = runner.run_lint(fix=False)
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error running checks: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -966,7 +972,7 @@ def library_translations(
 
     try:
         result = run_translations(context, extra_args=extra_args, quiet=quiet)
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error running translations: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -1006,7 +1012,7 @@ def library_license_headers(
 
     try:
         result = add_license_headers(context, organization=organization, quiet=quiet)
-    except Exception as e:
+    except OARepoError as e:
         console.error(
             f"❌ Error adding license headers: {e}", fg=typer.colors.BRIGHT_RED, bold=True
         )
@@ -1045,7 +1051,7 @@ def library_jslint(
 
     try:
         result = run_jslint(context, quiet=quiet)
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error running jslint: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
@@ -1106,7 +1112,7 @@ def library_jstest(
         result = run_jstest(
             context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
         )
-    except Exception as e:
+    except OARepoError as e:
         console.error(f"❌ Error running jstest: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -5,22 +5,25 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Annotated
 
 import typer
 
-from oarepo_cli.core.context import discover_context
+from oarepo_cli.core.context import discover_context, find_pyproject_toml
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import process
 from oarepo_cli.services.js_tools import run_jslint, run_jstest
 from oarepo_cli.services.license_headers import add_license_headers
 from oarepo_cli.services.lint import LintRunner
+from oarepo_cli.services.pyproject_reader import PyProjectReader
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 from oarepo_cli.services.test_orchestrator import TestOrchestrator
 from oarepo_cli.services.translations import run_translations
 from oarepo_cli.services.venv import VenvRequirements, VirtualEnvironmentManager
+from oarepo_cli.services.version_resolver import VersionResolver
 from oarepo_cli.ui import ConsoleOutput
 
 # Create the library subcommand group
@@ -1155,24 +1158,14 @@ def library_oarepo_versions(
         oarepo-cli library oarepo-versions
         oarepo-cli library oarepo-versions | jq .python_versions
     """
-    import json
-    from pathlib import Path
+    # Deliberately not discover_context(): this command only ever needs
+    # pyproject.toml to exist (it reports what a project *declares*, before
+    # any venv is created or an OARepo version is even resolvable), whereas
+    # discover_context() additionally requires a working Python binary and a
+    # resolvable OARepo version -- either of which may not exist yet.
+    pyproject_path = find_pyproject_toml()
 
-    # We need to use the version resolver to get the version info
-    from oarepo_cli.core.errors import ConfigurationError
-    from oarepo_cli.services.pyproject_reader import PyProjectReader
-    from oarepo_cli.services.version_resolver import VersionResolver
-
-    # Find pyproject.toml in current directory or parent directories
-    pyproject_path = None
-    current = Path.cwd()
-    for directory in [current, *current.parents]:
-        candidate = directory / "pyproject.toml"
-        if candidate.exists():
-            pyproject_path = candidate
-            break
-
-    if not pyproject_path:
+    if pyproject_path is None:
         console = ConsoleOutput(quiet=quiet)
         console.error(
             "❌ pyproject.toml not found in current directory or any parent",
@@ -1186,7 +1179,7 @@ def library_oarepo_versions(
 
     try:
         info = resolver.resolve_from_pyproject(pyproject_path)
-    except ConfigurationError as e:
+    except OARepoError as e:
         console = ConsoleOutput(quiet=quiet)
         console.error(f"❌ Error resolving versions: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -11,7 +11,7 @@ from typing import Annotated
 import typer
 
 from oarepo_cli.core.context import discover_context
-from oarepo_cli.core.errors import OARepoError, ProcessExecutionError
+from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.services import invenio_cli, repository, translations
 from oarepo_cli.services.local_packages import LocalPackageManager
 from oarepo_cli.services.models import ModelManager
@@ -125,7 +125,7 @@ def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool
 
     try:
         context = discover_context()
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ services {subcommand} failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -236,7 +236,7 @@ def install(
             bold=True,
         )
 
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Installation failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -283,7 +283,7 @@ def upgrade(
             bold=True,
         )
 
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Upgrade failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -325,7 +325,7 @@ def model_create(
     try:
         context = discover_context()
         ModelManager(context, quiet=quiet).create_model(name, config_file=config_file)
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Model creation failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -367,7 +367,7 @@ def model_update(
     try:
         context = discover_context()
         ModelManager(context, quiet=quiet).update_model(name, answers_file=answers_file)
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Model update failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -400,7 +400,7 @@ def local_add(
     try:
         context = discover_context()
         LocalPackageManager(context, quiet=quiet).add_package(path)
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Local package addition failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -451,7 +451,7 @@ def local_remove(
             manager.remove_all_packages()
         elif name is not None:
             manager.remove_package(name)
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Local package removal failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -508,7 +508,7 @@ def run_command(
             no_celery=no_celery,
             extra_args=ctx.args,
         )
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ Failed to start server: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -533,7 +533,7 @@ def cli_command(ctx: typer.Context) -> None:
     """
     try:
         context = discover_context()
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ repository cli failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -571,7 +571,7 @@ def translations_command(
             invenio_cli.run_invenio_cli(context, ["translations", "compile"], quiet=quiet)
         else:
             translations.run_translations(context, extra_args=ctx.args, quiet=quiet).check()
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ Translations failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -594,7 +594,7 @@ def index_rebuild(
     try:
         context = discover_context()
         repository.rebuild_index(context, quiet=quiet)
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ Index rebuild failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -642,7 +642,7 @@ def reset_command(
             "Please run `oarepo-cli repository run` to start the server "
             "and wait for the initial data to be loaded.\n"
         )
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ Reset failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
@@ -660,7 +660,7 @@ def info_command() -> None:
     """
     try:
         context = discover_context()
-    except (OARepoError, ProcessExecutionError) as e:
+    except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ repository info failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e

--- a/oarepo_cli/core/context.py
+++ b/oarepo_cli/core/context.py
@@ -106,6 +106,32 @@ class ProjectContext:
         return assets_dir if assets_dir.exists() else None
 
 
+def find_pyproject_toml(start: Path | None = None) -> Path | None:
+    """Search upward from ``start`` (default: cwd) for a ``pyproject.toml``.
+
+    Standalone helper for callers that only need the raw pyproject.toml
+    path -- e.g. ``library oarepo-versions``, which reports the OARepo/
+    Python/Node versions a project *declares* and must therefore keep
+    working before a venv exists or an OARepo version can be resolved,
+    unlike ``ContextBuilder.validate()``'s full ``ProjectContext`` (which
+    requires both). ``ContextBuilder.from_cwd()`` uses this too, so the
+    upward-search logic itself only lives in one place.
+
+    Args:
+        start: Directory to start searching from (default: current working
+            directory)
+
+    Returns:
+        Path to the found pyproject.toml, or None if none exists in
+        ``start`` or any parent directory
+    """
+    for directory in [start or Path.cwd(), *(start or Path.cwd()).parents]:
+        candidate = directory / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 class ContextBuilder:
     """Fluent builder for constructing ProjectContext with validation.
 
@@ -138,15 +164,13 @@ class ContextBuilder:
         """
         cwd = Path.cwd()
 
-        # Search upward for pyproject.toml
-        for parent in [cwd, *cwd.parents]:
-            pyproject = parent / "pyproject.toml"
-            if pyproject.exists():
-                self._root_directory = parent
-                self._pyproject_path = pyproject
-                return self
+        pyproject = find_pyproject_toml(cwd)
+        if pyproject is None:
+            raise ConfigurationError(f"pyproject.toml not found in {cwd} or any parent directory")
 
-        raise ConfigurationError(f"pyproject.toml not found in {cwd} or any parent directory")
+        self._root_directory = pyproject.parent
+        self._pyproject_path = pyproject
+        return self
 
     def from_directory(self, path: Path) -> ContextBuilder:
         """Discover project context from a specific directory.

--- a/tests/integration/test_library_clean.py
+++ b/tests/integration/test_library_clean.py
@@ -108,6 +108,36 @@ def test_library_clean_command_shows_output_real(
     assert len(result.output) >= 0  # Always true, just checking no exception
 
 
+def test_library_clean_command_prints_summary_once_when_something_removed(
+    runner: CliRunner,
+    testlib_with_artifacts: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The "Cleanup completed" summary line is printed exactly once, not twice
+    (regression test for a copy-paste bug where the summary block was duplicated)."""
+    monkeypatch.chdir(testlib_with_artifacts)
+
+    result = runner.invoke(app, ["library", "clean"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("Cleanup completed") == 1
+
+
+def test_library_clean_command_prints_summary_once_when_already_clean(
+    runner: CliRunner,
+    clean_testlib: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The "already clean" summary line is printed exactly once, not twice
+    (regression test for a copy-paste bug where the summary block was duplicated)."""
+    monkeypatch.chdir(clean_testlib)
+
+    result = runner.invoke(app, ["library", "clean"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("already clean") == 1
+
+
 def test_library_clean_command_partial_cleanup_real(
     runner: CliRunner,
     clean_testlib: Path,

--- a/tests/integration/test_library_lint_format.py
+++ b/tests/integration/test_library_lint_format.py
@@ -55,6 +55,25 @@ def test_lint_passes_on_clean_code(
     assert not (lint_project / ".mypy.ini").exists()
 
 
+def test_lint_does_not_swallow_non_oareporerror_exceptions(
+    runner: CliRunner, lint_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-OARepoError raised by LintRunner propagates instead of being turned into a
+    clean "exit 1" -- regression test for narrowing library.py's except clauses from
+    the previous blanket `except Exception` to `except OARepoError` (Step 4.12)."""
+    monkeypatch.chdir(lint_project)
+
+    def _raise_value_error(_self: object, **_kwargs: object) -> None:
+        raise ValueError("boom")
+
+    monkeypatch.setattr("oarepo_cli.cli.library.LintRunner.run_lint", _raise_value_error)
+
+    result = runner.invoke(app, ["library", "lint", "--quiet"])
+
+    assert isinstance(result.exception, ValueError)
+    assert "❌ Error running linters" not in result.output
+
+
 def test_lint_fixes_autofixable_violation_by_default(
     runner: CliRunner, lint_project: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -245,6 +245,27 @@ def test_index_rebuild_reports_error_and_exits_1(
     assert "Index rebuild failed" in result.output
 
 
+def test_index_rebuild_does_not_swallow_non_oareporerror_exceptions(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-OARepoError raised by rebuild_index propagates instead of being turned
+    into a clean "exit 1" -- regression test locking in repository.py's existing,
+    narrow except OARepoError (simplified from except (OARepoError,
+    ProcessExecutionError) in Step 4.12, since ProcessExecutionError already
+    subclasses OARepoError)."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.rebuild_index",
+        Mock(side_effect=ValueError("boom")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "index", "rebuild"])
+
+    assert isinstance(result.exception, ValueError)
+    assert "Index rebuild failed" not in result.output
+
+
 # --- repository reset ----------------------------------------------------
 
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from oarepo_cli.core.config import CliConfig, VenvConfig
-from oarepo_cli.core.context import ContextBuilder, discover_context
+from oarepo_cli.core.context import ContextBuilder, discover_context, find_pyproject_toml
 from oarepo_cli.core.errors import ConfigurationError
 
 
@@ -312,6 +312,40 @@ dependencies = ["oarepo>=14.0.0,<15.0.0"]
         assert context.pyproject_path == tmp_path / "pyproject.toml"
     finally:
         monkeypatch.undo()
+
+
+def test_find_pyproject_toml_in_given_directory(tmp_path: Path) -> None:
+    """find_pyproject_toml() finds a pyproject.toml directly in the given directory."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+    assert find_pyproject_toml(tmp_path) == tmp_path / "pyproject.toml"
+
+
+def test_find_pyproject_toml_searches_parents(tmp_path: Path) -> None:
+    """find_pyproject_toml() searches upward through parent directories."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    subdir = tmp_path / "subdir" / "nested"
+    subdir.mkdir(parents=True)
+
+    assert find_pyproject_toml(subdir) == tmp_path / "pyproject.toml"
+
+
+def test_find_pyproject_toml_returns_none_when_not_found(tmp_path: Path) -> None:
+    """find_pyproject_toml() returns None (not an exception) when nothing is found."""
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    assert find_pyproject_toml(subdir) is None
+
+
+def test_find_pyproject_toml_defaults_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """find_pyproject_toml() defaults to searching from the current working directory."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert find_pyproject_toml() == tmp_path / "pyproject.toml"
 
 
 def test_multi_version_selects_highest_by_default(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements the four planned bugfixes from #134 (Steps 4.11-4.14), each as its own commit:

- **Step 4.11** — `library clean` had its entire "Display summary" if/else block duplicated verbatim (copy-paste bug), printing the summary twice on every run. Removed the duplicate; added regression tests.
- **Step 4.12** — Unified exception handling: `library.py`'s 12 top-level command handlers caught broad `except Exception` (silently turning real bugs into a misleading clean "exit 1"); narrowed to `except OARepoError`, matching `repository.py`. Also simplified `repository.py`'s redundant `except (OARepoError, ProcessExecutionError)` to plain `except OARepoError` (`ProcessExecutionError` already subclasses it). Left `library.py`'s other 5 `except Exception` sites alone — those are a different, correct pattern (best-effort, warn-and-continue steps in `library_clean`/`library_upgrade`), now commented to explain why. Also dropped a manual `isinstance(e, typer.Exit)` guard in `library_test` that's no longer needed once the catch is narrowed. Verified via the full suite (478 passed) and added a regression test per module.
- **Step 4.13** — `library oarepo-versions` was the only command hand-rolling its own `pyproject.toml` directory walk instead of using `discover_context()`, with function-local imports. Confirmed `discover_context()` doesn't actually fit (it requires a resolvable OARepo version + Python binary, but `oarepo-versions` must work for a project with no `oarepo` dependency at all — an existing test covers this). Extracted the walk into a new `core.context.find_pyproject_toml()` helper (also adopted by `ContextBuilder.from_cwd()`, removing its own duplicate copy), and hoisted the remaining imports to module level.
- **Step 4.14** — Moved `library_shell`'s function-local `import traceback` to module level. Turns out `TID251`'s rule family isn't even enabled in this project's ruff config, so the `# noqa` was already a no-op.

`implementation-steps.md` is updated with `[x]` on all action items plus deviation notes for each step.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] Full `make test` — 484 passed (run twice, after 4.12 and again at the end)