### PR TITLE
docs: add test fixture naming conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,5 +135,30 @@ The API endpoint returns JSON with `path`, `line`, `original_line`, and `body` f
   from oarepo_cli.services import process
   ```
   This keeps type-only imports (which cause circular import issues) clearly separated from runtime imports.
+- **Test fixture naming**: Follow these conventions for pytest fixtures:
+  - **Use descriptive names without prefixes** for most fixtures: `testlib_project`, `clean_testlib`, `test_context`, `lint_project`
+  - **Use `mock_` prefix** only for fixtures that return Mock objects: `mock_context`, `mock_project_root`
+  - **Use `clean_` prefix** for cleanup fixtures that set up and tear down state: `clean_testlib`, `clean_testrepo`
+  - **Avoid generic names**: prefer `lint_project` over `project`, `test_context` over `context`
+  - **Document what the fixture provides** in the docstring, especially for complex fixtures
+  - Examples:
+    ```python
+    @pytest.fixture
+    def mock_context(tmp_path: Path) -> Mock:
+        """Create a mock ProjectContext for unit tests."""
+        ...
+
+
+    @pytest.fixture
+    def clean_testlib(testlib_project: Path) -> Iterator[Path]:
+        """Clean up testlib before and after each test."""
+        ...
+
+
+    @pytest.fixture
+    def lint_project(tmp_path: Path) -> Path:
+        """A minimal, lint-clean library project with a real venv."""
+        ...
+    ```
 - Follow `implementation-steps.md`'s status flags when checking off work:
   `[ ]` not started, `[~]` in progress, `[x]` done (code + tests passing), `[!]` blocked.

--- a/docs/architecture/fixture-naming-summary.md
+++ b/docs/architecture/fixture-naming-summary.md
@@ -1,0 +1,71 @@
+# Test Fixture Naming Convention Documentation
+
+## Summary
+
+This PR addresses review.md issue 4.1 (Test Fixture Naming Inconsistency) by documenting the observed fixture naming patterns in AGENTS.md.
+
+## Problem Statement
+
+From the code review:
+> **Issue:** Some fixtures use `mock_*` prefix, others use descriptive names without prefixes. There's no consistent convention.
+>
+> **Recommendation:** Document preferred fixture naming convention in AGENTS.md and apply uniformly in new tests.
+
+## Solution
+
+Rather than enforcing a new convention or refactoring existing code, this PR documents the patterns already present in the codebase:
+
+### Fixture Naming Conventions
+
+1. **`mock_*` prefix** - Only for fixtures that return Mock objects
+   - `mock_context` - Mock ProjectContext
+   - `mock_project_root` - Mock project root directory
+
+2. **`clean_*` prefix** - For cleanup fixtures with setup/teardown
+   - `clean_testlib` - Cleans up testlib before and after tests
+   - `clean_testrepo` - Resets testrepo install-generated state
+
+3. **Descriptive names without prefixes** - For most fixtures
+   - `testlib_project` - Path to testlib fixture project
+   - `test_context` - ProjectContext using testlib
+   - `lint_project` - Minimal, lint-clean library project
+   - `lint_project_multi_module` - Multi-module lint project
+
+4. **Guidelines**
+   - Avoid generic names (prefer `lint_project` over `project`)
+   - Always document what the fixture provides in its docstring
+   - Name should clearly indicate the fixture's purpose
+
+## Examples Provided
+
+The documentation includes three concrete examples showing:
+- A `mock_context` fixture returning a Mock object
+- A `clean_testlib` cleanup fixture with setup/teardown
+- A `lint_project` descriptive fixture
+
+These examples are taken directly from the existing codebase (tests/conftest.py, tests/unit/test_lint_service.py, tests/integration/conftest.py).
+
+## Impact
+
+- **No code changes required** - Existing fixtures already follow these patterns
+- **Clear guidance for future tests** - Developers know which pattern to use
+- **Documentation-only change** - Zero risk to existing functionality
+- **Maintains consistency** - Formalizes observed best practices
+
+## Files Modified
+
+1. **AGENTS.md**
+   - Added "Test fixture naming" subsection under Conventions
+   - Included three code examples
+   - Clear, actionable guidelines
+
+2. **docs/architecture/review.md**
+   - Marked issue 4.1 as resolved
+   - Updated recommendations section to show completion
+   - Added to changelog
+
+## Verification
+
+- ✅ `make check` passes (lint, format, type-check)
+- ✅ Documentation is clear and includes examples
+- ✅ Review.md accurately reflects resolution status

--- a/docs/architecture/review.md
+++ b/docs/architecture/review.md
@@ -57,16 +57,9 @@ All previous high-priority issues have been addressed. See git history for detai
 
 ## 4. Low Priority Issues
 
-### 4.1 Test Fixture Naming Inconsistency
+### All Resolved ✅
 
-**Locations:** Test files
-**Severity:** Low (Style)
-
-**Issue:**
-Some fixtures use `mock_*` prefix, others use descriptive names without prefixes. There's no consistent convention.
-
-**Recommendation:**
-Document preferred fixture naming convention in AGENTS.md and apply uniformly in new tests.
+All low priority issues have been addressed.
 
 ---
 
@@ -148,7 +141,7 @@ _All high-priority issues have been resolved!_ 🎉
 4. **Consider renaming forward_stdout** for clarity (issue 3.4) - 1-2 hours
 
 ### Long Term (Backlog)
-6. **Standardize fixture naming** convention (issue 4.1) - 1 hour
+_(All backlog items have been completed)_ ✅
 
 ---
 
@@ -238,6 +231,10 @@ The remaining issues are all medium/low priority maintainability improvements th
 See git history for detailed change tracking. Key milestones:
 
 ### 2026-08-05
+- ✅ Test fixture naming convention documented in AGENTS.md (issue 4.1)
+  - Added clear guidelines: `mock_*` for Mock objects, `clean_*` for cleanup fixtures
+  - Provided examples for descriptive naming patterns
+  - Emphasized good documentation practices
 - ✅ Lock file race conditions addressed (PR #152)
   - Added SIGTERM/SIGINT signal handlers
   - Added atexit handler for cleanup


### PR DESCRIPTION
## Summary

Addresses review.md issue 4.1 (Test Fixture Naming Inconsistency).

This PR documents the test fixture naming conventions observed in the codebase, providing clear guidelines for future test development.

## Changes

### AGENTS.md
Added a new section under **Conventions** with comprehensive fixture naming guidelines:

- **Use `mock_` prefix** only for fixtures that return Mock objects
  - Examples: `mock_context`, `mock_project_root`
- **Use `clean_` prefix** for cleanup fixtures that set up and tear down state
  - Examples: `clean_testlib`, `clean_testrepo`
- **Use descriptive names without prefixes** for most fixtures
  - Examples: `testlib_project`, `lint_project`, `test_context`
- **Avoid generic names**
  - Prefer `lint_project` over `project`, `test_context` over `context`
- **Document what the fixture provides** in the docstring

Includes three concrete code examples from the existing codebase to illustrate the patterns.

### review.md
- Marked issue 4.1 as resolved
- Updated recommendations section
- Added to changelog

## Impact

This is a documentation-only change. No code modifications are needed as the existing fixtures already follow these patterns. The documentation will guide future test development to maintain consistency.