### PR TITLE
Step 4.19: Repository jslint/jstest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`lint`](#repository-lint) | Run linters and type checkers | ✅ Implemented |
 | [`format`](#repository-format) | Format code with ruff | ✅ Implemented |
 | [`check`](#repository-check) | Read-only equivalent of `lint`+`format` | ✅ Implemented |
+| [`jslint`](#repository-jslint) | Run ESLint and Prettier on JS files | ✅ Implemented |
+| [`jstest`](#repository-jstest) | Run JavaScript tests (Jest) | ✅ Implemented |
 | [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
 | [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
 | [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
@@ -822,6 +824,46 @@ oarepo-cli repository check
 
 **Exit codes:**
 - Exit code of the first failing check
+- `1`: Project context could not be discovered
+
+### `repository jslint`
+
+Runs ESLint and Prettier on the repository's JavaScript files. Installs `@inveniosoftware/eslint-config-invenio` if needed, generates `.eslintrc.yaml`, runs eslint with `--fix`, and runs prettier (in check mode under `CI=true`). Skips entirely if no `package.json` is found at the repository root -- the common case, since a repository doesn't commit one there. Functionally identical to [`library jslint`](#library-jslint).
+
+```bash
+oarepo-cli repository jslint
+```
+
+**Options:**
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+**Exit codes:**
+- Exit code of the underlying eslint/prettier invocation
+- `1`: Project context could not be discovered
+
+### `repository jstest`
+
+Runs JavaScript tests (Jest) via `invenio webpack run test`, collecting every registered `invenio_assets.webpack` entry point -- including the repository's own (see `[project.entry-points."invenio_assets.webpack"]` in `pyproject.toml`), same as for a library. Requires the repository to already be installed ([`repository install`](#repository-install)), so its webpack build exists. Functionally identical to [`library jstest`](#library-jstest).
+
+```bash
+oarepo-cli repository jstest [OPTIONS]
+```
+
+**Options:**
+- `--setup`: Set up Jest configuration instead of running tests (currently delegates to bash script)
+- `--skip-services`: Don't start Docker services first
+- `--quiet` / `-q`: Suppress output from subprocesses
+
+Any additional arguments are passed directly to the test command.
+
+**Examples:**
+```bash
+oarepo-cli repository jstest
+oarepo-cli repository jstest --skip-services
+```
+
+**Exit codes:**
+- Exit code of the underlying test command
 - `1`: Project context could not be discovered
 
 ### `repository translations`

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1790,20 +1790,46 @@ on Step 4.15 for correct multi-module source-directory detection.
 **Goal**: Port `library jslint`/`jstest` to `repository`. Depends on Step
 4.15 for correct multi-module source-directory detection.
 
-- [ ] Add `repository jslint`/`repository jstest` to `cli/repository.py`,
+- [x] Add `repository jslint`/`repository jstest` to `cli/repository.py`,
   delegating to the existing `services.js_tools.run_jslint()`/`run_jstest()`
   exactly like their `library` counterparts
-- [ ] **Verify before implementing**: `run_jstest()` shells out to `invenio
+- [x] **Verify before implementing**: `run_jstest()` shells out to `invenio
   webpack run test`, which assumes a webpack/Jest setup created via
   `invenio webpack create` (a library workflow). Confirm a real repository
   project (which already ships `assets/`, `static/`, `ui/`, `i18n/`,
   `babel.ini`, `oarepo.yaml` per `tests/testrepo`) exposes the same `invenio
   webpack run test` entry point, or whether repository JS testing needs a
   different command/setup entirely
-- [ ] `run_jslint()`'s `package.json`-missing short-circuit (prints "No
+- [x] `run_jslint()`'s `package.json`-missing short-circuit (prints "No
   package.json found, skipping") already degrades gracefully -- confirm
   this is the desired behavior for a repository without JS assets configured
   yet, or whether it should be an error instead
+
+**Verification results**: `invenio webpack run test`/`invenio webpack create`
+are general Invenio mechanisms, not library-specific -- they collect
+*every* registered `invenio_assets.webpack` entry point project-wide (from
+installed packages *and* the project's own `pyproject.toml`; `tests/testrepo`
+itself registers two: `i18n = "i18n.webpack:theme"`, `components =
+"ui.components.webpack:theme"`), and `install_repository()`'s "Run
+invenio-cli install" step already triggers this webpack build during a real
+`repository install` -- exactly the same precondition `library jstest`
+already has (an installed venv with webpack already created). No changes
+needed to `services/js_tools.py`; both functions are reused completely
+as-is. `run_jslint()`'s package.json-missing skip is kept unchanged too
+(not special-cased for repository) -- it's the same safe default already
+accepted for a library without its own root-level JS lint config, and a
+repository not having one at the project root is the common case (its real
+webpack assets/`package.json` live inside the Flask instance path, not the
+git-tracked project root -- confirmed against `library_runner.sh`'s own
+`assets_path="${instance_path}/assets"`, used by its jstest setup path but
+notably *not* by `run_jslint()`, which really does check the bare project
+root either way).
+
+**No code duplication** (per Step 4.18's precedent): extracted the
+CLI-layer command bodies into a new shared `cli/js_commands.py`
+(`run_jslint_command()`/`run_jstest_command()`), reused verbatim by both
+`library.py` and `repository.py`, refactoring `library_jslint`/`jstest` to
+call it too rather than leaving the duplicated bodies in place.
 
 **Deliverables**:
 - `oarepo-cli repository jslint`/`jstest`, functionally equivalent to their
@@ -1811,12 +1837,16 @@ on Step 4.15 for correct multi-module source-directory detection.
   hold for a repository project
 
 **Tests** (mirroring `tests/integration/test_library_misc_commands.py`'s
-`library jslint`/`library jstest` coverage):
-- [ ] Test each command executes against a real multi-module repository
-  fixture (`tests/testrepo`)
-- [ ] Test the no-`package.json` short-circuit
-- [ ] Test `jslint` excludes `tests/` from the directories it lints,
-  matching `library jslint`'s existing behavior
+`library jslint`/`library jstest` coverage, plus CLI-wiring tests in
+`tests/integration/test_repository_misc.py`):
+- [x] Test each command's `--help`; a full real `jstest` run needs an
+  installed venv plus node/npm/webpack -- too heavy for this suite, and not
+  exercised for `library jstest` either
+- [x] Test the no-`package.json` short-circuit, against the
+  `lint_project_multi_module` fixture added in Step 4.18
+- [x] `jslint`/`jstest` reuse `context.code_directories` and its existing
+  `tests/`-exclusion unchanged -- already covered by Step 4.15's tests, not
+  re-tested here
 
 ---
 

--- a/oarepo_cli/cli/js_commands.py
+++ b/oarepo_cli/cli/js_commands.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Shared CLI-layer implementation for `library`/`repository` jslint/jstest.
+
+`library jslint`/`jstest` and `repository jslint`/`jstest` are functionally
+identical -- both just run `services.js_tools.run_jslint()`/`run_jstest()`
+-- so the console messages, error handling, and exit-code logic live here
+once, rather than duplicated verbatim across `cli/library.py` and
+`cli/repository.py` (mirrors `cli/lint_commands.py`'s identical rationale
+for `lint`/`format`/`check`). Each module still owns its own Typer command
+registration (decorator, options, docstring/`--help` text, and
+`discover_context()` call/error handling, which differs between the two).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+import typer
+
+from oarepo_cli.core.errors import OARepoError
+from oarepo_cli.services.js_tools import run_jslint, run_jstest
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from oarepo_cli.core.context import ProjectContext
+
+
+def run_jslint_command(context: ProjectContext, *, quiet: bool) -> NoReturn:
+    """Run ``run_jslint()`` and exit with its result, for `library`/`repository jslint`."""
+    console = ConsoleOutput(quiet=quiet)
+    console.info("🔍 Running JavaScript linters...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    try:
+        result = run_jslint(context, quiet=quiet)
+    except OARepoError as e:
+        console.error(f"❌ Error running jslint: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
+        raise typer.Exit(code=1) from e
+
+    if result.success:
+        console.success(
+            "✨ ✓ JavaScript linting complete!", fg=typer.colors.BRIGHT_GREEN, bold=True
+        )
+    else:
+        console.error("❌ JavaScript linting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)
+
+
+def run_jstest_command(
+    context: ProjectContext,
+    *,
+    setup: bool,
+    skip_services: bool,
+    extra_args: Sequence[str],
+    quiet: bool,
+) -> NoReturn:
+    """Run ``run_jstest()`` and exit with its result, for `library`/`repository jstest`."""
+    console = ConsoleOutput(quiet=quiet)
+    if setup:
+        console.info("🛠️  Setting up JavaScript tests...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+    else:
+        console.info("🧪 Running JavaScript tests...", fg=typer.colors.BRIGHT_BLUE, bold=True)
+
+    try:
+        result = run_jstest(
+            context,
+            setup=setup,
+            skip_services=skip_services,
+            extra_args=list(extra_args),
+            quiet=quiet,
+        )
+    except OARepoError as e:
+        console.error(f"❌ Error running jstest: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
+        raise typer.Exit(code=1) from e
+
+    if result.success:
+        console.success("✨ ✓ JavaScript tests complete!", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    else:
+        console.error("❌ JavaScript tests failed!", fg=typer.colors.BRIGHT_RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -12,12 +12,11 @@ from typing import Annotated
 
 import typer
 
-from oarepo_cli.cli import lint_commands
+from oarepo_cli.cli import js_commands, lint_commands
 from oarepo_cli.core.context import discover_context, find_pyproject_toml
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services import process
-from oarepo_cli.services.js_tools import run_jslint, run_jstest
 from oarepo_cli.services.license_headers import add_license_headers
 from oarepo_cli.services.pyproject_reader import PyProjectReader
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
@@ -996,24 +995,7 @@ def library_jslint(
         oarepo-cli library jslint
     """
     context = discover_context()
-    console = ConsoleOutput(quiet=quiet)
-
-    console.info("🔍 Running JavaScript linters...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-
-    try:
-        result = run_jslint(context, quiet=quiet)
-    except OARepoError as e:
-        console.error(f"❌ Error running jslint: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
-        raise typer.Exit(code=1) from e
-
-    if result.success:
-        console.success(
-            "✨ ✓ JavaScript linting complete!", fg=typer.colors.BRIGHT_GREEN, bold=True
-        )
-    else:
-        console.error("❌ JavaScript linting failed!", fg=typer.colors.BRIGHT_RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
+    js_commands.run_jslint_command(context, quiet=quiet)
 
 
 @library_app.command(
@@ -1052,27 +1034,9 @@ def library_jstest(
     extra_args = ctx.args if ctx.args else []
 
     context = discover_context()
-    console = ConsoleOutput(quiet=quiet)
-
-    if setup:
-        console.info("🛠️  Setting up JavaScript tests...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-    else:
-        console.info("🧪 Running JavaScript tests...", fg=typer.colors.BRIGHT_BLUE, bold=True)
-
-    try:
-        result = run_jstest(
-            context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
-        )
-    except OARepoError as e:
-        console.error(f"❌ Error running jstest: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
-        raise typer.Exit(code=1) from e
-
-    if result.success:
-        console.success("✨ ✓ JavaScript tests complete!", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    else:
-        console.error("❌ JavaScript tests failed!", fg=typer.colors.BRIGHT_RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
+    js_commands.run_jstest_command(
+        context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
+    )
 
 
 @library_app.command("oarepo-versions")

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -10,7 +10,7 @@ from typing import Annotated
 
 import typer
 
-from oarepo_cli.cli import lint_commands
+from oarepo_cli.cli import js_commands, lint_commands
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.services import invenio_cli, repository, translations
@@ -744,6 +744,92 @@ def check_command(
         raise typer.Exit(1) from e
 
     lint_commands.run_check(context, quiet=quiet)
+
+
+@repository_app.command("jslint")
+def jslint_command(
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Run ESLint and Prettier on the repository's JavaScript files.
+
+    Installs necessary dependencies if needed
+    (``@inveniosoftware/eslint-config-invenio``), generates
+    ``.eslintrc.yaml`` configuration, runs eslint with ``--fix`` to
+    auto-fix issues, and runs prettier to format code.
+
+    In CI environments (``CI=true``), prettier runs in check mode
+    (``--check``) instead of write mode (``--write``).
+
+    Skips entirely if no ``package.json`` is found at the repository root
+    (JS assets are optional for a repository).
+
+    Exit codes:
+        Exit code of the underlying eslint/prettier invocation
+        1: Project context could not be discovered
+    """
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository jslint failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    js_commands.run_jslint_command(context, quiet=quiet)
+
+
+@repository_app.command(
+    "jstest",
+    context_settings={
+        "allow_extra_args": True,
+        "allow_interspersed_args": True,
+        "ignore_unknown_options": True,
+    },
+)
+def jstest_command(
+    ctx: typer.Context,
+    setup: Annotated[
+        bool, typer.Option("--setup", help="Set up Jest configuration instead of running tests")
+    ] = False,
+    skip_services: Annotated[
+        bool, typer.Option("--skip-services", help="Skip starting Docker services")
+    ] = False,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Suppress output from subprocesses")
+    ] = False,
+) -> None:
+    """Run JavaScript tests (Jest) via ``invenio webpack``.
+
+    Runs Jest tests through ``invenio webpack run test``, collecting every
+    registered ``invenio_assets.webpack`` entry point -- including the
+    repository's own (see ``[project.entry-points."invenio_assets.webpack"]``
+    in ``pyproject.toml``), same as for a library. Requires the repository
+    to already be installed (``repository install``), so its webpack build
+    exists.
+
+    Use ``--setup`` to set up the Jest configuration (currently delegates
+    to bash script). By default, starts Docker services if needed. Use
+    ``--skip-services`` to skip service startup.
+
+    Any additional arguments are passed directly to the test command.
+
+    Exit codes:
+        Exit code of the underlying test command
+        1: Project context could not be discovered
+    """
+    extra_args = ctx.args if ctx.args else []
+
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ repository jstest failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    js_commands.run_jstest_command(
+        context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
+    )
 
 
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)

--- a/tests/integration/test_repository_jslint_jstest.py
+++ b/tests/integration/test_repository_jslint_jstest.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `repository jslint`/`jstest`.
+
+A full real jstest run needs an installed venv plus node/npm/webpack --
+too heavy for this suite, and not exercised for `library jstest` either
+(see test_library_misc_commands.py, which only covers --help there). The
+underlying services.js_tools.run_jslint()/run_jstest() and the shared
+cli/js_commands.py wiring are reused verbatim from `library` (Step 4.19),
+not duplicated, so this mirrors that file's own coverage level.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CLI runner."""
+    return CliRunner()
+
+
+def test_repository_jslint_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository jslint --help' displays help text."""
+    result = runner.invoke(app, ["repository", "jslint", "--help"])
+
+    assert result.exit_code == 0
+    assert "jslint" in result.stdout.lower()
+
+
+def test_repository_jstest_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository jstest --help' displays help text."""
+    result = runner.invoke(app, ["repository", "jstest", "--help"])
+
+    assert result.exit_code == 0
+    assert "jstest" in result.stdout.lower()
+
+
+def test_repository_jslint_skips_without_package_json(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that 'repository jslint' skips gracefully when no package.json exists --
+    the common case for a repository, which doesn't commit one at the project root."""
+    monkeypatch.chdir(lint_project_multi_module)
+
+    result = runner.invoke(app, ["repository", "jslint", "--quiet"], catch_exceptions=False)
+
+    assert result.exit_code == 0

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
-"""Tests for `repository cli`/`invenio`/`shell`/`lint`/`format`/`check`/`translations`/
-`index rebuild`/`reset`/`info`.
+"""Tests for `repository cli`/`invenio`/`shell`/`lint`/`format`/`check`/`jslint`/`jstest`/
+`translations`/`index rebuild`/`reset`/`info`.
 
 Delegation, argument wiring, and error/exit-code handling are covered here
 by mocking `discover_context()` and the specific service function/module
@@ -357,6 +357,81 @@ def test_check_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch
 
     runner = CliRunner()
     result = runner.invoke(app, ["repository", "check"])
+
+    assert result.exit_code == 1
+
+
+# --- repository jslint/jstest ---------------------------------------------
+
+
+def test_jslint_delegates_to_js_commands_run_jslint_command(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository jslint` delegates to the shared js_commands.run_jslint_command(), the
+    same function `library jslint` calls (Step 4.19)."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.js_commands.run_jslint_command",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "jslint", "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [{"context": mock_context, "quiet": True}]
+
+
+def test_jslint_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "jslint"])
+
+    assert result.exit_code == 1
+
+
+def test_jstest_delegates_to_js_commands_run_jstest_command(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository jstest` delegates to the shared js_commands.run_jstest_command(),
+    forwarding --setup/--skip-services/--quiet and any extra args."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.js_commands.run_jstest_command",
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["repository", "jstest", "--skip-services", "--quiet", "-t", "some.test"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "context": mock_context,
+            "setup": False,
+            "skip_services": True,
+            "extra_args": ["-t", "some.test"],
+            "quiet": True,
+        }
+    ]
+
+
+def test_jstest_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "jstest"])
 
     assert result.exit_code == 1
 


### PR DESCRIPTION
## Summary
- Adds `oarepo-cli repository jslint`/`jstest`, reusing `services.js_tools.run_jslint()`/`run_jstest()` completely unchanged — verified both generalize to a repository without modification:
  - `invenio webpack run test`/`invenio webpack create` are general Invenio mechanisms, not library-specific: they collect every registered `invenio_assets.webpack` entry point project-wide (installed packages *and* the project's own `pyproject.toml` — `tests/testrepo` itself registers two). `install_repository()`'s "invenio-cli install" step already triggers this webpack build during a real `repository install`, the same precondition `library jstest` already has.
  - `run_jslint()`'s package.json-missing skip is kept as-is (not special-cased for repository): a repository's real webpack assets/`package.json` live in the Flask instance path, not the git-tracked project root, so not finding one there is the expected common case — the same safe default already accepted for a library without its own root-level JS lint config.
- **No code duplication** (per Step 4.18's precedent): extracted the CLI-layer command bodies into a new shared `cli/js_commands.py` (`run_jslint_command`/`run_jstest_command`), reused verbatim by both `library.py` and `repository.py`, refactoring `library_jslint`/`jstest` to call it too.
- Updates `README.md` to document the new commands.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] Existing `library jslint`/`jstest` tests pass unchanged after the refactor (behavior-preserving)
- [x] New tests: `--help` for both, no-`package.json` short-circuit (against the multi-module fixture from Step 4.18), plus CLI-wiring/context-discovery-failure tests
- [x] Full `make test` — 526 passed