### PR TITLE
Step 4.16: Repository invenio command

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`local`](#repository-local) | Manage local package dependencies | ✅ Implemented |
 | [`run`](#repository-run) | Start repository server | ✅ Implemented |
 | [`cli`](#repository-cli) | Delegate to invenio-cli | ✅ Implemented |
+| [`invenio`](#repository-invenio) | Delegate to the venv's own bare invenio | ✅ Implemented |
 | [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
 | [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
 | [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
@@ -714,6 +715,24 @@ oarepo-cli repository cli --help
 
 **Exit codes:**
 - Whatever invenio-cli itself exits with
+- `1`: Project context could not be discovered
+
+### `repository invenio`
+
+Pure passthrough to the venv's own `invenio` binary (bare invenio, not invenio-cli -- see [`repository cli`](#repository-cli) for that): replaces this process (`os.execve`) with `invenio <args>`, so `--help` reaches invenio's own help (not oarepo-cli's), and the exit code is preserved exactly.
+
+```bash
+oarepo-cli repository invenio [invenio_args...]
+```
+
+**Examples:**
+```bash
+oarepo-cli repository invenio db upgrade
+oarepo-cli repository invenio --help
+```
+
+**Exit codes:**
+- Whatever invenio itself exits with
 - `1`: Project context could not be discovered
 
 ### `repository translations`

--- a/docs/architecture/00-main-architecture.md
+++ b/docs/architecture/00-main-architecture.md
@@ -176,6 +176,7 @@ extras now get all versions reported, restoring the bash script's capability.
 | `local` | `add <path>`, `remove <name>\|--all>` | Local package management | Must preserve |
 | `run` | `--no-services`, `--no-celery` | Start repository server | Must preserve |
 | `cli` | `[subcommand...]` | Delegates to invenio-cli | Must preserve |
+| `invenio` | `[subcommand...]` | Delegates to the venv's own bare invenio (not invenio-cli) | Must preserve |
 | `translations` | `compile` | Backend translations only | Must preserve |
 | `index` | `rebuild` | Rebuild search index | Must preserve |
 | `reset` | - | Full reset with confirmation prompt | Must preserve |

--- a/docs/architecture/03-migration-guide.md
+++ b/docs/architecture/03-migration-guide.md
@@ -93,6 +93,7 @@ oarepo-cli library test
 | `./run.sh run --no-services` | `oarepo-cli repository run --no-services` | Same flag |
 | `./run.sh run --no-celery` | `oarepo-cli repository run --no-celery` | Same flag |
 | `./run.sh cli <subcommand>` | `oarepo-cli repository cli <subcommand>` | Identical behavior |
+| `./run.sh invenio <args>` | `oarepo-cli repository invenio <args>` | Identical behavior (added in Step 4.16 -- previously unported, see `after_repository_cleanup.md` §3.1) |
 | `./run.sh translations` | `oarepo-cli repository translations` | Identical behavior |
 | `./run.sh translations compile` | `oarepo-cli repository translations compile` | Identical behavior |
 | `./run.sh index rebuild` | `oarepo-cli repository index rebuild` | Identical behavior |

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1615,7 +1615,7 @@ unported bash capability in the post-Phase-4 audit
 `invenio-cli`); `library invenio` already has a direct analog, `repository`
 never got one.
 
-- [ ] Add `repository invenio` to `cli/repository.py`: a pure passthrough
+- [x] Add `repository invenio` to `cli/repository.py`: a pure passthrough
   to the venv's own `invenio` binary, process-replacing (`os.execve`/
   `os.execvpe`) like `repository cli` does via `invenio_cli.exec_invenio_cli`
   -- so `--help` reaches `invenio`'s own help and the exit code is preserved
@@ -1625,22 +1625,32 @@ never got one.
   `exec_invenio_cli`) rather than the current blocking `_run_invenio()`,
   since this is a one-shot interactive command like `cli`, not a sequence of
   internal calls
-- [ ] Use the same `_SERVICES_CONTEXT_SETTINGS` context settings as `cli`/
+- [x] Use the same `_SERVICES_CONTEXT_SETTINGS` context settings as `cli`/
   `translations` (`allow_extra_args`, `ignore_unknown_options`,
   `help_option_names: []`) so arbitrary `invenio` subcommands and `--help`
   both pass through untouched
-- [ ] Update `03-migration-guide.md`'s repository command table and
+- [x] Update `03-migration-guide.md`'s repository command table and
   `00-main-architecture.md` §1.3 to list `invenio` alongside `cli`
+
+**Deviation from the original plan**: added a standalone
+`services.repository.exec_invenio()` function (not a shared helper with
+`invenio_cli.exec_invenio_cli`) -- the two exec bare, different binaries
+(`invenio` vs. `invenio-cli`) with different env needs (`PYTHONWARNINGS=
+ignore`, mirroring bash's `run_invenio()`, vs. invenio-cli's
+`UV_PRERELEASE` handling), so sharing would have meant a parameterized
+helper for two one-line call sites -- not worth the indirection. Mirrors
+`ServerRunner._exec_bare_invenio`'s identical approach for `invenio run`
+specifically.
 
 **Deliverables**:
 - `oarepo-cli repository invenio <args>` mirrors `run.sh invenio <args>`
 
 **Tests** (mirroring `tests/integration/test_repository_misc.py`'s existing
 `cli` coverage):
-- [ ] Test forwards arbitrary args to the venv's `invenio` binary
-- [ ] Test `--help` reaches `invenio`'s own help output
-- [ ] Test exit code is preserved exactly
-- [ ] Test failure when project context can't be discovered
+- [x] Test forwards arbitrary args to the venv's `invenio` binary
+- [x] Test `--help` reaches `invenio`'s own help output
+- [x] Test exit code is preserved exactly
+- [x] Test failure when project context can't be discovered
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -541,6 +541,34 @@ def cli_command(ctx: typer.Context) -> None:
     invenio_cli.exec_invenio_cli(context, ctx.args)
 
 
+@repository_app.command("invenio", context_settings=_SERVICES_CONTEXT_SETTINGS)
+def invenio_command(ctx: typer.Context) -> None:
+    """Run an arbitrary bare invenio command in the repository's virtual environment.
+
+    Pure passthrough to the venv's own ``invenio`` binary (not
+    ``invenio-cli`` -- see ``repository cli`` for that): replaces this
+    process (``os.execve``) with ``invenio <args>``, so ``--help`` reaches
+    invenio's own help (not oarepo-cli's), and the exit code is preserved
+    exactly.
+
+    Examples:
+        $ oarepo-cli repository invenio db upgrade
+        $ oarepo-cli repository invenio --help
+
+    Exit codes:
+        Whatever invenio itself exits with
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository invenio failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    repository.exec_invenio(context, ctx.args)
+
+
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)
 def translations_command(
     ctx: typer.Context,

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -9,7 +9,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import invenio_cli, process, translations
@@ -355,6 +355,35 @@ def get_invenio_binary(context: ProjectContext) -> Path:
     """Resolve the path to the venv's own ``invenio`` binary (bare, not ``invenio-cli``)."""
     bin_dir = get_platform_detector().get_venv_bin_dir()
     return context.venv_path / bin_dir / "invenio"
+
+
+def exec_invenio(context: ProjectContext, args: Sequence[str]) -> NoReturn:
+    """Replace the current process with the venv's own ``invenio`` binary. Never returns.
+
+    Mirrors ``repository_runner.sh``'s ``run_invenio()`` (``export
+    PYTHONWARNINGS=ignore; activate_venv; invenio "$@"``): a pure, one-shot
+    passthrough to the bare ``invenio`` CLI (not ``invenio-cli``, which
+    ``invenio_cli.exec_invenio_cli`` handles), like ``cli/library.py``'s
+    ``library_invenio``. Process replacement (``os.execve``) lets a
+    terminal Ctrl+C hit ``invenio`` directly, exactly as if the user had
+    run it themselves, and preserves its exit code exactly -- mirrors
+    ``ServerRunner._exec_bare_invenio``'s same approach for ``invenio run``
+    specifically.
+
+    Args:
+        context: Project context with paths and configuration -- also
+            ``chdir``s into ``context.root_directory`` first, since
+            ``execve`` has no ``cwd`` parameter of its own
+        args: Arguments to pass to ``invenio``
+
+    Raises:
+        OSError: If the invenio binary can't be exec'd (not found, not
+            executable, ...)
+    """
+    os.chdir(context.root_directory)
+    binary = get_invenio_binary(context)
+    env = {**os.environ, "PYTHONWARNINGS": "ignore"}
+    os.execve(str(binary), [str(binary), *args], env)
 
 
 def _run_invenio(context: ProjectContext, args: Sequence[str], *, quiet: bool = False) -> None:

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -100,6 +100,58 @@ def test_cli_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) 
     assert result.exit_code == 1
 
 
+# --- repository invenio -------------------------------------------------
+
+
+def test_invenio_delegates_to_exec_invenio(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository invenio <args>` execs the bare invenio binary with the given args
+    verbatim (not invenio-cli -- see `repository cli` for that)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.exec_invenio",
+        lambda context, args, **_kwargs: calls.append({"context": context, "args": list(args)}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "invenio", "db", "upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "args": ["db", "upgrade"]}]
+
+
+def test_invenio_help_forwarded_to_invenio(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--help is forwarded to invenio rather than intercepted by Typer/Click."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.exec_invenio",
+        lambda _context, args, **_kwargs: calls.append({"args": list(args)}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "invenio", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"args": ["--help"]}]
+
+
+def test_invenio_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "invenio", "db", "upgrade"])
+
+    assert result.exit_code == 1
+
+
 # --- repository translations -------------------------------------------
 
 

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -261,6 +261,35 @@ def test_get_invenio_binary_resolves_venv_bin_dir(tmp_path: Path) -> None:
     assert repository.get_invenio_binary(context) == tmp_path / ".venv" / bin_dir / "invenio"
 
 
+def test_exec_invenio_chdirs_and_execs_resolved_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exec_invenio() chdirs into the project root first (execve has no cwd of its own),
+    then execve's into the venv's own invenio binary with args appended, setting
+    PYTHONWARNINGS=ignore like repository_runner.sh's run_invenio()."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+
+    chdir_calls = []
+    execve_calls = []
+    monkeypatch.setattr("oarepo_cli.services.repository.os.chdir", chdir_calls.append)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+
+    repository.exec_invenio(context, ["db", "upgrade"])
+
+    assert chdir_calls == [tmp_path]
+    assert len(execve_calls) == 1
+    binary, argv, env = execve_calls[0]
+    expected_binary = str(repository.get_invenio_binary(context))
+    assert binary == expected_binary
+    assert argv == [expected_binary, "db", "upgrade"]
+    assert env["PYTHONWARNINGS"] == "ignore"
+
+
 def test_rebuild_index_runs_expected_invenio_sequence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds `oarepo-cli repository invenio <args>` — a bare-`invenio` passthrough mirroring `repository_runner.sh`'s `run.sh invenio <args>` (`export PYTHONWARNINGS=ignore; activate_venv; invenio "$@"`), a real bash capability that was never ported (identified in the post-Phase-4 parity audit). Distinct from `repository cli`, which delegates to `invenio-cli`; `library invenio` already had a direct analog, `repository` never did.
- Adds `services.repository.exec_invenio()`: process-replaces (`os.execve`) with the venv's own `invenio` binary — same approach as `ServerRunner._exec_bare_invenio` (`invenio run` specifically) and `invenio_cli.exec_invenio_cli` (`invenio-cli`), so `--help` reaches invenio's own help and the exit code is preserved exactly.
- Wired into `cli/repository.py` with the same `_SERVICES_CONTEXT_SETTINGS` as `cli`/`translations`, so arbitrary `invenio` subcommands and `--help` pass through untouched.
- Updates `README.md`, `00-main-architecture.md`, and `03-migration-guide.md` to document the new command.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] New tests: CLI delegation, `--help` passthrough, context-discovery failure (mirroring `repository cli`'s existing coverage), plus a unit test for `exec_invenio()`'s chdir/execve/env
- [x] Full `make test` — 497 passed