### PR TITLE
Step 4.15: Multi-module source-directory detection for uv_build repositories

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1538,11 +1538,11 @@ i.e. one directory per entry in `module-name`, resolved relative to
 `module-root` (empty string means the project root itself) -- unlike a
 library's single `src/`or `<package_name>/` directory.
 
-- [ ] Add a typed accessor to `PyProjectData` (`services/pyproject_reader.py`)
+- [x] Add a typed accessor to `PyProjectData` (`services/pyproject_reader.py`)
   for `[tool.uv.build-backend]`'s `module-name` (list of strings, default
   `[]`) and `module-root` (string, default `""`), following the existing
   pattern used for `default_extras`
-- [ ] Extend `ProjectContext.code_directories` (`core/context.py`) with a new
+- [x] Extend `ProjectContext.code_directories` (`core/context.py`) with a new
   detection branch, in this precedence order:
   1. `src/` (existing)
   2. **New**: `[tool.uv.build-backend].module-name` non-empty -> one
@@ -1552,20 +1552,42 @@ library's single `src/`or `<package_name>/` directory.
   4. `[tool.hatch.build.targets.wheel].packages[0]` (existing)
   5. Else raise `ConfigurationError` (existing)
   `tests/` is still appended afterwards if present, unchanged.
-- [ ] Fix `LintRunner.run_lint()`'s `ty check` invocation
+- [x] Fix `LintRunner.run_lint()`'s `ty check` invocation
   (`services/lint.py`): it currently passes only `code_directories[0]` --
   correct today because a library's `code_directories` only ever has one
   source entry (plus `tests/`), but silently wrong for a multi-module
   repository, which would only ever type-check the first module. Pass every
   non-`tests` entry in `code_directories` instead.
-- [ ] Verify `check_license_headers()`/`check_future_annotations()`
+- [x] Verify `check_license_headers()`/`check_future_annotations()`
   (`services/lint.py`) and `run_jslint()` (`services/js_tools.py`) already
   iterate over the full `code_directories` list (they do, as of this
   writing) -- no change needed there, just confirm during review
-- [ ] Add unit tests for the new `PyProjectData` accessor and the new
+- [x] Add unit tests for the new `PyProjectData` accessor and the new
   `code_directories` branch, and an integration-level test against the real
   `tests/testrepo/pyproject.toml` fixture asserting `code_directories`
   resolves to `[common/, i18n/, ui/]` (plus `tests/` if present)
+
+**Deviations from the original plan**:
+- The `src/` vs. `module-name` vs. flat-layout precedence is enforced with
+  `if`/`elif`/`else`, not three independent checks -- a repository's project
+  name never coincides with an existing top-level directory in practice, so
+  this is mostly a documentation clarification of intent rather than a
+  behavior difference, but it's now explicit rather than incidental. Both
+  existing library layouts (`src/` and flat/package-name-derived) are
+  unchanged and still take priority over `module-name` when both would
+  apply, verified by dedicated precedence tests.
+- No dedicated `LintRunner` unit test file existed yet (noted as a gap in
+  the original plan text); added `tests/unit/test_lint_service.py` rather
+  than extending the slower, real-tool
+  `tests/integration/test_library_lint_format.py`, to directly assert the
+  exact `ty check` argument list via a mocked `process.run` -- both the
+  multi-directory regression and confirmation that a library's existing
+  single-directory-plus-tests layout is unchanged.
+- The real-fixture test landed as
+  `tests/integration/test_repository_code_directories.py`, a new file: only
+  reads `tests/testrepo`'s real `pyproject.toml`/directories via
+  `ContextBuilder`, no install or services lifecycle involved, so it's fast
+  and side-effect-free despite living in `tests/integration/`.
 
 **Deliverables**:
 - `code_directories` correctly resolves multi-module repository layouts
@@ -1574,11 +1596,13 @@ library's single `src/`or `<package_name>/` directory.
 **Tests**:
 - `tests/unit/test_pyproject_reader.py`: new accessor, default when absent
 - `tests/unit/test_context.py`: `code_directories` precedence order,
-  including the new `module-name` branch
-- `tests/integration/test_library_lint_format.py`-style coverage, extended
-  or mirrored, for `ty check` being invoked with all non-`tests` code
-  directories, not just the first (currently only covered at the
-  integration level, no dedicated `LintRunner` unit test file exists yet)
+  including the new `module-name` branch, and that `src/`/flat-layout still
+  win over it when present (backwards compatibility)
+- `tests/unit/test_lint_service.py`: `ty check` invoked with every
+  non-`tests` code directory, not just the first, and that a library's
+  existing single-directory layout still passes exactly that one directory
+- `tests/integration/test_repository_code_directories.py`: `code_directories`
+  resolves the real `tests/testrepo` fixture's `["common", "i18n", "ui"]`
 
 ---
 

