### PR TITLE
Step 4.18: Repository lint/format/check commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,9 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`cli`](#repository-cli) | Delegate to invenio-cli | ✅ Implemented |
 | [`invenio`](#repository-invenio) | Delegate to the venv's own bare invenio | ✅ Implemented |
 | [`shell`](#repository-shell) | Start an interactive shell in the venv | ✅ Implemented |
+| [`lint`](#repository-lint) | Run linters and type checkers | ✅ Implemented |
+| [`format`](#repository-format) | Format code with ruff | ✅ Implemented |
+| [`check`](#repository-check) | Read-only equivalent of `lint`+`format` | ✅ Implemented |
 | [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
 | [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
 | [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
@@ -759,6 +762,67 @@ oarepo-cli repository shell --no-services
 **Exit codes:**
 - Whatever the shell itself exits with
 - `1`: Starting Docker services failed, or project context could not be discovered
+
+### `repository lint`
+
+Runs linters and type checkers on the repository's codebase -- ruff check, ruff format, a license header check, a `from __future__ import annotations` check, and ty check, in order, stopping at the first failure. Runs across every module directory declared in `[tool.uv.build-backend]` (or `src/`/the flat layout, if used instead). **By default, auto-fixes** what ruff and ty can fix. Functionally identical to [`library lint`](#library-lint) (both share the same underlying implementation), just operating on a repository's own code.
+
+```bash
+oarepo-cli repository lint
+```
+
+**Options:**
+- `--fix` / `--no-fix`: Auto-fix (default) vs. report-only mode
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Examples:**
+```bash
+oarepo-cli repository lint
+oarepo-cli repository lint --no-fix
+```
+
+**Exit codes:**
+- Exit code of the first failing check
+- `1`: Project context could not be discovered
+
+### `repository format`
+
+Formats the repository's codebase using ruff. **By default, rewrites files**. Functionally identical to [`library format`](#library-format).
+
+```bash
+oarepo-cli repository format
+```
+
+**Options:**
+- `--fix` / `--no-fix`: Rewrite files (default) vs. preview-only mode (`ruff format --check`)
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+Any additional arguments are passed directly to the ruff invocation(s).
+
+**Examples:**
+```bash
+oarepo-cli repository format
+oarepo-cli repository format --no-fix
+```
+
+**Exit codes:**
+- Exit code of the underlying ruff invocation
+- `1`: Project context could not be discovered
+
+### `repository check`
+
+Read-only equivalent of [`repository lint`](#repository-lint)/[`repository format`](#repository-format) that **never modifies files**. Safe for CI/CD. Functionally identical to [`library check`](#library-check).
+
+```bash
+oarepo-cli repository check
+```
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Exit codes:**
+- Exit code of the first failing check
+- `1`: Project context could not be discovered
 
 ### `repository translations`
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1726,25 +1726,44 @@ the open product question raised in the audit
 ([after_repository_cleanup.md](./after_repository_cleanup.md) §4). Depends
 on Step 4.15 for correct multi-module source-directory detection.
 
-- [ ] Add `repository lint`/`repository format`/`repository check` to
+- [x] Add `repository lint`/`repository format`/`repository check` to
   `cli/repository.py`, delegating to the existing `services.lint.LintRunner`
   exactly like their `library` counterparts (same `--fix`/`--no-fix` option
   on `lint`/`format`, defaulting to `--fix`; `check` is the always-read-only
   equivalent)
-- [ ] **Decide**: `LintRunner.run_lint()` unconditionally runs the license
+- [x] **Decide**: `LintRunner.run_lint()` unconditionally runs the license
   header check and the `from __future__ import annotations` check as part
   of `lint`/`check` (there's no way to opt out short of a dedicated
   `license-headers` command, which is out of scope here per the current
   request). Confirm this is desired for repository code too before wiring
   it up as-is, since repository projects may have different header/typing
   conventions than library packages
-- [ ] Confirm `ty.toml`/`.ruff.toml` template generation
+- [x] Confirm `ty.toml`/`.ruff.toml` template generation
   (`configuration/resources.py` templates) doesn't assume a
   single-package/library project shape
-- [ ] Reuse the exact exception-handling policy decided in Step 4.12
+- [x] Reuse the exact exception-handling policy decided in Step 4.12
   (narrow `except OARepoError`, not broad `except Exception`) -- these are
   new commands, so they should start out consistent rather than needing a
   follow-up fix
+
+**Decisions/deviations from the original plan**:
+- **License headers/future-annotations checks**: confirmed (user input) to
+  wire up as-is, matching `library` exactly -- `repository lint`/`check`
+  will fail against the real `tests/testrepo` fixture today (it has neither
+  convention yet), which is accepted as correct/expected rather than a bug
+  to work around.
+- **No code duplication** (explicitly requested): extracted the CLI-layer
+  command body -- console messages, `LintRunner` construction, exception
+  handling, exit-code logic -- into a new shared module,
+  `cli/lint_commands.py` (`run_lint()`/`run_format()`/`run_check()`),
+  reused verbatim by both `library.py` and `repository.py`. Refactored
+  `library_lint`/`library_format`/`library_check` to call it too, rather
+  than leaving their bodies duplicated in two places. Each module still
+  owns its own Typer registration (decorator, options, docstring) and its
+  own `discover_context()` call/error handling, which legitimately differ
+  between the two (`library.py` doesn't wrap `discover_context()` in
+  `try`/`except` at all, a pre-existing asymmetry with `repository.py`
+  left untouched here as out of scope).
 
 **Deliverables**:
 - `oarepo-cli repository lint`/`format`/`check`, functionally equivalent to
@@ -1752,12 +1771,18 @@ on Step 4.15 for correct multi-module source-directory detection.
   multi-module `code_directories`
 
 **Tests** (mirroring `tests/integration/test_library_lint_format.py`/
-`test_library_check.py`):
-- [ ] Test each command executes against a real multi-module repository
-  fixture (`tests/testrepo`)
-- [ ] Test `ty check` covers every module directory (regression test for
-  Step 4.15's fix)
-- [ ] Test `--fix`/`--no-fix` behavior matches `library`'s
+`test_library_check.py`, plus CLI-wiring tests in
+`tests/integration/test_repository_misc.py`):
+- [x] Test each command executes against a real multi-module repository
+  fixture -- a new, lint-clean `lint_project_multi_module` fixture
+  (`tests/integration/conftest.py`) shaped like the real `tests/testrepo`
+  (`[tool.uv.build-backend]`, not `tests/testrepo` itself, which isn't
+  lint-clean per the decision above and would only prove the command fails,
+  not that it works end-to-end)
+- [x] Test `ty check` covers every module directory (regression test for
+  Step 4.15's fix, exercised for real here via a type error planted in the
+  *second* module directory)
+- [x] Test `--fix`/`--no-fix` behavior matches `library`'s
 
 ---
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -12,13 +12,13 @@ from typing import Annotated
 
 import typer
 
+from oarepo_cli.cli import lint_commands
 from oarepo_cli.core.context import discover_context, find_pyproject_toml
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import process
 from oarepo_cli.services.js_tools import run_jslint, run_jstest
 from oarepo_cli.services.license_headers import add_license_headers
-from oarepo_cli.services.lint import LintRunner
 from oarepo_cli.services.pyproject_reader import PyProjectReader
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 from oarepo_cli.services.test_orchestrator import TestOrchestrator
@@ -826,24 +826,7 @@ def library_lint(
     Exits with the exit code of the first failing check.
     """
     context = discover_context()
-    console = ConsoleOutput(quiet=quiet)
-
-    console.info("🔍 Running linters...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-
-    runner = LintRunner(context=context, quiet=quiet)
-
-    try:
-        result = runner.run_lint(fix=fix)
-    except OARepoError as e:
-        console.error(f"❌ Error running linters: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
-        raise typer.Exit(code=1) from e
-
-    if result.success:
-        console.success("✨ ✓ Linting passed!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    else:
-        console.error("❌ Linting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
+    lint_commands.run_lint(context, fix=fix, quiet=quiet)
 
 
 @library_app.command(
@@ -884,24 +867,7 @@ def library_format(
     extra_args = ctx.args if ctx.args else []
 
     context = discover_context()
-    console = ConsoleOutput(quiet=quiet)
-
-    console.info("🎨 Formatting code...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-
-    runner = LintRunner(context=context, quiet=quiet)
-
-    try:
-        result = runner.run_format(fix=fix, extra_args=extra_args)
-    except OARepoError as e:
-        console.error(f"❌ Error formatting code: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
-        raise typer.Exit(code=1) from e
-
-    if result.success:
-        console.success("✨ ✓ Formatting complete!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    else:
-        console.error("❌ Formatting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
+    lint_commands.run_format(context, fix=fix, extra_args=extra_args, quiet=quiet)
 
 
 @library_app.command("check")
@@ -921,24 +887,7 @@ def library_check(
     Exits with the exit code of the first failing check.
     """
     context = discover_context()
-    console = ConsoleOutput(quiet=quiet)
-
-    console.info("🔎 Checking...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-
-    runner = LintRunner(context=context, quiet=quiet)
-
-    try:
-        result = runner.run_lint(fix=False)
-    except OARepoError as e:
-        console.error(f"❌ Error running checks: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
-        raise typer.Exit(code=1) from e
-
-    if result.success:
-        console.success("✨ ✓ Check passed!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    else:
-        console.error("❌ Check failed!", fg=typer.colors.BRIGHT_RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
+    lint_commands.run_check(context, quiet=quiet)
 
 
 @library_app.command(

--- a/oarepo_cli/cli/lint_commands.py
+++ b/oarepo_cli/cli/lint_commands.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Shared CLI-layer implementation for `library`/`repository` lint/format/check.
+
+`library lint`/`format`/`check` and `repository lint`/`format`/`check` are
+functionally identical -- both just run `services.lint.LintRunner` over
+`context.code_directories` -- so the console messages, error handling, and
+exit-code logic live here once, rather than duplicated verbatim across
+`cli/library.py` and `cli/repository.py`. Each module still owns its own
+Typer command registration (decorator, options, docstring/`--help` text,
+and `discover_context()` call/error handling, which differs between the
+two -- see each module's own commands).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+import typer
+
+from oarepo_cli.core.errors import OARepoError
+from oarepo_cli.services.lint import LintRunner
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from oarepo_cli.core.context import ProjectContext
+
+
+def run_lint(context: ProjectContext, *, fix: bool, quiet: bool) -> NoReturn:
+    """Run ``LintRunner.run_lint()`` and exit with its result, for `library`/`repository lint`."""
+    console = ConsoleOutput(quiet=quiet)
+    console.info("🔍 Running linters...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    runner = LintRunner(context=context, quiet=quiet)
+
+    try:
+        result = runner.run_lint(fix=fix)
+    except OARepoError as e:
+        console.error(f"❌ Error running linters: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
+        raise typer.Exit(code=1) from e
+
+    if result.success:
+        console.success("✨ ✓ Linting passed!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    else:
+        console.error("❌ Linting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)
+
+
+def run_format(
+    context: ProjectContext, *, fix: bool, extra_args: Sequence[str], quiet: bool
+) -> NoReturn:
+    """Run ``LintRunner.run_format()`` and exit with its result, for `library`/`repository format`."""
+    console = ConsoleOutput(quiet=quiet)
+    console.info("🎨 Formatting code...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    runner = LintRunner(context=context, quiet=quiet)
+
+    try:
+        result = runner.run_format(fix=fix, extra_args=list(extra_args))
+    except OARepoError as e:
+        console.error(f"❌ Error formatting code: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
+        raise typer.Exit(code=1) from e
+
+    if result.success:
+        console.success("✨ ✓ Formatting complete!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    else:
+        console.error("❌ Formatting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)
+
+
+def run_check(context: ProjectContext, *, quiet: bool) -> NoReturn:
+    """Run ``LintRunner.run_lint(fix=False)`` and exit with its result, for
+    `library`/`repository check`."""
+    console = ConsoleOutput(quiet=quiet)
+    console.info("🔎 Checking...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    runner = LintRunner(context=context, quiet=quiet)
+
+    try:
+        result = runner.run_lint(fix=False)
+    except OARepoError as e:
+        console.error(f"❌ Error running checks: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
+        raise typer.Exit(code=1) from e
+
+    if result.success:
+        console.success("✨ ✓ Check passed!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    else:
+        console.error("❌ Check failed!", fg=typer.colors.BRIGHT_RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import typer
 
+from oarepo_cli.cli import lint_commands
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.services import invenio_cli, repository, translations
@@ -623,6 +624,126 @@ def shell_command(
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ repository shell failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
+
+
+@repository_app.command("lint")
+def lint_command(
+    fix: Annotated[
+        bool,
+        typer.Option(
+            "--fix/--no-fix", help="Auto-fix what ruff/ty can fix (default) vs. report only"
+        ),
+    ] = True,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Run linters and type checkers on the repository's codebase.
+
+    Runs, in order, stopping at the first failure: ruff check, ruff format,
+    a license header check, a ``from __future__ import annotations`` check,
+    and ty check, across every module directory declared in
+    ``[tool.uv.build-backend]`` (or ``src/``/the flat layout, if used
+    instead). Generates ``.ruff.toml`` and ``ty.toml`` config files in the
+    project root.
+
+    By default (``--fix``), auto-fixes what ruff and ty can fix (``ruff
+    check --fix``, ``ruff format``, ``ty check --fix``) instead of only
+    reporting. Use ``--no-fix`` (or ``repository check``, its dedicated
+    read-only equivalent) to never modify any file.
+
+    Exit codes:
+        Exit code of the first failing check
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository lint failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    lint_commands.run_lint(context, fix=fix, quiet=quiet)
+
+
+@repository_app.command(
+    "format",
+    context_settings={
+        "allow_extra_args": True,
+        "allow_interspersed_args": True,
+        "ignore_unknown_options": True,
+    },
+)
+def format_command(
+    ctx: typer.Context,
+    fix: Annotated[
+        bool,
+        typer.Option(
+            "--fix/--no-fix",
+            help="Rewrite files (default) vs. preview-only (`ruff format --check`)",
+        ),
+    ] = True,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Format the repository's codebase using ruff.
+
+    By default (``--fix``), runs ``ruff format`` followed by ``ruff check
+    --fix``, rewriting files. Use ``--no-fix`` for a preview-only run
+    (``ruff format --check``, nothing written) -- or ``repository check``,
+    its dedicated read-only equivalent.
+
+    Any additional arguments are passed directly to the ruff invocation(s).
+
+    Examples:
+        $ oarepo-cli repository format
+        $ oarepo-cli repository format --no-fix
+
+    Exit codes:
+        Exit code of the underlying ruff invocation
+        1: Project context could not be discovered
+    """
+    extra_args = ctx.args if ctx.args else []
+
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository format failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    lint_commands.run_format(context, fix=fix, extra_args=extra_args, quiet=quiet)
+
+
+@repository_app.command("check")
+def check_command(
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Check the repository's codebase without modifying any file.
+
+    The read-only equivalent of ``repository lint``/``repository format``:
+    runs ruff check, ruff format --check, a license header check, a
+    ``from __future__ import annotations`` check, and ty check -- none of
+    them applying fixes. Equivalent to ``repository lint --no-fix``,
+    provided as its own command as the safe-for-CI entry point. Still
+    generates ``.ruff.toml``/``ty.toml`` config files in the project root
+    (that's config generation, not modifying target project source).
+
+    Exit codes:
+        Exit code of the first failing check
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository check failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    lint_commands.run_check(context, quiet=quiet)
 
 
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,6 +40,22 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 """
 
+MULTI_MODULE_PYPROJECT_TOML = """\
+[project]
+name = "{name}"
+version = "0.1.0"
+requires-python = ">=3.14,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+
+[tool.uv.build-backend]
+module-root = ""
+module-name = ["common", "i18n"]
+
+[build-system]
+requires = ["uv_build>=0.8.7,<0.9.0"]
+build-backend = "uv_build"
+"""
+
 
 @pytest.fixture
 def lint_project(tmp_path: Path) -> Path:
@@ -56,6 +72,33 @@ def lint_project(tmp_path: Path) -> Path:
     (root / "src" / "cleanlib").mkdir(parents=True)
     (root / "pyproject.toml").write_text(PYPROJECT_TOML.format(name="cleanlib"))
     (root / "src" / "cleanlib" / "__init__.py").write_text(CLEAN_MODULE)
+    (root / ".gitignore").write_text(".venv/\n")
+
+    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["uv", "venv", "--python", "3.14", "--seed", ".venv"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+
+    return root
+
+
+@pytest.fixture
+def lint_project_multi_module(tmp_path: Path) -> Path:
+    """A minimal, lint-clean repository project with a real venv, laid out like a real
+    uv_build repository (tests/testrepo): several top-level module directories declared
+    in [tool.uv.build-backend] instead of a single src/ -- unlike lint_project's
+    library-style single-source-dir layout. See lint_project's own docstring for the
+    .gitignore/--exclude pyproject.toml rationale, identical here.
+    """
+    root = tmp_path / "cleanrepo"
+    (root / "common").mkdir(parents=True)
+    (root / "i18n").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(MULTI_MODULE_PYPROJECT_TOML.format(name="cleanrepo"))
+    (root / "common" / "__init__.py").write_text(CLEAN_MODULE)
+    (root / "i18n" / "__init__.py").write_text(CLEAN_MODULE)
     (root / ".gitignore").write_text(".venv/\n")
 
     subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)

--- a/tests/integration/test_library_lint_format.py
+++ b/tests/integration/test_library_lint_format.py
@@ -60,13 +60,15 @@ def test_lint_does_not_swallow_non_oareporerror_exceptions(
 ) -> None:
     """A non-OARepoError raised by LintRunner propagates instead of being turned into a
     clean "exit 1" -- regression test for narrowing library.py's except clauses from
-    the previous blanket `except Exception` to `except OARepoError` (Step 4.12)."""
+    the previous blanket `except Exception` to `except OARepoError` (Step 4.12). The
+    shared lint/format/check command body now lives in cli/lint_commands.py (Step
+    4.18), reused by both `library lint` and `repository lint`."""
     monkeypatch.chdir(lint_project)
 
     def _raise_value_error(_self: object, **_kwargs: object) -> None:
         raise ValueError("boom")
 
-    monkeypatch.setattr("oarepo_cli.cli.library.LintRunner.run_lint", _raise_value_error)
+    monkeypatch.setattr("oarepo_cli.cli.lint_commands.LintRunner.run_lint", _raise_value_error)
 
     result = runner.invoke(app, ["library", "lint", "--quiet"])
 

--- a/tests/integration/test_repository_check.py
+++ b/tests/integration/test_repository_check.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for the read-only `repository check` command, against a
+multi-module uv_build project -- see test_repository_lint_format.py's module
+docstring for why this doesn't re-cover ground already tested for `library check`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CLI runner."""
+    return CliRunner()
+
+
+def test_repository_check_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository check --help' displays help text."""
+    result = runner.invoke(app, ["repository", "check", "--help"])
+
+    assert result.exit_code == 0
+    assert "check" in result.stdout.lower()
+
+
+def test_repository_check_passes_on_clean_multi_module_project(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that 'repository check' exits 0 on a clean, multi-module project."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    result = runner.invoke(app, ["repository", "check", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+
+
+def test_repository_check_never_modifies_files(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that 'repository check' reports a violation without modifying any file."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    module = lint_project_multi_module / "i18n" / "__init__.py"
+    dirty = module.read_text() + "\nimport os\n"
+    module.write_text(dirty)
+
+    result = runner.invoke(app, ["repository", "check", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert module.read_text() == dirty
+
+
+def test_repository_check_matches_lint_no_fix_exit_code(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that 'repository check' and 'repository lint --no-fix' agree on pass/fail."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    module = lint_project_multi_module / "common" / "__init__.py"
+    module.write_text(module.read_text() + "\nimport os\n")
+
+    check_result = runner.invoke(app, ["repository", "check", "--quiet"], catch_exceptions=False)
+    lint_no_fix_result = runner.invoke(
+        app, ["repository", "lint", "--no-fix", "--quiet"], catch_exceptions=False
+    )
+
+    assert check_result.exit_code == lint_no_fix_result.exit_code
+    assert check_result.exit_code != 0

--- a/tests/integration/test_repository_lint_format.py
+++ b/tests/integration/test_repository_lint_format.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `repository lint`/`format`, using real ruff/ty against a
+multi-module uv_build project (unlike test_library_lint_format.py's single-src-dir
+project) -- the CLI wiring and LintRunner internals themselves are already covered
+there and in tests/unit/test_lint_service.py, since Step 4.18 reuses both verbatim
+(cli/lint_commands.py, services/lint.py) rather than duplicating them for repository.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CLI runner."""
+    return CliRunner()
+
+
+def test_repository_lint_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository lint --help' displays help text."""
+    result = runner.invoke(app, ["repository", "lint", "--help"])
+
+    assert result.exit_code == 0
+    assert "lint" in result.stdout.lower()
+
+
+def test_repository_format_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository format --help' displays help text."""
+    result = runner.invoke(app, ["repository", "format", "--help"])
+
+    assert result.exit_code == 0
+    assert "format" in result.stdout.lower()
+
+
+def test_repository_lint_passes_on_clean_multi_module_project(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository lint` exits 0 on a clean, multi-module (uv_build) project -- exercising
+    the real ty/ruff invocation across every module directory, not just the first."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    result = runner.invoke(app, ["repository", "lint", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert (lint_project_multi_module / ".ruff.toml").exists()
+    assert (lint_project_multi_module / "ty.toml").exists()
+
+
+def test_repository_lint_fails_on_type_error_in_second_module(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository lint` catches a type error in the *second* module directory --
+    regression test for Step 4.15's ty-check fix, which used to only pass
+    code_directories[0] (the first module) to ty, silently skipping the rest."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    second_module = lint_project_multi_module / "i18n" / "__init__.py"
+    second_module.write_text(
+        "# Copyright (c) 2026 Example Org.\n"
+        "#\n"
+        "# This file is a part of cleanrepo.\n"
+        '"""Sample module with a real type error."""\n'
+        "\n"
+        "from __future__ import annotations\n"
+        "\n"
+        "\n"
+        "def greet() -> str:\n"
+        '    """Return a greeting message."""\n'
+        "    return 42\n"
+    )
+
+    result = runner.invoke(app, ["repository", "lint", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code != 0
+
+
+def test_repository_format_fixes_issues(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository format` (default --fix) rewrites a badly-formatted file."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    module = lint_project_multi_module / "common" / "__init__.py"
+    module.write_text(
+        "# Copyright (c) 2026 Example Org.\n"
+        "#\n"
+        "# This file is a part of cleanrepo.\n"
+        '"""Sample module."""\n'
+        "\n"
+        "from __future__ import annotations\n"
+        "\n"
+        "\n"
+        "def greet(  )->str:\n"
+        '    """Return a greeting message."""\n'
+        "    return   'hello'\n"
+    )
+
+    result = runner.invoke(app, ["repository", "format", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "def greet() -> str:" in module.read_text()
+
+
+def test_repository_lint_requires_pyproject(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository lint` fails cleanly (exit 1) when no pyproject.toml can be found."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["repository", "lint", "--quiet"])
+
+    assert result.exit_code == 1

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
-"""Tests for `repository cli`/`invenio`/`shell`/`translations`/`index rebuild`/`reset`/`info`.
+"""Tests for `repository cli`/`invenio`/`shell`/`lint`/`format`/`check`/`translations`/
+`index rebuild`/`reset`/`info`.
 
 Delegation, argument wiring, and error/exit-code handling are covered here
 by mocking `discover_context()` and the specific service function/module
@@ -260,6 +261,104 @@ def test_shell_reports_services_start_failure_and_never_execs_shell(
 
     assert result.exit_code == 1
     assert shell_calls == []
+
+
+# --- repository lint/format/check ----------------------------------------
+
+
+def test_lint_delegates_to_lint_commands_run_lint(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository lint` delegates to the shared lint_commands.run_lint(), passing
+    through --fix/--quiet -- the same function `library lint` calls (Step 4.18)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.lint_commands.run_lint",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "lint", "--no-fix", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "fix": False, "quiet": True}]
+
+
+def test_lint_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "lint"])
+
+    assert result.exit_code == 1
+
+
+def test_format_delegates_to_lint_commands_run_format(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository format` delegates to the shared lint_commands.run_format(), forwarding
+    --fix/--quiet and any extra args (e.g. a path) to the underlying ruff invocation."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.lint_commands.run_format",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "format", "--quiet", "common/"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {"context": mock_context, "fix": True, "extra_args": ["common/"], "quiet": True}
+    ]
+
+
+def test_format_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "format"])
+
+    assert result.exit_code == 1
+
+
+def test_check_delegates_to_lint_commands_run_check(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository check` delegates to the shared lint_commands.run_check(), the
+    always-read-only equivalent (no --fix option)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.lint_commands.run_check",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "check", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "quiet": True}]
+
+
+def test_check_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "check"])
+
+    assert result.exit_code == 1
 
 
 # --- repository translations -------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `oarepo-cli repository lint`/`format`/`check`, resolving the audit's open question of whether `repository` should get `library`'s dev-tooling commands (yes). Functionally identical to their `library` counterparts — both just run `services.lint.LintRunner` over `context.code_directories`, correctly multi-module-aware since Step 4.15.
- **Confirmed (user input)**: wire up the license-header/future-annotations checks as-is, matching `library` exactly, rather than special-casing them for repository — `repository lint`/`check` will fail against the real `tests/testrepo` fixture today (neither convention exists there yet), accepted as correct/expected.
- **No code duplication** (explicitly requested): extracted the CLI-layer command body — console messages, `LintRunner` construction, exception handling, exit-code logic — into a new shared `cli/lint_commands.py` (`run_lint`/`run_format`/`run_check`), reused verbatim by both `library.py` and `repository.py`. Refactored `library_lint`/`format`/`check` to call it too, removing the (already near-identical) duplicated bodies. Each module still owns its own Typer registration and `discover_context()` handling, which legitimately differ.
- Adds a new `lint_project_multi_module` fixture (`tests/integration/conftest.py`), a lint-clean project shaped like the real `tests/testrepo` (`[tool.uv.build-backend]`, not `src/`), to exercise the full real ruff/ty pipeline end-to-end for a multi-module layout.
- Updates `README.md` to document the new commands.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] Existing `library lint`/`format`/`check` tests pass unchanged after the refactor (behavior-preserving)
- [x] New tests: real ruff/ty runs against the multi-module fixture (including a regression test for Step 4.15's `ty check` fix, planting a type error in the *second* module directory), plus CLI-wiring/context-discovery-failure tests for `repository lint`/`format`/`check`
- [x] Full `make test` — 519 passed