### PR TITLE
Step 4.17: Repository shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`run`](#repository-run) | Start repository server | ✅ Implemented |
 | [`cli`](#repository-cli) | Delegate to invenio-cli | ✅ Implemented |
 | [`invenio`](#repository-invenio) | Delegate to the venv's own bare invenio | ✅ Implemented |
+| [`shell`](#repository-shell) | Start an interactive shell in the venv | ✅ Implemented |
 | [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
 | [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
 | [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
@@ -734,6 +735,30 @@ oarepo-cli repository invenio --help
 **Exit codes:**
 - Whatever invenio itself exits with
 - `1`: Project context could not be discovered
+
+### `repository shell`
+
+Starts an interactive bash shell with the repository's virtual environment activated. By default, Docker services are started first (via `invenio-cli services start`, like [`repository run`](#repository-run)) -- use `--no-services` to skip, e.g. if they're already running. This command replaces the current process (`os.execve`) with the shell -- it never returns on success.
+
+Unlike [`library shell`](#library-shell), no environment variables are loaded from an `.env-services` file: a repository resolves its own service connection details from `invenio.cfg`/`.invenio.private` instead.
+
+```bash
+oarepo-cli repository shell
+```
+
+**Options:**
+- `--no-services`: Don't start Docker services first
+- `--quiet` / `-q`: Suppress output from starting Docker services
+
+**Examples:**
+```bash
+oarepo-cli repository shell
+oarepo-cli repository shell --no-services
+```
+
+**Exit codes:**
+- Whatever the shell itself exits with
+- `1`: Starting Docker services failed, or project context could not be discovered
 
 ### `repository translations`
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1660,12 +1660,12 @@ specifically.
 `repository_runner.sh` never had a `shell` subcommand. Added for
 library/repository UX parity, not bash compatibility.
 
-- [ ] Add `repository shell` to `cli/repository.py`: opens an interactive
+- [x] Add `repository shell` to `cli/repository.py`: opens an interactive
   bash shell with the venv activated (`VIRTUAL_ENV`/`PATH`), mirroring
   `library_shell`'s environment setup (`VIRTUAL_ENV_PROMPT`, fallback `PS1`,
   dropping inherited `PROMPT_COMMAND`, silencing macOS's bash deprecation
   nag) and process-replacement via `os.execve`
-- [ ] **Decide the services-lifecycle question before implementing**:
+- [x] **Decide the services-lifecycle question before implementing**:
   `library shell` starts services via `ServicesLifecycleManager`
   (docker-services-cli directly) and loads `.env-services` into the shell's
   environment, because a library has no other way to reach its dev
@@ -1681,9 +1681,30 @@ library/repository UX parity, not bash compatibility.
   whether it should mirror `run`'s `--no-services` flag instead of
   `library shell`'s `--skip-services`, for naming consistency with the rest
   of the `repository` command group
-- [ ] Add `--quiet`/`-q` consistent with other `repository` commands
+- [x] Add `--quiet`/`-q` consistent with other `repository` commands
   (`library shell` has none since it's a forced-`quiet=False` passthrough;
   decide whether to match that or the rest of `repository`'s convention)
+
+**Decisions**: confirmed (user input) that an interactive `invenio shell`
+session needs services running, so `repository shell` starts Docker
+services by default, matching `run`'s `--no-services` flag name/default
+rather than `library shell`'s `--skip-services`. `--quiet`/`-q` was added,
+matching the rest of `repository`'s convention rather than `library
+shell`'s forced-non-quiet passthrough. No `.env-services`-equivalent
+loading: a repository never needs it (see `exec_shell()`'s docstring). The
+venv-activation/exec logic itself lives in a new
+`services.repository.exec_shell()` (not inline in `cli/repository.py`),
+matching this module's established thin-CLI-over-a-service-function
+pattern (`exec_invenio`, `rebuild_index`, ...) rather than `library.py`'s
+fully-inline style -- and, like `repository cli`/`invenio`, the exec call
+itself sits outside the `except OARepoError` block, so an `OSError` from a
+failed exec propagates raw rather than being caught and reformatted (unlike
+`library_shell`, which does catch it) -- kept consistent with
+`repository.py`'s own established convention for its other exec-based
+commands rather than mirroring `library_shell` on this specific point.
+`repository install` is assumed already run (the venv is assumed to exist,
+like `cli`/`invenio`/`run`) -- unlike `library_shell`, this command doesn't
+call `ensure_venv_exists()` to create it on demand.
 
 **Deliverables**:
 - `oarepo-cli repository shell` opens an interactive shell in the
@@ -1692,10 +1713,10 @@ library/repository UX parity, not bash compatibility.
 
 **Tests** (mirroring `tests/integration/test_library_misc_commands.py`'s
 `library shell`/`library invenio` coverage where applicable):
-- [ ] Test venv activation env vars are set correctly
-- [ ] Test services are started via the repository's own mechanism, not
+- [x] Test venv activation env vars are set correctly
+- [x] Test services are started via the repository's own mechanism, not
   `ServicesLifecycleManager`
-- [ ] Test failure when project context can't be discovered / venv missing
+- [x] Test failure when project context can't be discovered / venv missing
 
 ---
 

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -569,6 +569,62 @@ def invenio_command(ctx: typer.Context) -> None:
     repository.exec_invenio(context, ctx.args)
 
 
+@repository_app.command("shell")
+def shell_command(
+    no_services: Annotated[
+        bool,
+        typer.Option("--no-services", help="Don't start Docker services first"),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from starting Docker services",
+        ),
+    ] = False,
+) -> None:
+    """Start an interactive bash shell in the repository's virtual environment.
+
+    Opens a bash shell with the virtual environment activated. By default,
+    Docker services are started first (via ``invenio-cli services start``,
+    like ``repository run``) -- use ``--no-services`` to skip, e.g. if
+    they're already running.
+
+    Unlike ``library shell``, no environment variables are loaded from an
+    ``.env-services`` file: a repository resolves its own service
+    connection details from ``invenio.cfg``/``.invenio.private`` instead.
+
+    This command replaces the current process (``os.execve``) with the
+    shell -- it never returns on success.
+
+    Examples:
+        $ oarepo-cli repository shell
+        $ oarepo-cli repository shell --no-services
+
+    Exit codes:
+        Whatever the shell itself exits with
+        1: Starting Docker services failed, or project context could not be
+           discovered
+    """
+    try:
+        context = discover_context()
+
+        console = ConsoleOutput(quiet=quiet)
+        if not no_services:
+            console.info("→ Starting Docker services...\n")
+            invenio_cli.run_invenio_cli(context, ["services", "start"], quiet=quiet)
+
+        console.info("→ Starting bash shell in virtual environment...\n")
+        console.info("  Type 'exit' or press Ctrl+D to exit the shell.\n")
+
+        repository.exec_shell(context)
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ repository shell failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)
 def translations_command(
     ctx: typer.Context,

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -386,6 +386,65 @@ def exec_invenio(context: ProjectContext, args: Sequence[str]) -> NoReturn:
     os.execve(str(binary), [str(binary), *args], env)
 
 
+def exec_shell(context: ProjectContext) -> NoReturn:
+    """Replace the current process with an interactive bash shell in the repository's venv.
+
+    Mirrors ``cli/library.py``'s ``library_shell``'s environment setup
+    (``VIRTUAL_ENV``/``PATH``, ``VIRTUAL_ENV_PROMPT``, a fallback ``PS1``,
+    dropping an inherited ``PROMPT_COMMAND``, silencing macOS's bash
+    deprecation nag) -- but unlike ``library_shell``, doesn't load any
+    ``.env-services`` environment variables: a repository resolves its own
+    service connection details from ``invenio.cfg``/``.invenio.private``
+    (see ``configure_local_ports()``), not from env vars
+    docker-services-cli would write, so there's nothing to load. Docker
+    services themselves are the caller's responsibility (started via
+    ``invenio-cli services start``, like ``repository run``, not
+    ``ServicesLifecycleManager`` -- a repository's services are always
+    managed through invenio-cli, unlike a library's).
+
+    Args:
+        context: Project context with paths and configuration -- also
+            ``chdir``s into ``context.root_directory`` first, since
+            ``execve`` has no ``cwd`` parameter of its own
+
+    Raises:
+        OSError: If the shell can't be exec'd (not found, not executable, ...)
+    """
+    platform = get_platform_detector()
+    bin_dir = platform.get_venv_bin_dir()
+
+    shell_env = dict(os.environ)
+    shell_env["VIRTUAL_ENV"] = str(context.venv_path)
+    venv_bin_path = str(context.venv_path / bin_dir)
+    shell_env["PATH"] = f"{venv_bin_path}{os.pathsep}{shell_env.get('PATH', '')}"
+
+    # Advertise the venv to prompt tools that read it directly (uv's own
+    # activate script sets this too). Use the project name rather than
+    # ".venv" since it's the more useful thing to see in the prompt.
+    shell_env["VIRTUAL_ENV_PROMPT"] = context.root_directory.name
+
+    # Fallback PS1 for plain bash with no prompt tool of its own. Only takes
+    # effect if nothing later in shell startup (rc files, prompt tools that
+    # respect this convention) resets it -- VIRTUAL_ENV_DISABLE_PROMPT lets
+    # users who prefer their own prompt opt out entirely.
+    if "VIRTUAL_ENV_DISABLE_PROMPT" not in shell_env:
+        shell_env["PS1"] = f"({context.root_directory.name}) \\u@\\h:\\w\\$ "
+
+    # Drop PROMPT_COMMAND: prompt tools (e.g. starship) set it to recompute
+    # PS1 before every prompt render, so an inherited value would silently
+    # override PS1 above the moment the first prompt is drawn.
+    shell_env.pop("PROMPT_COMMAND", None)
+
+    # Suppress macOS's "default interactive shell is now zsh" nag: it's
+    # printed on every interactive bash startup and reads like something
+    # went wrong.
+    shell_env["BASH_SILENCE_DEPRECATION_WARNING"] = "1"
+
+    os.chdir(context.root_directory)
+    bash_path = platform.get_default_shell()
+    os.execve(bash_path, ["bash"], shell_env)
+
+
 def _run_invenio(context: ProjectContext, args: Sequence[str], *, quiet: bool = False) -> None:
     """Run a bare ``invenio`` subcommand in the venv, waiting for it to complete.
 

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
-"""Tests for `repository cli`/`translations`/`index rebuild`/`reset`/`info`.
+"""Tests for `repository cli`/`invenio`/`shell`/`translations`/`index rebuild`/`reset`/`info`.
 
 Delegation, argument wiring, and error/exit-code handling are covered here
 by mocking `discover_context()` and the specific service function/module
@@ -150,6 +150,116 @@ def test_invenio_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPat
     result = runner.invoke(app, ["repository", "invenio", "db", "upgrade"])
 
     assert result.exit_code == 1
+
+
+# --- repository shell ----------------------------------------------------
+
+
+def test_shell_starts_services_by_default_then_execs_shell(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository shell` starts Docker services via invenio-cli (like `repository run`,
+    not ServicesLifecycleManager) before exec'ing the shell, by default."""
+    services_calls: list[dict[str, object]] = []
+    shell_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda context, args, **kwargs: services_calls.append(
+            {"context": context, "args": list(args), **kwargs}
+        ),
+    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.repository.exec_shell", shell_calls.append)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "shell"])
+
+    assert result.exit_code == 0, result.output
+    assert services_calls == [
+        {"context": mock_context, "args": ["services", "start"], "quiet": False}
+    ]
+    assert shell_calls == [mock_context]
+
+
+def test_shell_no_services_skips_starting_services(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--no-services skips starting Docker services but still execs the shell."""
+    services_calls: list[object] = []
+    shell_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda *args, **kwargs: services_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.repository.exec_shell", shell_calls.append)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "shell", "--no-services"])
+
+    assert result.exit_code == 0, result.output
+    assert services_calls == []
+    assert shell_calls == [mock_context]
+
+
+def test_shell_quiet_forwarded_to_services_start(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--quiet is forwarded to the services-start invenio-cli call."""
+    services_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda context, args, **kwargs: services_calls.append(
+            {"context": context, "args": list(args), **kwargs}
+        ),
+    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.repository.exec_shell", lambda _context: None)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "shell", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert services_calls[0]["quiet"] is True
+
+
+def test_shell_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "shell"])
+
+    assert result.exit_code == 1
+
+
+def test_shell_reports_services_start_failure_and_never_execs_shell(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ProcessExecutionError starting services is reported cleanly, exit code 1, and
+    the shell is never exec'd."""
+    shell_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        Mock(
+            side_effect=ProcessExecutionError(
+                message="invenio-cli services start failed",
+                command=["invenio-cli", "services", "start"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+        ),
+    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.repository.exec_shell", shell_calls.append)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "shell"])
+
+    assert result.exit_code == 1
+    assert shell_calls == []
 
 
 # --- repository translations -------------------------------------------

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -290,6 +290,43 @@ def test_exec_invenio_chdirs_and_execs_resolved_binary(
     assert env["PYTHONWARNINGS"] == "ignore"
 
 
+def test_exec_shell_sets_up_venv_activation_and_execs_bash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exec_shell() chdirs into the project root, activates the venv (VIRTUAL_ENV/PATH,
+    VIRTUAL_ENV_PROMPT, a fallback PS1), and execve's into the default shell -- without
+    loading any .env-services variables, unlike library_shell."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+
+    monkeypatch.delenv("VIRTUAL_ENV_DISABLE_PROMPT", raising=False)
+    monkeypatch.setenv("PROMPT_COMMAND", "some_prompt_tool")
+
+    chdir_calls = []
+    execve_calls = []
+    monkeypatch.setattr("oarepo_cli.services.repository.os.chdir", chdir_calls.append)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+
+    repository.exec_shell(context)
+
+    assert chdir_calls == [tmp_path]
+    assert len(execve_calls) == 1
+    bash_path, argv, env = execve_calls[0]
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    assert bash_path == get_platform_detector().get_default_shell()
+    assert argv == ["bash"]
+    assert env["VIRTUAL_ENV"] == str(context.venv_path)
+    assert env["PATH"].startswith(str(context.venv_path / bin_dir))
+    assert env["VIRTUAL_ENV_PROMPT"] == tmp_path.name
+    assert env["PS1"] == f"({tmp_path.name}) \\u@\\h:\\w\\$ "
+    assert "PROMPT_COMMAND" not in env
+    assert env["BASH_SILENCE_DEPRECATION_WARNING"] == "1"
+
+
 def test_rebuild_index_runs_expected_invenio_sequence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds `oarepo-cli repository shell` — an interactive bash shell with the repository's venv activated. New command, no bash equivalent (`repository_runner.sh` never had a `shell` subcommand); added for library/repository UX parity.
- Starts Docker services by default (confirmed: an `invenio shell` session needs them), via `invenio-cli services start` like `repository run` — not `ServicesLifecycleManager`, which is library-only. `--no-services` skips this, matching `repository run`'s flag naming rather than `library shell`'s `--skip-services`.
- `--quiet`/`-q` added too, matching the rest of `repository`'s convention (`library shell` has none, since it's a forced non-quiet passthrough).
- Adds `services.repository.exec_shell()`: builds the same venv-activation environment as `library_shell` (`VIRTUAL_ENV`/`PATH`, `VIRTUAL_ENV_PROMPT`, fallback `PS1`, dropped `PROMPT_COMMAND`, macOS bash deprecation nag suppression) but skips `.env-services` loading entirely — a repository resolves its own service connection details from `invenio.cfg`/`.invenio.private` instead. Lives in `services/repository.py`, matching this module's established thin-CLI-over-a-service-function pattern (`exec_invenio`, `rebuild_index`, ...).
- Updates `README.md` to document the new command.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] New tests: services started by default / skipped with `--no-services`, `--quiet` forwarding, context-discovery and services-start failure handling, plus a unit test for `exec_shell()`'s venv-activation env vars
- [x] Full `make test` — 503 passed