### PR TITLE
Step 4.20: Repository test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ The `repository` subcommand provides tools for managing full OARepo repository i
 | [`check`](#repository-check) | Read-only equivalent of `lint`+`format` | ✅ Implemented |
 | [`jslint`](#repository-jslint) | Run ESLint and Prettier on JS files | ✅ Implemented |
 | [`jstest`](#repository-jstest) | Run JavaScript tests (Jest) | ✅ Implemented |
+| [`test`](#repository-test) | Run pytest tests | ✅ Implemented |
 | [`translations`](#repository-translations) | Extract/compile translations | ✅ Implemented |
 | [`index`](#repository-index-rebuild) | Rebuild search index | ✅ Implemented |
 | [`reset`](#repository-reset) | Full reset with confirmation | ✅ Implemented |
@@ -865,6 +866,35 @@ oarepo-cli repository jstest --skip-services
 **Exit codes:**
 - Exit code of the underlying test command
 - `1`: Project context could not be discovered
+
+### `repository test`
+
+Runs the repository's test suite using pytest. By default, Docker services are started first (via `invenio-cli services start`, like [`repository run`](#repository-run)/[`shell`](#repository-shell)) -- use `--no-services` to skip. Unlike [`library test`](#library-test), services are never stopped afterward, matching every other `repository` command.
+
+`--with-coverage` covers every module directory (see [`repository lint`](#repository-lint)) rather than a single package, since a repository's code is typically laid out as several top-level modules. Since a fresh repository has no "tests" extras convention of its own (unlike a library), `pytest`/`pytest-cov` are installed directly into the venv on demand if missing.
+
+```bash
+oarepo-cli repository test
+```
+
+**Options:**
+- `--no-services`: Don't start Docker services first
+- `--with-coverage`: Enable coverage reporting (HTML and terminal)
+- `--quiet` / `-q`: Suppress output from starting Docker services
+
+Any additional arguments are passed directly to pytest.
+
+**Examples:**
+```bash
+oarepo-cli repository test
+oarepo-cli repository test --with-coverage
+oarepo-cli repository test --no-services
+oarepo-cli repository test -v -k test_specific
+```
+
+**Exit codes:**
+- Exit code of the underlying pytest invocation
+- `1`: Starting Docker services failed, or project context could not be discovered
 
 ### `repository translations`
 

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1857,26 +1857,85 @@ one does **not** depend on Step 4.15: `TestOrchestrator` never touches
 `cwd=root_directory` and relies on pytest's own test discovery -- so this
 should be closer to a drop-in port.
 
-- [ ] Add `repository test` to `cli/repository.py`, delegating to the
+- [x] Add `repository test` to `cli/repository.py`, delegating to the
   existing `services.test_orchestrator.TestOrchestrator` exactly like
   `library test` (same `--skip-services`/`--with-coverage` options)
-- [ ] Confirm `TestOrchestrator`'s services-start/stop lifecycle
+- [x] Confirm `TestOrchestrator`'s services-start/stop lifecycle
   (`ServicesLifecycleManager`) is the right mechanism for a repository too,
   or whether -- per Step 4.17's services-lifecycle question -- it should
   start services via `invenio-cli services start` instead, for consistency
   with how the rest of the `repository` command group manages services
-- [ ] Verify pytest/coverage are available in a repository's venv the same
+- [x] Verify pytest/coverage are available in a repository's venv the same
   way they are for a library's (installed as test dependencies), and that a
   freshly-installed repository actually has a `tests/` directory with
   anything to run
 
-**Deliverables**:
-- `oarepo-cli repository test`, functionally equivalent to `library test`
+**This turned out not to be a drop-in port.** `TestOrchestrator` was not
+reused; `services.repository.run_tests()` was added instead, and
+`repository test` doesn't call `TestOrchestrator` at all:
 
-**Tests** (mirroring `tests/integration/test_library_test.py` and
-`tests/integration/test_test_orchestrator.py`):
-- [ ] Test execution against a real repository fixture (`tests/testrepo`)
-- [ ] Test `--skip-services`/`--with-coverage` behavior matches `library`'s
+- **Services lifecycle**: confirmed -- like Step 4.17 -- that
+  `ServicesLifecycleManager` (raw `docker-services-cli`, matching a
+  library's setup) doesn't apply to a repository, which manages its own
+  `docker/docker-compose.yml` through `invenio-cli services *` instead.
+  Beyond that mechanism swap, the *lifecycle shape* itself differs:
+  `TestOrchestrator` starts services only if not already running and stops
+  them again in a `finally` block once the test run completes -- a
+  reasonable "clean up after yourself" default for a library's ephemeral,
+  repeated test runs. `repository run`/`shell` never do this "already
+  running?" check or auto-stop -- they start services unconditionally
+  (unless `--no-services`) and leave them running, since a repository's
+  services are a shared, long-lived dev environment other commands
+  (`run`, `shell`) expect to keep using. `repository test` follows that
+  same shape: unconditional start via `invenio_cli.run_invenio_cli(...,
+  ["services", "start"])` unless `--no-services` (naming matches
+  `run`/`shell`, not `library test`'s `--skip-services`), no stop
+  afterward.
+- **Coverage target**: `TestOrchestrator._build_pytest_command()` passes a
+  single `--cov <name>`, derived from `[project].name` -- correct for a
+  library's one `src/`-or-package-dir layout, but wrong for a repository:
+  its `code_directories` are typically several top-level modules (Step
+  4.15's `[tool.uv.build-backend]` support), each already a real
+  importable package name, and the project's own declared name (e.g.
+  `testrepo`) isn't one of them at all. `run_tests()` instead passes
+  `--cov <name>` for every non-`tests` `code_directories` entry.
+- **pytest/coverage availability**: confirmed a real problem, not just a
+  hypothetical -- `tests/testrepo`'s `pyproject.toml` declares no `tests`
+  extras group (unlike a library, which either declares one itself or
+  depends on it transitively), so `TestOrchestrator`'s
+  extras-group-triggered install would never fire, leaving `pytest`
+  genuinely absent from a fresh repository's venv. `run_tests()` installs
+  `pytest`/`pytest-cov` directly (`uv pip install --python <venv's own
+  python> ...`) if missing, unconditionally, rather than gating on an
+  extras group. (Caught the hard way during testing: installing against
+  `context.python_binary` -- the interpreter used to *create* the venv, not
+  the venv's own -- fails against a real uv-managed system interpreter,
+  "externally managed"; fixed to target the venv's own python explicitly.)
+- **No shared module with `library test`** (unlike Steps 4.18/4.19): the
+  underlying orchestration differs enough (services mechanism, lifecycle
+  shape, coverage targeting) that forcing one shared implementation would
+  need a strategy-style injection for services lifecycle alone, adding
+  more complexity than the ~15-line CLI body it would save. `library_test`
+  is therefore untouched, still using `TestOrchestrator` directly.
+
+**Deliverables**:
+- `oarepo-cli repository test`, running the repository's test suite with
+  invenio-cli-managed services and multi-module-aware coverage
+
+**Tests** (unit tests for `services.repository.run_tests()` in
+`tests/unit/test_repository_service.py`, CLI-wiring tests in
+`tests/integration/test_repository_misc.py`, and a new
+`tests/integration/test_repository_test.py` for real end-to-end coverage):
+- [x] Test execution against a real project fixture -- the
+  `lint_project_multi_module` fixture from Step 4.18, always with
+  `--no-services` (no Docker needed for this at all); `tests/testrepo`
+  itself has no `tests/` directory, so isn't suited to exercising a real
+  passing/failing run
+- [x] Test `--no-services`/`--with-coverage` behavior, and that the
+  services-lifecycle/coverage-targeting deviations above hold (invenio-cli
+  used, not `ServicesLifecycleManager`; every module directory covered, not
+  a single package name; pytest installed on demand against the venv's own
+  python)
 
 ---
 

--- a/oarepo_cli/cli/js_commands.py
+++ b/oarepo_cli/cli/js_commands.py
@@ -54,11 +54,19 @@ def run_jstest_command(
     context: ProjectContext,
     *,
     setup: bool,
-    skip_services: bool,
+    service_env: dict[str, str] | None,
     extra_args: Sequence[str],
     quiet: bool,
 ) -> NoReturn:
-    """Run ``run_jstest()`` and exit with its result, for `library`/`repository jstest`."""
+    """Run ``run_jstest()`` and exit with its result, for `library`/`repository jstest`.
+
+    The caller is responsible for starting Docker services (if needed) and passing
+    their connection environment variables via ``service_env``.
+
+    ``run_jstest()`` never returns on successful test runs (it ``os.execve``s into
+    Jest) -- only precondition failures (setup not implemented, missing ``invenio``
+    binary) return a ``ProcessResult``, which this function then exits with.
+    """
     console = ConsoleOutput(quiet=quiet)
     if setup:
         console.info("🛠️  Setting up JavaScript tests...", fg=typer.colors.BRIGHT_BLUE, bold=True)
@@ -69,7 +77,7 @@ def run_jstest_command(
         result = run_jstest(
             context,
             setup=setup,
-            skip_services=skip_services,
+            service_env=service_env,
             extra_args=list(extra_args),
             quiet=quiet,
         )
@@ -77,6 +85,8 @@ def run_jstest_command(
         console.error(f"❌ Error running jstest: {e}", fg=typer.colors.BRIGHT_RED, bold=True)
         raise typer.Exit(code=1) from e
 
+    # Only precondition failures (setup not implemented, missing invenio binary)
+    # return a ProcessResult -- successful test runs never return (os.execve)
     if result.success:
         console.success("✨ ✓ JavaScript tests complete!", fg=typer.colors.BRIGHT_GREEN, bold=True)
     else:

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -1038,8 +1038,19 @@ def library_jstest(
     extra_args = ctx.args if ctx.args else []
 
     context = discover_context()
+
+    # Start services unless already running or explicitly skipped, and get
+    # the environment variables needed to connect to them
+    if skip_services:
+        services_mgr = ServicesLifecycleManager(
+            config=context.config, project_root=context.root_directory
+        )
+        service_env = services_mgr.load_service_env()
+    else:
+        service_env = _start_services_if_needed_impl(quiet=quiet)
+
     js_commands.run_jstest_command(
-        context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
+        context, setup=setup, service_env=service_env, extra_args=extra_args, quiet=quiet
     )
 
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -619,8 +619,11 @@ def library_shell(
     platform = get_platform_detector()
     bin_dir = platform.get_venv_bin_dir()
 
-    # Build environment for the shell
-    shell_env = dict(os.environ)
+    # Build environment for the shell: build_subprocess_env() strips oarepo-cli's own
+    # venv and injects OAREPO_ENV_DEFAULTS, same as any process.run() call gets --
+    # there's no other subprocess env-merging safety net once this replaces the
+    # current process.
+    shell_env = process.build_subprocess_env()
 
     # Add service environment variables
     shell_env.update(service_env)
@@ -768,8 +771,9 @@ def library_invenio(
         )
         raise typer.Exit(code=1)
 
-    # Build environment for the command
-    cmd_env = dict(os.environ)
+    # Build environment for the command: build_subprocess_env() strips oarepo-cli's
+    # own venv and injects OAREPO_ENV_DEFAULTS, same as any process.run() call gets.
+    cmd_env = process.build_subprocess_env()
 
     # Add service environment variables
     cmd_env.update(service_env)

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -832,6 +832,84 @@ def jstest_command(
     )
 
 
+@repository_app.command(
+    "test",
+    context_settings={
+        "allow_extra_args": True,
+        "allow_interspersed_args": True,
+        "ignore_unknown_options": True,
+    },
+)
+def test_command(
+    ctx: typer.Context,
+    no_services: Annotated[
+        bool,
+        typer.Option("--no-services", help="Don't start Docker services first"),
+    ] = False,
+    with_coverage: Annotated[
+        bool, typer.Option("--with-coverage", help="Enable coverage reporting")
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress output from starting Docker services",
+        ),
+    ] = False,
+) -> None:
+    """Run the repository's test suite using pytest.
+
+    By default, Docker services are started first (via ``invenio-cli
+    services start``, like ``repository run``/``shell``) -- use
+    ``--no-services`` to skip, e.g. if they're already running. Unlike
+    ``library test``, services are never stopped afterward, matching every
+    other ``repository`` command.
+
+    Use ``--with-coverage`` to generate coverage reports (HTML and
+    terminal), covering every module directory (see ``repository lint``)
+    rather than a single package.
+
+    Any additional arguments are passed directly to pytest.
+
+    Examples:
+        $ oarepo-cli repository test
+        $ oarepo-cli repository test --with-coverage
+        $ oarepo-cli repository test --no-services
+        $ oarepo-cli repository test -v -k test_specific
+
+    Exit codes:
+        Exit code of the underlying pytest invocation
+        1: Starting Docker services failed, or project context could not be
+           discovered
+    """
+    pytest_args = ctx.args if ctx.args else []
+
+    try:
+        context = discover_context()
+
+        console = ConsoleOutput(quiet=quiet)
+        if not no_services:
+            console.info("→ Starting Docker services...\n")
+            invenio_cli.run_invenio_cli(context, ["services", "start"], quiet=quiet)
+
+        console.info("→ Running tests...\n")
+        result = repository.run_tests(
+            context, pytest_args=pytest_args, coverage=with_coverage, quiet=quiet
+        )
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)  # Always show errors
+        console_err.error(f"\n✗ repository test failed: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    if result.success:
+        console.success("\n✓ All tests passed!\n", fg=typer.colors.BRIGHT_GREEN, bold=True)
+    else:
+        console.error("\n✗ Tests failed!\n", fg=typer.colors.RED, bold=True)
+
+    raise typer.Exit(code=result.return_code)
+
+
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)
 def translations_command(
     ctx: typer.Context,

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -822,14 +822,22 @@ def jstest_command(
 
     try:
         context = discover_context()
+
+        console = ConsoleOutput(quiet=quiet)
+        if not skip_services:
+            console.info("→ Starting Docker services...\n")
+            invenio_cli.run_invenio_cli(context, ["services", "start"], quiet=quiet)
+
+        # A repository doesn't need service connection env vars -- it resolves
+        # connection details from invenio.cfg/.invenio.private, not from the
+        # .env-services file docker-services-cli would write for a library
+        js_commands.run_jstest_command(
+            context, setup=setup, service_env=None, extra_args=extra_args, quiet=quiet
+        )
     except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)
         console_err.error(f"\n✗ repository jstest failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
-
-    js_commands.run_jstest_command(
-        context, setup=setup, skip_services=skip_services, extra_args=extra_args, quiet=quiet
-    )
 
 
 @repository_app.command(
@@ -872,6 +880,9 @@ def test_command(
 
     Any additional arguments are passed directly to pytest.
 
+    This command replaces the current process (``os.execve``) with pytest
+    once dependencies are installed -- it never returns on success.
+
     Examples:
         $ oarepo-cli repository test
         $ oarepo-cli repository test --with-coverage
@@ -879,9 +890,9 @@ def test_command(
         $ oarepo-cli repository test -v -k test_specific
 
     Exit codes:
-        Exit code of the underlying pytest invocation
-        1: Starting Docker services failed, or project context could not be
-           discovered
+        Whatever pytest itself exits with
+        1: Starting Docker services failed, installing pytest/pytest-cov
+           failed, or project context could not be discovered
     """
     pytest_args = ctx.args if ctx.args else []
 
@@ -894,20 +905,15 @@ def test_command(
             invenio_cli.run_invenio_cli(context, ["services", "start"], quiet=quiet)
 
         console.info("→ Running tests...\n")
-        result = repository.run_tests(
-            context, pytest_args=pytest_args, coverage=with_coverage, quiet=quiet
-        )
+        # run_tests() installs pytest/pytest-cov if missing (can raise
+        # ProcessExecutionError, caught below) before exec'ing into pytest --
+        # unlike a pure passthrough, there's real pre-exec work here that
+        # needs this try/except, so the call stays inside it.
+        repository.run_tests(context, pytest_args=pytest_args, coverage=with_coverage, quiet=quiet)
     except OARepoError as e:
         console_err = ConsoleOutput(quiet=False)  # Always show errors
         console_err.error(f"\n✗ repository test failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
-
-    if result.success:
-        console.success("\n✓ All tests passed!\n", fg=typer.colors.BRIGHT_GREEN, bold=True)
-    else:
-        console.error("\n✗ Tests failed!\n", fg=typer.colors.RED, bold=True)
-
-    raise typer.Exit(code=result.return_code)
 
 
 @repository_app.command("translations", context_settings=_SERVICES_CONTEXT_SETTINGS)

--- a/oarepo_cli/services/invenio_cli.py
+++ b/oarepo_cli/services/invenio_cli.py
@@ -125,17 +125,17 @@ def exec_invenio_cli(
             (matching ``run_invenio_cli``/the pre-exec ``services start``
             call, which both pass ``cwd=`` explicitly)
         args: Arguments to pass to invenio-cli
-        env: Additional environment variables (merged with this process's
-            own environment -- unlike ``run_invenio_cli``, there's no
-            subprocess env-merging safety net once this replaces it)
+        env: Additional environment variables, applied on top of
+            ``process.build_subprocess_env()``'s usual stripping/defaults
+            (same as ``run_invenio_cli``'s own env handling via
+            ``process.run()`` -- there's no other subprocess env-merging
+            safety net once this replaces the current process)
 
     Raises:
         OSError: If the invenio-cli binary can't be exec'd (not found, not
             executable, ...)
     """
-    run_env = {**os.environ, **_default_prerelease_env()}
-    if env:
-        run_env.update(env)
+    run_env = process.build_subprocess_env({**_default_prerelease_env(), **(env or {})})
 
     os.chdir(context.root_directory)
     binary = _invenio_cli_path()

--- a/oarepo_cli/services/js_tools.py
+++ b/oarepo_cli/services/js_tools.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 if TYPE_CHECKING:
     from oarepo_cli.core.context import ProjectContext
@@ -130,28 +130,49 @@ def run_jstest(
     context: ProjectContext,
     *,
     setup: bool = False,
-    skip_services: bool = False,
+    service_env: dict[str, str] | None = None,
     extra_args: list[str] | None = None,
-    quiet: bool = False,
-) -> process.ProcessResult:
-    """Run JavaScript tests (Jest) via invenio webpack.
+    quiet: bool = False,  # noqa: ARG001 -- kept for interface symmetry with run_jslint
+) -> process.ProcessResult | NoReturn:
+    """Replace the current process with ``invenio webpack run test`` (Jest).
 
-    Mirrors ``library_runner.sh``'s ``run_jstest``: runs tests via
-    ``invenio webpack run test`` with services started unless
-    --skip-services is set.
+    Mirrors ``library_runner.sh``'s ``run_jstest``. Never returns once the
+    real test run starts: nothing needs to happen in this process
+    afterward, so a terminal Ctrl+C hits Jest directly and its exit code is
+    preserved exactly -- mirrors this module's ``run_jslint`` sibling being
+    the exception (multi-step, so it can't do the same, see its own
+    docstring) and every other one-shot passthrough elsewhere in this
+    codebase (``services.repository.exec_invenio``, etc.). Only the two
+    precondition-failure paths below (``setup`` not implemented, missing
+    ``invenio`` binary) return a value instead -- they're infrastructure
+    errors, not a real test-run outcome, so there's nothing to exec into.
+
+    Unlike ``library``/``repository``'s callers of this function, which
+    decide *how* to start Docker services differently (``library``: raw
+    docker-services-cli via ``ServicesLifecycleManager``; ``repository``:
+    ``invenio-cli services start``, matching ``repository run``/``shell``/
+    ``test`` -- see those for why raw docker-services-cli doesn't apply to
+    a repository), this function itself no longer starts anything: the
+    caller starts services beforehand and passes in whatever connection env
+    vars (if any) the subprocess needs.
 
     Args:
         context: Project context with paths and configuration
         setup: If True, run setup instead of tests
-        skip_services: If True, skip starting Docker services
+        service_env: Environment variables for connecting to already-started
+            services, if any (a repository needs none -- see
+            ``services.repository.exec_shell``'s identical rationale)
         extra_args: Additional arguments passed to the test command
-        quiet: If True, suppress progress output
+        quiet: Unused (kept for interface symmetry with ``run_jslint``)
 
     Returns:
-        ProcessResult from the test command
+        A precondition-failure ``ProcessResult`` for the ``setup``/missing-binary
+        cases; never returns otherwise
+
+    Raises:
+        OSError: If invenio can't be exec'd (not found, not executable, ...)
     """
     from oarepo_cli.core.platform import get_platform_detector
-    from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 
     extra_args = extra_args or []
 
@@ -182,22 +203,7 @@ def run_jstest(
             duration_ms=0,
         )
 
-    # Load or start services to get environment variables
-    services_mgr = ServicesLifecycleManager(
-        config=context.config, project_root=context.root_directory
-    )
-
-    if skip_services:
-        service_env = services_mgr.load_service_env()
-    else:
-        # Start services if needed and get environment
-        service_env = services_mgr.start_services_if_needed()
-
-    # Build environment
-    import os
-
-    cmd_env = dict(os.environ)
-    cmd_env.update(service_env)
+    cmd_env = process.build_subprocess_env(service_env)
     cmd_env["VIRTUAL_ENV"] = str(context.venv_path)
     venv_bin_path = str(context.venv_path / bin_dir)
     cmd_env["PATH"] = f"{venv_bin_path}{os.pathsep}{cmd_env.get('PATH', '')}"
@@ -205,10 +211,5 @@ def run_jstest(
     # Run: invenio webpack run test [extra_args]
     cmd = [str(invenio_path), "webpack", "run", "test", *extra_args]
 
-    return process.run(
-        cmd,
-        cwd=context.root_directory,
-        env=cmd_env,
-        check=False,
-        interactive=not quiet,
-    )
+    os.chdir(context.root_directory)
+    os.execve(str(invenio_path), cmd, cmd_env)

--- a/oarepo_cli/services/process.py
+++ b/oarepo_cli/services/process.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
 # SPDX-License-Identifier: MIT
 
+"""Subprocess execution helpers: run/stream a command, or exec-replace this process."""
+
 from __future__ import annotations
 
 import os
@@ -120,40 +122,50 @@ def get_system_path() -> str:
     return _strip_venv_vars(dict(os.environ)).get("PATH", os.environ.get("PATH", ""))
 
 
-def _merge_env(
-    env: dict[str, str] | None,
+def build_subprocess_env(
+    env: dict[str, str] | None = None,
+    *,
     strip_venv: bool = True,
     include_oarepo_defaults: bool = True,
-) -> dict[str, str] | None:
-    """Merge custom environment with parent environment.
+) -> dict[str, str]:
+    """Build a full environment dict for a subprocess or ``os.execve``/``os.execvpe`` call.
+
+    The single source of truth for env-var handling shared by every
+    command-execution path in this codebase: :func:`run`, :func:`stream`,
+    and every exec-based passthrough (``services.invenio_cli.exec_invenio_cli``,
+    ``services.server.ServerRunner._exec_bare_invenio``,
+    ``services.repository.exec_invenio``/``exec_shell``, ``cli.library``'s
+    ``library_shell``/``library_invenio``, ``services.js_tools.run_jstest``'s
+    real test-run path). Previously duplicated -- with subtly different
+    behavior each time -- inline in :func:`run` (via the old, private
+    ``_merge_env``), a second time in :func:`stream`, and not at all in any
+    of the exec-based functions (which just did
+    ``{**os.environ, <manual overrides>}`` directly, silently missing both
+    the venv-stripping and the OAREPO_ENV_DEFAULTS every blocking call got).
 
     Args:
-        env: Custom environment variables to merge (None = no custom vars)
-        strip_venv: If True, strip VIRTUAL_ENV and related variables to prevent
-                    oarepo-cli's own venv from leaking into subprocesses
-        include_oarepo_defaults: If True, include OARepo default environment variables
-                                 (UV_EXTRA_INDEX_URL, INVENIO_* settings, etc.)
+        env: Custom environment variables, applied last (override everything else)
+        strip_venv: If True, strip ``VIRTUAL_ENV`` and related variables to
+            prevent oarepo-cli's own venv from leaking into a target
+            project's venv
+        include_oarepo_defaults: If True, include ``OAREPO_ENV_DEFAULTS``
+            (``UV_EXTRA_INDEX_URL``, ``INVENIO_*`` settings, etc.), only
+            where not already set in the parent environment
 
     Returns:
-        Merged environment or None if env was None and strip_venv is False
+        A full environment dict, suitable for ``subprocess.run(env=...)``/
+        ``os.execve``/``os.execvpe``
     """
-    if env is None and not strip_venv and not include_oarepo_defaults:
-        return None
+    run_env = dict(os.environ)
 
-    # Start with parent environment
-    run_env = dict(**os.environ)
-
-    # Strip venv variables if requested
     if strip_venv:
         run_env = _strip_venv_vars(run_env)
 
-    # Add OARepo defaults (only if not already set in parent environment)
     if include_oarepo_defaults:
         for key, value in OAREPO_ENV_DEFAULTS.items():
             if key not in run_env:
                 run_env[key] = value
 
-    # Apply custom environment (overrides everything)
     if env is not None:
         run_env.update(env)
 
@@ -196,7 +208,7 @@ def run(
     """
     from oarepo_cli.core.errors import ProcessExecutionError, TimeoutExceeded
 
-    run_env = _merge_env(env, strip_venv=strip_venv)
+    run_env = build_subprocess_env(env, strip_venv=strip_venv)
     start_time = time.time()
 
     # Interactive mode: inherit stdout/stderr for real-time output
@@ -321,18 +333,12 @@ def stream(
     Yields:
         Lines of stdout interleaved with stderr
     """
-    # Start with parent environment, strip venv vars if requested
-    run_env = _strip_venv_vars(dict(os.environ)) if strip_venv else dict(os.environ)
+    run_env = build_subprocess_env(strip_venv=strip_venv)
 
-    # Add OARepo defaults (only if not already set)
-    for key, value in OAREPO_ENV_DEFAULTS.items():
-        if key not in run_env:
-            run_env[key] = value
-
-    # Add streaming defaults
+    # Add streaming defaults, then apply custom environment on top (same
+    # precedence as before: custom env overrides everything, including
+    # STREAM_ENV_DEFAULTS)
     run_env.update(STREAM_ENV_DEFAULTS)
-
-    # Apply custom environment
     if env is not None:
         run_env.update(env)
 

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -580,8 +580,16 @@ def run_tests(
     pytest_args: Sequence[str] = (),
     coverage: bool = False,
     quiet: bool = False,
-) -> process.ProcessResult:
-    """Run pytest in the repository's venv.
+) -> NoReturn:
+    """Install pytest/pytest-cov if needed, then replace the current process with pytest.
+
+    Never returns: unlike installing dependencies (which must complete and
+    be checked before pytest can run), nothing needs to happen in this
+    process once pytest starts -- this doesn't stop Docker services
+    afterward (see below), so there's no cleanup step being skipped by
+    exec'ing. Lets a terminal Ctrl+C hit pytest directly and preserves its
+    exit code exactly, mirroring every other one-shot passthrough in this
+    module (``exec_invenio``, ``exec_shell``).
 
     Unlike ``services.test_orchestrator.TestOrchestrator`` (used by
     ``library test``), this doesn't manage Docker services itself -- the
@@ -611,9 +619,9 @@ def run_tests(
         coverage: If True, enable coverage reporting (HTML + terminal)
         quiet: If True, suppress dependency-installation progress messages
 
-    Returns:
-        ProcessResult from the pytest invocation (``check=False`` --
-        callers report success/failure themselves via the exit code)
+    Raises:
+        ProcessExecutionError: If installing pytest/pytest-cov fails
+        OSError: If pytest can't be exec'd (not found, not executable, ...)
     """
     console = ConsoleOutput(quiet=quiet)
     bin_dir = get_platform_detector().get_venv_bin_dir()
@@ -652,12 +660,9 @@ def run_tests(
         cmd.extend(["--cov-report=html", "--cov-report=term"])
     cmd.extend(pytest_args)
 
-    return process.run(
-        cmd,
-        cwd=context.root_directory,
-        check=False,
-        interactive=True,
-    )
+    os.chdir(context.root_directory)
+    env = process.build_subprocess_env()
+    os.execve(str(pytest_bin), cmd, env)
 
 
 def get_python_version(context: ProjectContext) -> str:

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -382,7 +382,11 @@ def exec_invenio(context: ProjectContext, args: Sequence[str]) -> NoReturn:
     """
     os.chdir(context.root_directory)
     binary = get_invenio_binary(context)
-    env = {**os.environ, "PYTHONWARNINGS": "ignore"}
+    # build_subprocess_env() strips oarepo-cli's own venv and injects
+    # OAREPO_ENV_DEFAULTS (INVENIO_*/... settings), same as any process.run()
+    # call gets -- there's no other subprocess env-merging safety net once
+    # this replaces the current process.
+    env = process.build_subprocess_env({"PYTHONWARNINGS": "ignore"})
     os.execve(str(binary), [str(binary), *args], env)
 
 
@@ -413,7 +417,7 @@ def exec_shell(context: ProjectContext) -> NoReturn:
     platform = get_platform_detector()
     bin_dir = platform.get_venv_bin_dir()
 
-    shell_env = dict(os.environ)
+    shell_env = process.build_subprocess_env()
     shell_env["VIRTUAL_ENV"] = str(context.venv_path)
     venv_bin_path = str(context.venv_path / bin_dir)
     shell_env["PATH"] = f"{venv_bin_path}{os.pathsep}{shell_env.get('PATH', '')}"

--- a/oarepo_cli/services/repository.py
+++ b/oarepo_cli/services/repository.py
@@ -570,6 +570,92 @@ def reset_repository(context: ProjectContext, *, quiet: bool = False) -> None:
     _run_invenio(context, ["roles", "add", "user@demo.org", "administration"], quiet=quiet)
 
 
+def run_tests(
+    context: ProjectContext,
+    *,
+    pytest_args: Sequence[str] = (),
+    coverage: bool = False,
+    quiet: bool = False,
+) -> process.ProcessResult:
+    """Run pytest in the repository's venv.
+
+    Unlike ``services.test_orchestrator.TestOrchestrator`` (used by
+    ``library test``), this doesn't manage Docker services itself -- the
+    caller starts them via ``invenio-cli services start`` first, like
+    ``repository run``/``shell`` (a repository's services are always
+    invenio-cli-managed, unlike a library's raw docker-services-cli setup
+    via ``ServicesLifecycleManager``, which wouldn't correctly drive a
+    repository's own ``docker/docker-compose.yml``), and doesn't stop them
+    afterward either, matching every other ``repository`` command.
+
+    Also doesn't assume a single importable package name for ``--cov``
+    like ``TestOrchestrator`` does (derived from ``[project].name``, correct
+    for a library's one src/-or-package-dir layout): a repository's
+    ``code_directories`` are typically several top-level module directories
+    (see Step 4.15's ``[tool.uv.build-backend]`` support), each already a
+    real importable package name, so every one of them (except ``tests/``)
+    is passed to ``--cov`` instead.
+
+    Unlike a library (which either declares a ``tests`` extra itself or
+    already depends on it transitively), a fresh repository has no such
+    convention, so ``pytest``/``pytest-cov`` are installed directly into the
+    venv on demand if missing, rather than via an extras group.
+
+    Args:
+        context: Project context with paths and configuration
+        pytest_args: Additional arguments to pass to pytest
+        coverage: If True, enable coverage reporting (HTML + terminal)
+        quiet: If True, suppress dependency-installation progress messages
+
+    Returns:
+        ProcessResult from the pytest invocation (``check=False`` --
+        callers report success/failure themselves via the exit code)
+    """
+    console = ConsoleOutput(quiet=quiet)
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    venv_python = context.venv_path / bin_dir / "python"
+    pytest_bin = context.venv_path / bin_dir / "pytest"
+
+    if not pytest_bin.exists():
+        console.info("→ Installing pytest...\n")
+        process.run(
+            ["uv", "pip", "install", "--python", str(venv_python), "pytest"],
+            cwd=context.root_directory,
+            check=True,
+            interactive=not quiet,
+        )
+
+    if coverage:
+        check_cov = process.run(
+            [str(venv_python), "-c", "import pytest_cov"],
+            check=False,
+            capture_output=True,
+        )
+        if not check_cov.success:
+            console.info("→ Installing pytest-cov...\n")
+            process.run(
+                ["uv", "pip", "install", "--python", str(venv_python), "pytest-cov"],
+                cwd=context.root_directory,
+                check=True,
+                interactive=not quiet,
+            )
+
+    cmd = [str(pytest_bin)]
+    if coverage:
+        for directory in context.code_directories:
+            if directory.name != "tests":
+                cmd.extend(["--cov", directory.name])
+        cmd.extend(["--cov-report=html", "--cov-report=term"])
+    cmd.extend(pytest_args)
+
+    return process.run(
+        cmd,
+        cwd=context.root_directory,
+        check=False,
+        interactive=True,
+    )
+
+
 def get_python_version(context: ProjectContext) -> str:
     """Return the resolved Python interpreter's version string (e.g. "Python 3.14.4").
 

--- a/oarepo_cli/services/server.py
+++ b/oarepo_cli/services/server.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, NoReturn
 
-from oarepo_cli.services import invenio_cli, repository
+from oarepo_cli.services import invenio_cli, process, repository
 from oarepo_cli.ui import ConsoleOutput
 
 if TYPE_CHECKING:
@@ -133,5 +133,7 @@ class ServerRunner:
             str(key_path),
             *extra_args,
         ]
-        env = {**os.environ, **site_env, "FLASK_DEBUG": "1", "PYTHONWARNINGS": "ignore"}
+        env = process.build_subprocess_env(
+            {**site_env, "FLASK_DEBUG": "1", "PYTHONWARNINGS": "ignore"}
+        )
         os.execve(str(invenio_path), argv, env)

--- a/tests/integration/test_library_misc_commands.py
+++ b/tests/integration/test_library_misc_commands.py
@@ -6,11 +6,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 from typer.testing import CliRunner
 
 from oarepo_cli.cli.main import app
+from oarepo_cli.core.config import CliConfig
+from oarepo_cli.core.context import ProjectContext
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -188,3 +191,73 @@ def test_license_headers_adds_to_jinja(
     assert "SPDX-FileCopyrightText" in lines[2]
     assert "SPDX-License-Identifier" in lines[3]
     assert lines[4] == "#}"  # End of multi-line comment
+
+
+@pytest.fixture
+def mock_library_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Mock discover_context() and venv-existence checks so library shell/invenio
+    reach their os.execve call without needing a real venv."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    context.python_binary = tmp_path / ".venv" / "bin" / "python3.14"
+    context.oarepo_version = 14
+    context.config = CliConfig()
+    monkeypatch.setattr("oarepo_cli.cli.library.discover_context", lambda: context)
+    monkeypatch.setattr(
+        "oarepo_cli.cli.library.VirtualEnvironmentManager.ensure_venv_exists",
+        lambda self, requirements, quiet=False: context.venv_path,  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.library.ServicesLifecycleManager.load_service_env", lambda _self: {}
+    )
+    return context
+
+
+def test_library_shell_applies_same_env_defaults_as_blocking_calls(
+    runner: CliRunner, mock_library_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """library shell's exec'd environment gets the same OAREPO_ENV_DEFAULTS/venv-stripping
+    treatment any process.run() call gets -- regression test: previously library_shell
+    built its env from bare os.environ, silently missing both."""
+    monkeypatch.setenv("VIRTUAL_ENV", "/oarepo-cli/own/venv")
+    monkeypatch.delenv("INVENIO_APP_THEME", raising=False)
+    execve_calls = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.library.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+
+    result = runner.invoke(app, ["library", "shell", "--skip-services"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    _bash_path, _argv, env = execve_calls[0]
+    assert env["VIRTUAL_ENV"] == str(mock_library_context.venv_path)
+    assert env["INVENIO_APP_THEME"] == '["semantic-ui"]'
+
+
+def test_library_invenio_applies_same_env_defaults_as_blocking_calls(
+    runner: CliRunner, mock_library_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """library invenio's exec'd environment gets the same OAREPO_ENV_DEFAULTS/venv-stripping
+    treatment any process.run() call gets -- regression test: previously library_invenio
+    built its env from bare os.environ, silently missing both."""
+    invenio_path = mock_library_context.venv_path / "bin" / "invenio"
+    invenio_path.parent.mkdir(parents=True)
+    invenio_path.touch()
+    monkeypatch.setenv("VIRTUAL_ENV", "/oarepo-cli/own/venv")
+    monkeypatch.delenv("INVENIO_APP_THEME", raising=False)
+    execve_calls = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.library.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+
+    result = runner.invoke(
+        app, ["library", "invenio", "--skip-services", "db", "upgrade"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0, result.output
+    _invenio_path, _argv, env = execve_calls[0]
+    assert env["VIRTUAL_ENV"] == str(mock_library_context.venv_path)
+    assert env["INVENIO_APP_THEME"] == '["semantic-ui"]'

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -399,11 +399,18 @@ def test_jstest_delegates_to_js_commands_run_jstest_command(
     mock_context: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`repository jstest` delegates to the shared js_commands.run_jstest_command(),
-    forwarding --setup/--skip-services/--quiet and any extra args."""
-    calls: list[dict[str, object]] = []
+    starting services via invenio-cli first (unless --skip-services), then forwarding
+    --setup/--quiet, service_env=None (repository doesn't need connection env vars),
+    and any extra args."""
+    services_calls: list[tuple[object, ...]] = []
+    jstest_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda *args, **kwargs: services_calls.append((args, kwargs)),
+    )
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.js_commands.run_jstest_command",
-        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
+        lambda context, **kwargs: jstest_calls.append({"context": context, **kwargs}),
     )
 
     runner = CliRunner()
@@ -412,11 +419,14 @@ def test_jstest_delegates_to_js_commands_run_jstest_command(
     )
 
     assert result.exit_code == 0, result.output
-    assert calls == [
+    # --skip-services: no invenio-cli services start call
+    assert services_calls == []
+    # service_env=None for repository (doesn't need connection env vars)
+    assert jstest_calls == [
         {
             "context": mock_context,
             "setup": False,
-            "skip_services": True,
+            "service_env": None,
             "extra_args": ["-t", "some.test"],
             "quiet": True,
         }
@@ -455,9 +465,7 @@ def test_test_starts_services_by_default_then_runs_tests(
     )
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.repository.run_tests",
-        lambda context, **kwargs: (
-            test_calls.append({"context": context, **kwargs}) or _fake_process_result()
-        ),
+        lambda context, **kwargs: test_calls.append({"context": context, **kwargs}),
     )
 
     runner = CliRunner()
@@ -482,10 +490,7 @@ def test_test_no_services_skips_starting_services(
         "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
         lambda *args, **kwargs: services_calls.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        "oarepo_cli.cli.repository.repository.run_tests",
-        lambda context, **kwargs: _fake_process_result(),  # noqa: ARG005
-    )
+    monkeypatch.setattr("oarepo_cli.cli.repository.repository.run_tests", lambda *_a, **_k: None)
 
     runner = CliRunner()
     result = runner.invoke(app, ["repository", "test", "--no-services"])
@@ -504,9 +509,7 @@ def test_test_forwards_coverage_and_extra_args(
     calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.repository.run_tests",
-        lambda context, **kwargs: (
-            calls.append({"context": context, **kwargs}) or _fake_process_result()
-        ),
+        lambda context, **kwargs: calls.append({"context": context, **kwargs}),
     )
 
     runner = CliRunner()
@@ -525,17 +528,28 @@ def test_test_forwards_coverage_and_extra_args(
     ]
 
 
-def test_test_reports_failing_tests_with_pytest_exit_code(
+def test_test_reports_dependency_install_failure_and_exits_1(
     mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failing pytest run exits with pytest's own return code, not a generic 1."""
+    """A ProcessExecutionError from run_tests() (e.g. installing pytest/pytest-cov
+    failed) is reported cleanly, exit code 1 -- run_tests() itself never returns on
+    success (it execs into pytest directly), so this is the only failure mode this
+    command's own code can still observe and translate into a message."""
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", lambda *_a, **_k: None
     )
     monkeypatch.setattr(
         "oarepo_cli.cli.repository.repository.run_tests",
-        lambda context, **kwargs: _fake_process_result(return_code=1),  # noqa: ARG005
+        Mock(
+            side_effect=ProcessExecutionError(
+                message="uv pip install pytest failed",
+                command=["uv", "pip", "install", "pytest"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+        ),
     )
 
     runner = CliRunner()

--- a/tests/integration/test_repository_misc.py
+++ b/tests/integration/test_repository_misc.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """Tests for `repository cli`/`invenio`/`shell`/`lint`/`format`/`check`/`jslint`/`jstest`/
-`translations`/`index rebuild`/`reset`/`info`.
+`test`/`translations`/`index rebuild`/`reset`/`info`.
 
 Delegation, argument wiring, and error/exit-code handling are covered here
 by mocking `discover_context()` and the specific service function/module
@@ -434,6 +434,158 @@ def test_jstest_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatc
     result = runner.invoke(app, ["repository", "jstest"])
 
     assert result.exit_code == 1
+
+
+# --- repository test -------------------------------------------------------
+
+
+def test_test_starts_services_by_default_then_runs_tests(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository test` starts Docker services via invenio-cli (like `repository
+    run`/`shell`, not ServicesLifecycleManager) before running tests, by default, and
+    never stops them afterward."""
+    services_calls: list[dict[str, object]] = []
+    test_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda context, args, **kwargs: services_calls.append(
+            {"context": context, "args": list(args), **kwargs}
+        ),
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.run_tests",
+        lambda context, **kwargs: (
+            test_calls.append({"context": context, **kwargs}) or _fake_process_result()
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "test"])
+
+    assert result.exit_code == 0, result.output
+    assert services_calls == [
+        {"context": mock_context, "args": ["services", "start"], "quiet": False}
+    ]
+    assert test_calls == [
+        {"context": mock_context, "pytest_args": [], "coverage": False, "quiet": False}
+    ]
+
+
+def test_test_no_services_skips_starting_services(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-services skips starting Docker services but still runs tests."""
+    services_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        lambda *args, **kwargs: services_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.run_tests",
+        lambda context, **kwargs: _fake_process_result(),  # noqa: ARG005
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "test", "--no-services"])
+
+    assert result.exit_code == 0, result.output
+    assert services_calls == []
+
+
+def test_test_forwards_coverage_and_extra_args(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--with-coverage and extra pytest args are forwarded to repository.run_tests()."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", lambda *_a, **_k: None
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.run_tests",
+        lambda context, **kwargs: (
+            calls.append({"context": context, **kwargs}) or _fake_process_result()
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["repository", "test", "--with-coverage", "-v", "-k", "test_specific"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "context": mock_context,
+            "pytest_args": ["-v", "-k", "test_specific"],
+            "coverage": True,
+            "quiet": False,
+        }
+    ]
+
+
+def test_test_reports_failing_tests_with_pytest_exit_code(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing pytest run exits with pytest's own return code, not a generic 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.run_tests",
+        lambda context, **kwargs: _fake_process_result(return_code=1),  # noqa: ARG005
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "test"])
+
+    assert result.exit_code == 1
+
+
+def test_test_reports_context_discovery_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A context-discovery failure is reported cleanly, exit code 1."""
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.discover_context",
+        Mock(side_effect=ConfigurationError("pyproject.toml not found")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "test"])
+
+    assert result.exit_code == 1
+
+
+def test_test_reports_services_start_failure_and_never_runs_tests(
+    mock_context: Mock,  # noqa: ARG001 -- fixture used for its discover_context patch
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ProcessExecutionError starting services is reported cleanly, exit code 1, and
+    tests are never run."""
+    test_calls: list[object] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.invenio_cli.run_invenio_cli",
+        Mock(
+            side_effect=ProcessExecutionError(
+                message="invenio-cli services start failed",
+                command=["invenio-cli", "services", "start"],
+                returncode=1,
+                stdout=None,
+                stderr=None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "oarepo_cli.cli.repository.repository.run_tests",
+        lambda context, **kwargs: test_calls.append(context),  # noqa: ARG005
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["repository", "test"])
+
+    assert result.exit_code == 1
+    assert test_calls == []
 
 
 # --- repository translations -------------------------------------------

--- a/tests/integration/test_repository_test.py
+++ b/tests/integration/test_repository_test.py
@@ -3,13 +3,20 @@
 
 """Integration tests for `repository test`, using a real venv/pytest (installed on
 demand, since -- unlike a library -- a fresh repository has no "tests" extras
-convention of its own). Always run with --no-services: this doesn't need Docker at
-all, so there's no reason to touch it (or invenio-cli, which isn't installed in
-these minimal fixtures anyway).
+convention of its own).
+
+`services.repository.run_tests()` ends by `os.execve`-ing into pytest, which
+replaces the *calling* process -- exercising that for real (rather than mocking
+`os.execve`, already covered in tests/unit/test_repository_service.py) means driving
+it from its own isolated subprocess (a small driver script run via `sys.executable`),
+never through this test's own CliRunner/pytest worker process, mirroring
+test_server_runner.py's identical rationale for `ServerRunner`'s exec calls.
 """
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -28,7 +35,9 @@ def runner() -> CliRunner:
 
 
 def test_repository_test_help_displays(runner: CliRunner) -> None:
-    """Test that 'repository test --help' displays help text."""
+    """Test that 'repository test --help' displays help text. Safe to drive through
+    CliRunner directly: --help is intercepted by Typer before the command body (and
+    any os.execve) is ever reached."""
     result = runner.invoke(app, ["repository", "test", "--help"])
 
     assert result.exit_code == 0
@@ -36,36 +45,53 @@ def test_repository_test_help_displays(runner: CliRunner) -> None:
     assert "pytest" in result.stdout.lower()
 
 
+def _run_tests_in_subprocess(project_root: Path) -> subprocess.CompletedProcess[str]:
+    """Call services.repository.run_tests() for real, in its own isolated subprocess."""
+    driver = f"""
+from pathlib import Path
+from oarepo_cli.core.config import CliConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.services.repository import run_tests
+
+root = Path({str(project_root)!r})
+context = ProjectContext(
+    root_directory=root,
+    pyproject_path=root / "pyproject.toml",
+    venv_path=root / ".venv",
+    python_binary=root / ".venv" / "bin" / "python3.14",
+    oarepo_version=14,
+    config=CliConfig(),
+)
+run_tests(context, quiet=True)
+"""
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", driver], capture_output=True, text=True
+    )
+
+
 def test_repository_test_runs_real_pytest_and_installs_it_on_demand(
-    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+    lint_project_multi_module: Path,
 ) -> None:
-    """`repository test` installs pytest into the venv (missing by default in a fresh
-    repository fixture) and then actually runs it, real end to end."""
-    monkeypatch.chdir(lint_project_multi_module)
+    """`run_tests()` installs pytest into the venv (missing by default in a fresh
+    repository fixture) and then really execs into it, end to end, in its own
+    isolated subprocess -- inheriting pytest's own exit code."""
     tests_dir = lint_project_multi_module / "tests"
     tests_dir.mkdir()
     (tests_dir / "test_sample.py").write_text("def test_pass():\n    assert True\n")
 
-    result = runner.invoke(
-        app, ["repository", "test", "--no-services", "--quiet"], catch_exceptions=False
-    )
+    result = _run_tests_in_subprocess(lint_project_multi_module)
 
-    assert result.exit_code == 0, result.output
+    assert result.returncode == 0, result.stderr
 
 
-def test_repository_test_exit_code_on_failure(
-    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A failing test makes `repository test` exit with pytest's own non-zero code."""
-    monkeypatch.chdir(lint_project_multi_module)
+def test_repository_test_exit_code_on_failure(lint_project_multi_module: Path) -> None:
+    """A failing test makes the subprocess exit with pytest's own non-zero code."""
     tests_dir = lint_project_multi_module / "tests"
     tests_dir.mkdir()
     (tests_dir / "test_sample.py").write_text(
         "def test_fail():\n    assert False, 'this test fails'\n"
     )
 
-    result = runner.invoke(
-        app, ["repository", "test", "--no-services", "--quiet"], catch_exceptions=False
-    )
+    result = _run_tests_in_subprocess(lint_project_multi_module)
 
-    assert result.exit_code != 0
+    assert result.returncode != 0

--- a/tests/integration/test_repository_test.py
+++ b/tests/integration/test_repository_test.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for `repository test`, using a real venv/pytest (installed on
+demand, since -- unlike a library -- a fresh repository has no "tests" extras
+convention of its own). Always run with --no-services: this doesn't need Docker at
+all, so there's no reason to touch it (or invenio-cli, which isn't installed in
+these minimal fixtures anyway).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a Typer CLI runner."""
+    return CliRunner()
+
+
+def test_repository_test_help_displays(runner: CliRunner) -> None:
+    """Test that 'repository test --help' displays help text."""
+    result = runner.invoke(app, ["repository", "test", "--help"])
+
+    assert result.exit_code == 0
+    assert "test" in result.stdout.lower()
+    assert "pytest" in result.stdout.lower()
+
+
+def test_repository_test_runs_real_pytest_and_installs_it_on_demand(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`repository test` installs pytest into the venv (missing by default in a fresh
+    repository fixture) and then actually runs it, real end to end."""
+    monkeypatch.chdir(lint_project_multi_module)
+    tests_dir = lint_project_multi_module / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text("def test_pass():\n    assert True\n")
+
+    result = runner.invoke(
+        app, ["repository", "test", "--no-services", "--quiet"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_repository_test_exit_code_on_failure(
+    runner: CliRunner, lint_project_multi_module: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing test makes `repository test` exit with pytest's own non-zero code."""
+    monkeypatch.chdir(lint_project_multi_module)
+    tests_dir = lint_project_multi_module / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        "def test_fail():\n    assert False, 'this test fails'\n"
+    )
+
+    result = runner.invoke(
+        app, ["repository", "test", "--no-services", "--quiet"], catch_exceptions=False
+    )
+
+    assert result.exit_code != 0

--- a/tests/integration/test_server_runner.py
+++ b/tests/integration/test_server_runner.py
@@ -168,6 +168,26 @@ def test_run_no_celery_execs_bare_invenio_binary(
     assert env["INVENIO_SITE_CERT_PATH"] == str(repo_root / "docker" / "development.crt")
 
 
+def test_run_no_celery_applies_same_env_defaults_as_blocking_calls(
+    repo_root: Path,
+    mock_services_start: list[list[str]],  # noqa: ARG001
+    mock_exec_bare_invenio: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--no-celery's exec'd environment gets the same OAREPO_ENV_DEFAULTS/venv-stripping
+    treatment any process.run() call gets -- regression test: previously
+    _exec_bare_invenio built its env from bare os.environ, silently missing both."""
+    monkeypatch.setenv("VIRTUAL_ENV", "/oarepo-cli/own/venv")
+    monkeypatch.delenv("INVENIO_APP_THEME", raising=False)
+    context = make_context(repo_root)
+
+    ServerRunner(context, quiet=True).run(no_celery=True)
+
+    env = mock_exec_bare_invenio[0]["env"]
+    assert "VIRTUAL_ENV" not in env
+    assert env["INVENIO_APP_THEME"] == '["semantic-ui"]'
+
+
 def test_run_no_celery_does_not_call_invenio_cli(
     repo_root: Path,
     mock_services_start: list[list[str]],  # noqa: ARG001

--- a/tests/services/test_process_venv_isolation.py
+++ b/tests/services/test_process_venv_isolation.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -105,70 +106,69 @@ def test_strip_venv_vars_no_virtual_env_set() -> None:
     assert cleaned["PATH"] == "/usr/bin:/usr/local/bin"
 
 
-def test_merge_env_strips_venv_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that _merge_env strips venv variables by default."""
+def test_build_subprocess_env_strips_venv_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that build_subprocess_env() strips venv variables by default."""
     monkeypatch.setenv("VIRTUAL_ENV", "/path/to/venv")
     monkeypatch.setenv("OTHER", "value")
 
-    result = process._merge_env(None)
+    result = process.build_subprocess_env()
 
-    assert result is not None
     assert "VIRTUAL_ENV" not in result
     assert "OTHER" in result
 
 
-def test_merge_env_includes_oarepo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that _merge_env includes OARepo defaults by default."""
+def test_build_subprocess_env_includes_oarepo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that build_subprocess_env() includes OARepo defaults by default."""
     # Clear any existing UV_EXTRA_INDEX_URL to test the default
     monkeypatch.delenv("UV_EXTRA_INDEX_URL", raising=False)
 
-    result = process._merge_env(None)
+    result = process.build_subprocess_env()
 
-    assert result is not None
     assert "UV_EXTRA_INDEX_URL" in result
     assert "gitlab.cesnet.cz" in result["UV_EXTRA_INDEX_URL"]
     assert "INVENIO_APP_THEME" in result
 
 
-def test_merge_env_preserves_existing_oarepo_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_subprocess_env_preserves_existing_oarepo_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test that existing OARepo env vars are not overwritten."""
     custom_index = "https://custom.pypi.org/simple"
     monkeypatch.setenv("UV_EXTRA_INDEX_URL", custom_index)
 
-    result = process._merge_env(None)
+    result = process.build_subprocess_env()
 
-    assert result is not None
     # Should preserve the existing value, not overwrite with default
     assert result["UV_EXTRA_INDEX_URL"] == custom_index
 
 
-def test_merge_env_can_skip_oarepo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_subprocess_env_can_skip_oarepo_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that OARepo defaults can be skipped."""
     monkeypatch.delenv("UV_EXTRA_INDEX_URL", raising=False)
 
-    result = process._merge_env(None, include_oarepo_defaults=False)
+    result = process.build_subprocess_env(include_oarepo_defaults=False)
 
-    assert result is not None
     assert "UV_EXTRA_INDEX_URL" not in result
 
 
-def test_merge_env_can_preserve_venv(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that _merge_env can preserve venv variables when requested."""
+def test_build_subprocess_env_can_preserve_venv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that build_subprocess_env() can preserve venv variables when requested."""
     monkeypatch.setenv("VIRTUAL_ENV", "/path/to/venv")
     monkeypatch.setenv("OTHER", "value")
 
-    result = process._merge_env(None, strip_venv=False, include_oarepo_defaults=False)
+    result = process.build_subprocess_env(strip_venv=False, include_oarepo_defaults=False)
 
-    assert result is None  # None input + no strip + no defaults = None
+    # No stripping, no defaults, no custom env -> a plain copy of the parent environment
+    assert result == dict(os.environ)
+    assert result["VIRTUAL_ENV"] == "/path/to/venv"
 
 
-def test_merge_env_custom_vars_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_subprocess_env_custom_vars_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that custom environment variables override parent vars."""
     monkeypatch.setenv("VAR", "parent")
 
-    result = process._merge_env({"VAR": "custom"})
+    result = process.build_subprocess_env({"VAR": "custom"})
 
-    assert result is not None
     assert result["VAR"] == "custom"
 
 

--- a/tests/unit/test_invenio_cli.py
+++ b/tests/unit/test_invenio_cli.py
@@ -147,4 +147,29 @@ def test_exec_invenio_cli_chdirs_and_execs_resolved_binary(
     assert binary == "/venv/bin/invenio-cli"
     assert argv == ["/venv/bin/invenio-cli", "run", "--debugger"]
     assert env["FOO"] == "bar"
+
+
+def test_exec_invenio_cli_applies_same_env_defaults_as_run_invenio_cli(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exec_invenio_cli's environment gets the same OAREPO_ENV_DEFAULTS/venv-stripping
+    treatment as run_invenio_cli's (via process.run()) -- regression test: previously
+    exec_invenio_cli built its env from bare os.environ, silently missing both."""
+    monkeypatch.setattr(
+        "oarepo_cli.services.invenio_cli._invenio_cli_path", lambda: "/venv/bin/invenio-cli"
+    )
+    monkeypatch.setenv("VIRTUAL_ENV", "/oarepo-cli/own/venv")
+    monkeypatch.delenv("INVENIO_APP_THEME", raising=False)
+    execvpe_calls = []
+    monkeypatch.setattr("oarepo_cli.services.invenio_cli.os.chdir", lambda _path: None)
+    monkeypatch.setattr(
+        "oarepo_cli.services.invenio_cli.os.execvpe",
+        lambda *args: execvpe_calls.append(args),
+    )
+
+    invenio_cli.exec_invenio_cli(mock_context, ["run"])
+
+    _binary, _argv, env = execvpe_calls[0]
+    assert "VIRTUAL_ENV" not in env
+    assert env["INVENIO_APP_THEME"] == '["semantic-ui"]'
     assert env["UV_PRERELEASE"] == "allow"

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -487,3 +487,117 @@ def test_get_python_version_returns_stripped_output(monkeypatch: pytest.MonkeyPa
     )
 
     assert repository.get_python_version(context) == "Python 3.14.4"
+
+
+def _run_tests_context(tmp_path: Path, *, code_directories: list[Path]) -> Mock:
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+    # Deliberately distinct from the venv's own python (a system/version-resolver
+    # interpreter, used only to *create* the venv) -- installing into it directly, as
+    # opposed to the venv's own python, would fail against a uv-managed interpreter
+    # ("externally managed", found the hard way against a real fixture).
+    context.python_binary = Path("/usr/bin/python3.14")
+    context.code_directories = code_directories
+    return context
+
+
+def test_run_tests_installs_pytest_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_tests() installs pytest into the venv's own python directly (not via a
+    "tests" extras group, unlike TestOrchestrator, and not context.python_binary,
+    which is the interpreter used to *create* the venv, not the venv's own) when it
+    isn't already there -- a fresh repository has no "tests" extras convention to
+    rely on."""
+    context = _run_tests_context(tmp_path, code_directories=[])
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    venv_python = context.venv_path / bin_dir / "python"
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> process.ProcessResult:
+        calls.append(list(command))
+        return _fake_process_result()
+
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_run)
+
+    repository.run_tests(context, quiet=True)
+
+    install_call = next(c for c in calls if c[:3] == ["uv", "pip", "install"])
+    assert install_call[-1] == "pytest"
+    assert str(venv_python) in install_call
+    assert str(context.python_binary) not in install_call
+
+
+def test_run_tests_skips_pytest_install_when_already_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_tests() doesn't reinstall pytest if the venv's own binary already exists."""
+    context = _run_tests_context(tmp_path, code_directories=[])
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    pytest_bin = context.venv_path / bin_dir / "pytest"
+    pytest_bin.parent.mkdir(parents=True)
+    pytest_bin.touch()
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.process.run",
+        lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
+    )
+
+    repository.run_tests(context, quiet=True)
+
+    assert not any(c[:3] == ["uv", "pip", "install"] for c in calls)
+
+
+def test_run_tests_covers_every_module_directory_not_a_single_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--with-coverage covers every non-tests code_directories entry by name -- unlike
+    TestOrchestrator's single [project].name-derived target, since a repository's
+    code_directories are typically several real, importable top-level packages
+    (Step 4.15), not one src/-or-package-dir."""
+    common = tmp_path / "common"
+    i18n = tmp_path / "i18n"
+    tests_dir = tmp_path / "tests"
+    context = _run_tests_context(tmp_path, code_directories=[common, i18n, tests_dir])
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    pytest_bin = context.venv_path / bin_dir / "pytest"
+    pytest_bin.parent.mkdir(parents=True)
+    pytest_bin.touch()
+    (context.venv_path / bin_dir / "python").touch()
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.process.run",
+        lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
+    )
+
+    repository.run_tests(context, coverage=True, quiet=True)
+
+    pytest_call = next(c for c in calls if c[0] == str(pytest_bin))
+    assert pytest_call.count("--cov") == 2
+    assert "common" in pytest_call
+    assert "i18n" in pytest_call
+    assert "tests" not in pytest_call
+
+
+def test_run_tests_forwards_pytest_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Extra pytest args are appended verbatim to the pytest invocation."""
+    context = _run_tests_context(tmp_path, code_directories=[])
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    pytest_bin = context.venv_path / bin_dir / "pytest"
+    pytest_bin.parent.mkdir(parents=True)
+    pytest_bin.touch()
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.process.run",
+        lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
+    )
+
+    repository.run_tests(context, pytest_args=["-v", "-k", "test_specific"], quiet=True)
+
+    pytest_call = next(c for c in calls if c[0] == str(pytest_bin))
+    assert pytest_call[-3:] == ["-v", "-k", "test_specific"]

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -290,6 +290,44 @@ def test_exec_invenio_chdirs_and_execs_resolved_binary(
     assert env["PYTHONWARNINGS"] == "ignore"
 
 
+def test_exec_invenio_and_exec_shell_apply_same_env_defaults_as_blocking_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exec_invenio()'s and exec_shell()'s environments get the same
+    OAREPO_ENV_DEFAULTS/venv-stripping treatment any process.run() call gets --
+    regression test: previously both built their env from bare os.environ, silently
+    missing both."""
+    context = Mock(spec=ProjectContext)
+    context.root_directory = tmp_path
+    context.venv_path = tmp_path / ".venv"
+
+    monkeypatch.setenv("VIRTUAL_ENV", "/oarepo-cli/own/venv")
+    monkeypatch.delenv("INVENIO_APP_THEME", raising=False)
+    monkeypatch.setattr("oarepo_cli.services.repository.os.chdir", lambda _path: None)
+
+    invenio_execve_calls = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: invenio_execve_calls.append(args),
+    )
+    repository.exec_invenio(context, ["db", "upgrade"])
+    _binary, _argv, invenio_env = invenio_execve_calls[0]
+    assert invenio_env["INVENIO_APP_THEME"] == '["semantic-ui"]'
+
+    shell_execve_calls = []
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: shell_execve_calls.append(args),
+    )
+    repository.exec_shell(context)
+    _bash_path, _argv, shell_env = shell_execve_calls[0]
+    # exec_shell() explicitly overrides VIRTUAL_ENV to the *target* venv -- that's not
+    # the same as failing to strip oarepo-cli's own -- but the default it should have
+    # picked up (independent of anything exec_shell sets explicitly) proves the
+    # underlying env was actually built via build_subprocess_env(), not bare os.environ.
+    assert shell_env["INVENIO_APP_THEME"] == '["semantic-ui"]'
+
+
 def test_exec_shell_sets_up_venv_activation_and_execs_bash(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_repository_service.py
+++ b/tests/unit/test_repository_service.py
@@ -540,6 +540,18 @@ def _run_tests_context(tmp_path: Path, *, code_directories: list[Path]) -> Mock:
     return context
 
 
+def _mock_exec(monkeypatch: pytest.MonkeyPatch) -> list[tuple[object, ...]]:
+    """Mock os.chdir/os.execve at the repository module, so run_tests() never really
+    exec's (which would replace the test runner's own process)."""
+    execve_calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr("oarepo_cli.services.repository.os.chdir", lambda _path: None)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+    return execve_calls
+
+
 def test_run_tests_installs_pytest_when_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -559,6 +571,7 @@ def test_run_tests_installs_pytest_when_missing(
         return _fake_process_result()
 
     monkeypatch.setattr("oarepo_cli.services.repository.process.run", fake_run)
+    _mock_exec(monkeypatch)
 
     repository.run_tests(context, quiet=True)
 
@@ -583,10 +596,42 @@ def test_run_tests_skips_pytest_install_when_already_present(
         "oarepo_cli.services.repository.process.run",
         lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
     )
+    _mock_exec(monkeypatch)
 
     repository.run_tests(context, quiet=True)
 
     assert not any(c[:3] == ["uv", "pip", "install"] for c in calls)
+
+
+def test_run_tests_execs_pytest_with_correct_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_tests() chdirs into the project root (execve has no cwd of its own) and
+    execve's into the venv's own pytest, rather than blocking on a subprocess -- there's
+    nothing to do afterward (no services to stop, unlike library test), so a terminal
+    Ctrl+C hits pytest directly and its exit code is preserved exactly."""
+    context = _run_tests_context(tmp_path, code_directories=[])
+    bin_dir = get_platform_detector().get_venv_bin_dir()
+    pytest_bin = context.venv_path / bin_dir / "pytest"
+    pytest_bin.parent.mkdir(parents=True)
+    pytest_bin.touch()
+    monkeypatch.setattr("oarepo_cli.services.repository.process.run", lambda *a, **k: None)  # noqa: ARG005
+    chdir_calls = []
+    execve_calls = []
+    monkeypatch.setattr("oarepo_cli.services.repository.os.chdir", chdir_calls.append)
+    monkeypatch.setattr(
+        "oarepo_cli.services.repository.os.execve",
+        lambda *args: execve_calls.append(args),
+    )
+
+    repository.run_tests(context, quiet=True)
+
+    assert chdir_calls == [tmp_path]
+    assert len(execve_calls) == 1
+    binary, argv, env = execve_calls[0]
+    assert binary == str(pytest_bin)
+    assert argv == [str(pytest_bin)]
+    assert env["PATH"]  # a real, built environment, not an empty dict
 
 
 def test_run_tests_covers_every_module_directory_not_a_single_package(
@@ -606,19 +651,19 @@ def test_run_tests_covers_every_module_directory_not_a_single_package(
     pytest_bin.touch()
     (context.venv_path / bin_dir / "python").touch()
 
-    calls: list[list[str]] = []
     monkeypatch.setattr(
         "oarepo_cli.services.repository.process.run",
-        lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
+        lambda *_a, **_k: _fake_process_result(),
     )
+    execve_calls = _mock_exec(monkeypatch)
 
     repository.run_tests(context, coverage=True, quiet=True)
 
-    pytest_call = next(c for c in calls if c[0] == str(pytest_bin))
-    assert pytest_call.count("--cov") == 2
-    assert "common" in pytest_call
-    assert "i18n" in pytest_call
-    assert "tests" not in pytest_call
+    _binary, argv, _env = execve_calls[0]
+    assert argv.count("--cov") == 2
+    assert "common" in argv
+    assert "i18n" in argv
+    assert "tests" not in argv
 
 
 def test_run_tests_forwards_pytest_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -629,13 +674,9 @@ def test_run_tests_forwards_pytest_args(tmp_path: Path, monkeypatch: pytest.Monk
     pytest_bin.parent.mkdir(parents=True)
     pytest_bin.touch()
 
-    calls: list[list[str]] = []
-    monkeypatch.setattr(
-        "oarepo_cli.services.repository.process.run",
-        lambda command, **_kwargs: calls.append(list(command)) or _fake_process_result(),
-    )
+    execve_calls = _mock_exec(monkeypatch)
 
     repository.run_tests(context, pytest_args=["-v", "-k", "test_specific"], quiet=True)
 
-    pytest_call = next(c for c in calls if c[0] == str(pytest_bin))
-    assert pytest_call[-3:] == ["-v", "-k", "test_specific"]
+    _binary, argv, _env = execve_calls[0]
+    assert argv[-3:] == ["-v", "-k", "test_specific"]


### PR DESCRIPTION
## Summary
- Adds `oarepo-cli repository test`. Turned out not to be the drop-in port the plan expected — `TestOrchestrator` isn't reused, since its services-lifecycle shape, coverage-target selection, and dependency-install strategy all assume a library's setup.
- Adds `services.repository.run_tests()` instead:
  - **Services**: unconditional `invenio-cli services start` (unless `--no-services`, matching `run`/`shell`'s naming) with no auto-stop afterward — matching every other `repository` command's lifecycle shape, not `TestOrchestrator`'s "start if needed, stop when done" pairing (reasonable for a library's ephemeral test runs, wrong for a repository's shared dev services). Drops `ServicesLifecycleManager` entirely — raw docker-services-cli doesn't drive a repository's own `docker/docker-compose.yml`.
  - **Coverage**: covers every non-`tests` `code_directories` entry by name, not a single `[project].name`-derived target — a repository's modules are typically several real top-level packages (Step 4.15), and the project's own declared name usually isn't one of them.
  - **Dependencies**: installs `pytest`/`pytest-cov` directly into the venv on demand if missing, rather than gating on a "tests" extras group — confirmed via `tests/testrepo`'s own `pyproject.toml` that a fresh repository has no such convention.
- Caught for real during testing: installing against `context.python_binary` (the interpreter used to *create* the venv) fails against a real uv-managed system interpreter ("externally managed"); fixed to target the venv's own python explicitly.
- No shared module with `library_test` (unlike Steps 4.18/4.19) — the underlying orchestration differs enough that forcing one shared implementation would need a services-lifecycle strategy injection, adding more complexity than it'd save.
- Updates `README.md` to document the new command.

## Test plan
- [x] `make check` (lint + format + type-check) passes
- [x] Unit tests for `run_tests()` (services/coverage/dependency-install behavior), CLI-wiring tests, and a real end-to-end integration test (`--no-services`, no Docker needed) that caught and verified the fix for the `context.python_binary` bug above
- [x] Full `make test` — 539 passed