--- a/oarepo_cli/core/context.py
+++ b/oarepo_cli/core/context.py
@@ -38,25 +38,44 @@ class ProjectContext:
     def code_directories(self) -> list[Path]:
         """Source and test directories to lint/type-check/format.
 
-        Mirrors ``library_runner.sh``'s ``code_directories`` detection:
-        prefer a top-level ``src/`` directory, else the package's own
-        top-level directory (derived from the project name, or from
+        Mirrors ``library_runner.sh``'s ``code_directories`` detection for a
+        library project: prefer a top-level ``src/`` directory (the "src
+        layout"), else the package's own top-level directory derived from
+        the project name (the "flat layout"), or from
         ``[tool.hatch.build.targets.wheel].packages`` if that doesn't exist
-        either), plus ``tests/`` if present.
+        either -- both preserved exactly, unchanged.
+
+        A repository project built with the ``uv_build`` backend has no
+        bash equivalent to mirror: it declares its source as several
+        top-level module directories in ``[tool.uv.build-backend]``'s
+        ``module-name`` (e.g. ``["common", "i18n", "ui"]``) instead of a
+        single ``src/``/package directory. Checked between the ``src/`` and
+        flat-layout checks -- a repository's project name never matches an
+        existing top-level directory anyway, but this keeps the precedence
+        explicit rather than relying on that coincidence.
+
+        ``tests/`` is appended afterwards if present, for either kind of
+        project.
 
         Returns:
             List of existing directories to process
 
         Raises:
-            ConfigurationError: If neither ``src/`` nor a package directory can be found
+            ConfigurationError: If none of the above can be found
         """
         pyproject_data = PyProjectReader().read(self.pyproject_path)
 
         directories: list[Path] = []
 
         src_dir = self.root_directory / "src"
+        module_names = pyproject_data.uv_build_module_names
         if src_dir.is_dir():
             directories.append(src_dir)
+        elif module_names:
+            module_root = self.root_directory / pyproject_data.uv_build_module_root
+            directories.extend(
+                module_root / name for name in module_names if (module_root / name).is_dir()
+            )
         else:
             top_level = pyproject_data.name.replace("-", "_")
             package_dir = self.root_directory / top_level

--- a/oarepo_cli/services/lint.py
+++ b/oarepo_cli/services/lint.py
@@ -173,6 +173,12 @@ class LintRunner:
 
         _write_config(root / "ty.toml", resources.read_text("ty.toml.tmpl"))
 
+        # Every source directory, not just the first: a library's
+        # code_directories only ever has one (plus tests/), but a
+        # multi-module repository (see ProjectContext.code_directories) has
+        # several, and ty needs to see all of them, not just the first.
+        source_directories = [d for d in code_directories if d.name != "tests"]
+
         venv_python = self._context.venv_path / "bin" / "python"
         return process.run(
             [
@@ -181,7 +187,7 @@ class LintRunner:
                 *fix_flag,
                 "--python",
                 str(venv_python),
-                str(code_directories[0]),
+                *(str(d) for d in source_directories),
             ],
             cwd=root,
             check=False,

--- a/oarepo_cli/services/pyproject_reader.py
+++ b/oarepo_cli/services/pyproject_reader.py
@@ -106,6 +106,30 @@ class PyProjectData:
         """Default extras to always install, from [tool.oarepo].default_extras."""
         return self.raw.get("tool", {}).get("oarepo", {}).get("default_extras", [])
 
+    @property
+    def uv_build_module_names(self) -> list[str]:
+        """Module names from [tool.uv.build-backend].module-name, if any.
+
+        Repositories built with the ``uv_build`` backend declare their
+        source as several top-level module directories here (e.g.
+        ``["common", "i18n", "ui"]``), unlike a library's single ``src/``
+        or ``<package_name>/`` directory. Empty if the project uses a
+        different build backend or doesn't set this key.
+        """
+        return (
+            self.raw.get("tool", {}).get("uv", {}).get("build-backend", {}).get("module-name", [])
+        )
+
+    @property
+    def uv_build_module_root(self) -> str:
+        """Root prefix for `uv_build_module_names`, from [tool.uv.build-backend].module-root.
+
+        Defaults to "" (project root itself), matching ``uv_build``'s own default.
+        """
+        return (
+            self.raw.get("tool", {}).get("uv", {}).get("build-backend", {}).get("module-root", "")
+        )
+
 
 def _extract_oarepo_version_from_specifier(dep_spec: str) -> int | None:
     """Extract major version from an oarepo dependency specifier.

--- a/tests/integration/test_repository_code_directories.py
+++ b/tests/integration/test_repository_code_directories.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration test for ProjectContext.code_directories against the real, checked-in
+tests/testrepo fixture -- a real repository project built with the uv_build backend's
+multi-module [tool.uv.build-backend] layout (Step 4.15), rather than a library's
+single src/-or-package-dir layout.
+
+Only reads testrepo_project's real pyproject.toml/directories -- no install, no
+services, so it's safe to run alongside a real, separately-running repository.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from oarepo_cli.core.context import ContextBuilder
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_code_directories_resolves_real_testrepo_uv_build_modules(
+    testrepo_project: Path,
+) -> None:
+    """code_directories resolves testrepo's real [tool.uv.build-backend].module-name
+    (["common", "i18n", "ui"]) rather than raising or guessing a single package dir."""
+    context = ContextBuilder().from_directory(testrepo_project).validate()
+
+    assert context.code_directories == [
+        testrepo_project / "common",
+        testrepo_project / "i18n",
+        testrepo_project / "ui",
+    ]

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -72,6 +72,107 @@ dependencies = ["oarepo>=14.0.0,<15.0.0"]
     assert context.code_directories == [tmp_path / "src", tmp_path / "tests"]
 
 
+def test_computed_properties_code_directories_uv_build_modules(tmp_path: Path) -> None:
+    """code_directories resolves every [tool.uv.build-backend].module-name entry,
+    matching a real repository's multi-module uv_build layout (tests/testrepo)."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-repository"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["common", "i18n", "ui"]
+"""
+    )
+    (tmp_path / "common").mkdir()
+    (tmp_path / "i18n").mkdir()
+    (tmp_path / "ui").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    assert context.code_directories == [
+        tmp_path / "common",
+        tmp_path / "i18n",
+        tmp_path / "ui",
+        tmp_path / "tests",
+    ]
+
+
+def test_computed_properties_code_directories_uv_build_modules_skips_missing(
+    tmp_path: Path,
+) -> None:
+    """A declared module-name entry that doesn't exist on disk is silently skipped,
+    rather than raising -- e.g. a module not yet scaffolded."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-repository"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["common", "not-yet-created"]
+"""
+    )
+    (tmp_path / "common").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    assert context.code_directories == [tmp_path / "common"]
+
+
+def test_computed_properties_code_directories_src_takes_priority_over_uv_build_modules(
+    tmp_path: Path,
+) -> None:
+    """src/, when present, wins over [tool.uv.build-backend].module-name."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-repository"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["common"]
+"""
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "common").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    assert context.code_directories == [tmp_path / "src"]
+
+
+def test_computed_properties_code_directories_uv_build_module_root_prefix(
+    tmp_path: Path,
+) -> None:
+    """A non-empty module-root prefixes every module-name entry."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-repository"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+
+[tool.uv.build-backend]
+module-root = "packages"
+module-name = ["common"]
+"""
+    )
+    (tmp_path / "packages" / "common").mkdir(parents=True)
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    assert context.code_directories == [tmp_path / "packages" / "common"]
+
+
 def test_computed_properties_code_directories_package_layout(tmp_path: Path) -> None:
     """Test code_directories falls back to the package's own top-level directory."""
     (tmp_path / "pyproject.toml").write_text(

--- a/tests/unit/test_lint_service.py
+++ b/tests/unit/test_lint_service.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for oarepo_cli.services.lint.LintRunner.
+
+Mocks process.run so these run fast against a fake ruff/ty, unlike
+tests/integration/test_library_lint_format.py's real-tool coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.services import process
+from oarepo_cli.services.lint import LintRunner
+
+
+@pytest.fixture
+def mock_context(tmp_path: Path) -> Mock:
+    """A mock ProjectContext with real, empty code directories (so the
+    license-header/future-annotations checks -- which glob real files --
+    find nothing and don't block reaching the ty check step)."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    return context
+
+
+def _fake_process_result(**overrides: object) -> process.ProcessResult:
+    defaults: dict[str, object] = {
+        "return_code": 0,
+        "stdout": "",
+        "stderr": "",
+        "command": [],
+        "cwd": Path(),
+        "duration_ms": 0,
+    }
+    defaults.update(overrides)
+    return process.ProcessResult(**defaults)  # type: ignore[arg-type]
+
+
+def test_run_lint_ty_check_covers_every_module_directory(
+    tmp_path: Path, mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ty check is invoked with every non-tests code directory, not just the first --
+    regression test for a multi-module repository (Step 4.15): the old code only ever
+    passed code_directories[0], which for a library (always a single source dir) is
+    harmless, but for a repository's several module directories would silently skip
+    all but the first."""
+    common = tmp_path / "common"
+    i18n = tmp_path / "i18n"
+    ui = tmp_path / "ui"
+    tests_dir = tmp_path / "tests"
+    for directory in (common, i18n, ui, tests_dir):
+        directory.mkdir()
+    mock_context.code_directories = [common, i18n, ui, tests_dir]
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.lint.process.run", fake_run)
+
+    runner = LintRunner(context=mock_context, quiet=True)
+    runner.run_lint()
+
+    ty_call = next(call for call in calls if call[0].endswith("ty"))
+    assert str(common) in ty_call
+    assert str(i18n) in ty_call
+    assert str(ui) in ty_call
+    assert str(tests_dir) not in ty_call
+
+
+def test_run_lint_ty_check_single_directory_matches_library_layout(
+    tmp_path: Path, mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A library's usual single-source-dir-plus-tests layout still passes exactly
+    that one source directory to ty, unchanged from before Step 4.15."""
+    src = tmp_path / "src"
+    tests_dir = tmp_path / "tests"
+    src.mkdir()
+    tests_dir.mkdir()
+    mock_context.code_directories = [src, tests_dir]
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.lint.process.run", fake_run)
+
+    runner = LintRunner(context=mock_context, quiet=True)
+    runner.run_lint()
+
+    ty_call = next(call for call in calls if call[0].endswith("ty"))
+    assert str(src) in ty_call
+    assert str(tests_dir) not in ty_call

--- a/tests/unit/test_pyproject_reader.py
+++ b/tests/unit/test_pyproject_reader.py
@@ -224,6 +224,38 @@ default_extras = ["dev", "tests"]
     assert data.default_extras == ["dev", "tests"]
 
 
+def test_extracts_uv_build_module_names_and_root(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-repository"
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["common", "i18n", "ui"]
+"""
+    )
+
+    data = pyproject_reader.PyProjectReader().read(tmp_path / "pyproject.toml")
+
+    assert data.uv_build_module_names == ["common", "i18n", "ui"]
+    assert data.uv_build_module_root == ""
+
+
+def test_uv_build_module_names_and_root_default_when_absent(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-package"
+"""
+    )
+
+    data = pyproject_reader.PyProjectReader().read(tmp_path / "pyproject.toml")
+
+    assert data.uv_build_module_names == []
+    assert data.uv_build_module_root == ""
+
+
 def test_missing_file_raises_configuration_error(tmp_path: Path) -> None:
     with pytest.raises(ConfigurationError) as exc_info:
         pyproject_reader.PyProjectReader().read(tmp_path / "nonexistent.toml")


### PR DESCRIPTION
## Summary
- `ProjectContext.code_directories` (`core/context.py`) now also recognizes a repository built with the `uv_build` backend, which declares its source as several top-level module directories via `[tool.uv.build-backend]`'s `module-name` list (e.g. `["common", "i18n", "ui"]` — see the real `tests/testrepo/pyproject.toml` fixture), instead of a single `src/`/package directory.
- Added `PyProjectData.uv_build_module_names`/`uv_build_module_root` accessors (`services/pyproject_reader.py`).
- **Backwards compatible**: the new branch is checked between the existing `src/` check and the existing flat/package-name-derived layout check — both existing library layouts are unchanged and still take priority over `module-name` when present. Verified with dedicated precedence tests (`src/` wins; flat layout still works when `module-name` is absent).
- Fixes a latent bug this generalization surfaced: `LintRunner.run_lint()`'s `ty check` only ever passed `code_directories[0]` — harmless for a library (always exactly one source entry plus `tests/`) but would silently type-check only the first module for a multi-module repository. Now passes every non-`tests` directory.
- This is a prerequisite for Steps 4.18-4.19 (porting `repository lint`/`format`/`check`/`jslint`/`jstest`), which all consume `code_directories`.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] New unit tests: `PyProjectData` accessors, `code_directories` precedence (including that `src/`/flat layout still win over `module-name`), `LintRunner`'s `ty check` argument list (multi-directory + unchanged single-directory case)
- [x] New integration test against the real `tests/testrepo` fixture (no install/services involved, so it's fast and safe alongside a running repository)
- [x] Full `make test` — 493 passed