### PR TITLE
Step 5.2: Repository Installation Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,20 +497,31 @@ oarepo-cli new my-repo
 ```
 
 **Options:**
-- `--python <binary>`: Python binary to use (default: `python3.14`)
+- `--python <binary>`: Python binary to use (default: `python3.14`) — validated for interface
+  compatibility with the shell script, but not otherwise used: copier runs in-process (see below)
 - `--template <url/path>`: Copier template — a GitHub URL or a local path (default: `https://github.com/oarepo/nrp-app-copier`)
 - `--version <ref>`: Template git ref, used when `--template` is a GitHub URL (default: `rdm-14`)
-- `--uv <binary>`: `uv` binary to use (default: `uv`)
-- `--uvx <binary>`: `uvx` binary to use (default: `uvx`)
+- `--uv <binary>`: `uv` binary to use (default: `uv`) — validated but not otherwise used, same as `--python`
+- `--uvx <binary>`: `uvx` binary to use (default: `uvx`) — validated but not otherwise used, same as `--python`
 - `--config <file>`: Additional copier data file, seeding answers non-interactively
 
-**Current status:** argument parsing and upfront validation only (`uv`/`uvx`/`python` must
-resolve on `PATH`, the repository name must be non-blank) — the actual scaffolding (running
-copier, generating SSL certificates, Docker compose symlinks, git init) is not implemented yet.
+**What it does:**
+1. Validates `uv`/`uvx`/`python` resolve on `PATH` and the repository name is non-blank
+2. Renders the template into `./<REPOSITORY_NAME>` via `copier.run_copy` — invoked in-process,
+   using this venv's own installed `copier` + `copier-template-extensions`, the same approach
+   [`repository model create`](#repository-model) uses, rather than shelling out to
+   `uvx --python <python_binary> --with copier-template-extensions --with pycountry copier copy ...`
+   for a fresh ephemeral environment on every call
+3. Generates a self-signed development TLS certificate/key pair (`docker/development.crt`/`.key`)
+4. Runs a best-effort `docker compose down` to clear out any stale containers from a previous
+   attempt at the same repository name
+5. Initializes a git repository with an initial commit (skipped in CI, or without git installed)
 
 **Exit codes:**
 - `0`: Success
-- `1`: Invalid input (missing repository name, or `uv`/`uvx`/`python` binary not found)
+- `1`: Invalid input (missing repository name, or `uv`/`uvx`/`python` binary not found), or
+  repository creation failed (e.g. a given `--config` file was removed after Typer's own
+  existence check but before copier ran)
 - `2`: Usage error (missing `REPOSITORY_NAME`, or `--config` file doesn't exist)
 
 ## Repository Tools
@@ -1125,7 +1136,7 @@ If you're migrating from the old bash scripts:
 | `./run.sh format` | `oarepo-cli library format` |
 | `./run.sh shell` | `oarepo-cli library shell` |
 | `./run.sh oarepo-versions` | `oarepo-cli library oarepo-versions` |
-| `./repository_installer.sh NAME` | `oarepo-cli new NAME` (argument validation only so far — see [Repository Installer](#repository-installer)) |
+| `./repository_installer.sh NAME` | `oarepo-cli new NAME` (see [Repository Installer](#repository-installer)) |
 
 **Breaking changes:**
 - `library lint` and `library format` **auto-fix by default** (use `--no-fix` for report-only)

--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1962,22 +1962,26 @@ reused; `services.repository.run_tests()` was added instead, and
 ### Step 5.2: Repository Installation Workflow
 **Goal**: Implement complete repository scaffolding.
 
-- [ ] Implement `services/repository_installer.py` with `RepositoryInstaller` class
-- [ ] Method: `install(name, template, version, python_binary)` → Path
-- [ ] Run `copier copy` with template
-- [ ] Generate SSL certificates with openssl
-- [ ] Setup Docker compose symlinks
-- [ ] Initialize git repository (if not in CI)
-- [ ] Return path to created repository
+- [x] Implement `services/repository_installer.py` with `RepositoryInstaller` class
+- [x] Method: `install(name, *, template, version, config_file)` → Path (no
+      `python_binary` -- copier runs in-process, the same
+      `services.models.ModelManager` approach, so there's no separate copier
+      process left to select an interpreter for; see the class docstring)
+- [x] Run `copier copy` with template (via `copier.run_copy`, in-process,
+      like `ModelManager`, not `uvx --python ... copier copy ...`)
+- [x] Generate SSL certificates with openssl
+- [x] Setup Docker compose symlinks
+- [x] Initialize git repository (if not in CI)
+- [x] Return path to created repository
 
 **Deliverables**:
 - Full repository installation
 
 **Tests** (`tests/integration/test_repository_installer.py`):
-- [ ] Test copier executed with params
-- [ ] Test certificates generated
-- [ ] Test git initialized
-- [ ] Integration test: create real repository (slow)
+- [x] Test copier executed with params
+- [x] Test certificates generated
+- [x] Test git initialized
+- [x] Integration test: create real repository (slow)
 
 ---
 

--- a/oarepo_cli/cli/installer.py
+++ b/oarepo_cli/cli/installer.py
@@ -3,17 +3,17 @@
 
 """Top-level `new` command: scaffolds a brand-new repository.
 
-This is the CLI-only skeleton for `repository_installer.sh`'s replacement:
-argument parsing, defaults, and the same upfront validation the shell
-script performs in its `parse_arguments()` (uv/uvx/python binaries must
-resolve on PATH, a repository name must be given) -- before any subprocess
-runs. Mirrors `core/context.py`'s ProjectContext resolution, which
-performs the identical "not found" check for its own Python binary.
+Argument parsing, defaults, and the same upfront validation
+`repository_installer.sh`'s `parse_arguments()` performs (uv/uvx/python
+binaries must resolve on PATH, a repository name must be given) -- before
+any subprocess runs. Mirrors `core/context.py`'s ProjectContext
+resolution, which performs the identical "not found" check for its own
+Python binary.
 
 The actual scaffolding (copier invocation, certificate generation, Docker
-compose symlinks, git init) is a separate, later step -- see
-`implementation-steps.md`'s Step 5.2 (`services/repository_installer.py`,
-`RepositoryInstaller`), not implemented yet.
+Compose cleanup, git init) is `services.repository_installer.RepositoryInstaller`
+-- see its class docstring for why `--python`/`--uv`/`--uvx` are validated
+here but not forwarded to it.
 """
 
 from __future__ import annotations
@@ -26,6 +26,7 @@ import typer
 
 from oarepo_cli.core.errors import ConfigurationError, OARepoError
 from oarepo_cli.services.process import get_system_path
+from oarepo_cli.services.repository_installer import RepositoryInstaller
 from oarepo_cli.ui import ConsoleOutput
 
 DEFAULT_PYTHON = "python3.14"
@@ -39,10 +40,10 @@ def _require_binary(binary: str, option: str) -> None:
     """Raise ConfigurationError if `binary` cannot be resolved on PATH.
 
     Mirrors repository_installer.sh's `command -v "${binary}"` checks for
-    uv/uvx/python: verified upfront since copier is invoked as `uvx
-    --python <python_binary> ... copier ...` (Step 5.2), where a
-    missing/misnamed binary would otherwise only surface as an opaque uvx
-    failure well into the installation.
+    uv/uvx/python. RepositoryInstaller no longer actually uses these
+    binaries itself (see its class docstring) -- validated here purely for
+    interface compatibility with the shell script, which required them
+    upfront before running anything.
     """
     if shutil.which(binary, path=get_system_path()) is None:
         raise ConfigurationError(
@@ -73,7 +74,7 @@ def new_repository(
     ] = DEFAULT_TEMPLATE_VERSION,
     uv: Annotated[str, typer.Option("--uv", help="uv binary to use")] = DEFAULT_UV,
     uvx: Annotated[str, typer.Option("--uvx", help="uvx binary to use")] = DEFAULT_UVX,
-    config: Annotated[  # noqa: ARG001 -- forwarded to RepositoryInstaller once Step 5.2 implements it
+    config: Annotated[
         Path | None,
         typer.Option(
             "--config",
@@ -87,10 +88,9 @@ def new_repository(
 ) -> None:
     """Create a new repository from a copier template.
 
-    See ``services.repository_installer.RepositoryInstaller`` (not yet
-    implemented -- see ``implementation-steps.md``'s Step 5.2) for the
-    actual scaffolding steps: running copier, generating SSL certificates,
-    setting up Docker compose symlinks, and initializing git.
+    See ``services.repository_installer.RepositoryInstaller.install`` for
+    the individual steps: running copier, generating SSL certificates,
+    cleaning up stale Docker state, and initializing git.
 
     Examples:
         $ oarepo-cli new my-repo
@@ -101,7 +101,7 @@ def new_repository(
     Exit codes:
         0: Success
         1: Invalid input (missing repository name, or uv/uvx/python binary
-           not found)
+           not found), or repository creation failed
     """
     console = ConsoleOutput()
     try:
@@ -110,12 +110,18 @@ def new_repository(
         _require_binary(uv, "--uv")
         _require_binary(uvx, "--uvx")
         _require_binary(python, "--python")
+
+        console.info(
+            f"Creating repository '{repository_name}' using template '{template}' "
+            f"with version '{version}'...\n",
+            fg=typer.colors.BRIGHT_BLUE,
+        )
+        RepositoryInstaller(console).install(
+            repository_name,
+            template=template,
+            version=version,
+            config_file=config,
+        )
     except OARepoError as e:
         console.error(f"\n✗ Repository creation failed: {e}\n", fg=typer.colors.RED)
         raise typer.Exit(1) from e
-
-    console.info(
-        f"Creating repository '{repository_name}' using template '{template}' "
-        f"with version '{version}'...\n",
-        fg=typer.colors.BRIGHT_BLUE,
-    )

--- a/oarepo_cli/services/repository_installer.py
+++ b/oarepo_cli/services/repository_installer.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Repository installer: scaffolds a brand-new repository from a copier template."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import copier
+import yaml
+
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services import process
+from oarepo_cli.services.process import ProcessOutputMode
+from oarepo_cli.ui import ConsoleOutput  # noqa: TC001 (used at runtime, not just type hints)
+
+DEVELOPMENT_CERT_SUBJECT = "/C=CH/ST=./L=./O=./OU=./CN=localhost/emailAddress=."
+
+
+def _load_yaml_data(path: Path) -> dict[str, Any]:
+    """Load a YAML answers/data file into a dict, the same way copier's own
+    ``--data-file`` CLI flag does (``copier._cli.py:data_file_switch``),
+    matching ``services.models._load_yaml_data``'s same rationale.
+    """
+    with path.open("rb") as f:
+        return yaml.safe_load(f) or {}
+
+
+class RepositoryInstaller:
+    """Scaffolds a brand-new repository from a copier template.
+
+    Mirrors ``repository_installer.sh``'s ``create_repository()`` and the
+    setup steps that follow it (SSL certificate generation, a Docker
+    Compose cleanup, git initialization), but invokes copier directly as a
+    library (``copier.run_copy``) using this venv's own installed
+    ``copier`` + ``copier-template-extensions``, exactly the approach
+    ``services.models.ModelManager`` already uses for model templates --
+    rather than shelling out to ``uvx --python <python_binary> --with
+    copier-template-extensions --with pycountry copier copy ...`` for a
+    fresh ephemeral environment on every call.
+
+    One consequence: the ``--python``/``--uv``/``--uvx`` options on
+    ``cli.installer.new_repository`` no longer select which
+    interpreter/tool actually runs copier -- they're still validated there
+    for interface compatibility with the shell script (a missing binary is
+    still reported clearly, before anything else runs) but aren't forwarded
+    here, since there's no longer a separate copier process to run them
+    with.
+    """
+
+    def __init__(self, console: ConsoleOutput) -> None:
+        """Initialize the repository installer.
+
+        Args:
+            console: Console output handler for status messages
+        """
+        self._console = console
+
+    def install(
+        self,
+        name: str,
+        *,
+        template: str,
+        version: str,
+        config_file: Path | None = None,
+    ) -> Path:
+        """Create a new repository from ``template`` in ``./<name>``.
+
+        Mirrors ``repository_installer.sh``'s ``create_repository()`` plus
+        everything that follows it in the script: SSL certificate
+        generation, a best-effort ``docker compose down`` for any stale
+        containers from a previous attempt at this name, and git
+        initialization (skipped in CI or without git installed).
+
+        Args:
+            name: Repository name -- both the copier ``repository_name``
+                answer (always passed, matching the shell script's own
+                unconditional ``-d repository_name=`` even when
+                ``--config``/``--data-file`` is also given) and the
+                destination directory, created relative to the current
+                working directory (matching the shell script)
+            template: A GitHub URL (rendered with ``vcs_ref=version``) or a
+                local path (``version`` is ignored, matching copier's own
+                behavior for non-VCS templates)
+            version: Template git ref, used only when ``template`` is a
+                GitHub URL
+            config_file: Optional YAML data file seeding all answers (see
+                ``services.models.ModelManager.create_model``'s docstring
+                for why this is passed as copier's ``data``, not merely
+                ``answers_file``)
+
+        Returns:
+            Path to the created repository (``./<name>``, resolved)
+
+        Raises:
+            ConfigurationError: If config_file is given but doesn't exist
+        """
+        if config_file is not None and not config_file.exists():
+            raise ConfigurationError(f"Missing repository config file: {config_file}")
+
+        target_dir = Path.cwd() / name
+        is_github = template.startswith("https://")
+
+        self._console.info(f"→ Creating repository '{name}' from {template}\n")
+
+        # copier's quiet flag controls its own output
+        quiet_for_copier = self._console.is_quiet
+        data: dict[str, Any] = _load_yaml_data(config_file) if config_file is not None else {}
+        data["repository_name"] = name
+        copier.run_copy(
+            template,
+            target_dir,
+            data=data,
+            vcs_ref=version if is_github else None,
+            unsafe=True,
+            quiet=quiet_for_copier,
+        )
+
+        self._generate_certificates(target_dir)
+        self._clean_docker_state(target_dir)
+        self._init_git(target_dir)
+
+        self._console.success(f"✓ Repository '{name}' created successfully.\n")
+        return target_dir
+
+    def _generate_certificates(self, target_dir: Path) -> None:
+        """Generate a self-signed development TLS cert/key pair.
+
+        Matches ``repository_installer.sh``'s ``openssl`` invocation
+        exactly: same RSA key size, validity period, and subject.
+        """
+        docker_dir = target_dir / "docker"
+        self._console.info("→ Generating development TLS certificate\n")
+        process.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:4096",
+                "-nodes",
+                "-out",
+                str(docker_dir / "development.crt"),
+                "-keyout",
+                str(docker_dir / "development.key"),
+                "-days",
+                "3650",
+                "-subj",
+                DEVELOPMENT_CERT_SUBJECT,
+            ],
+            output_mode=ProcessOutputMode.INTERACTIVE,
+        )
+
+    def _clean_docker_state(self, target_dir: Path) -> None:
+        """Best-effort ``docker compose down`` for any stale containers left
+        over from a previous attempt at this repository name.
+
+        Matches ``repository_installer.sh``'s transient ``.env`` symlink
+        (``ln -s ../variables .env``, used only so ``docker compose`` can
+        resolve its variable substitutions, then removed again
+        immediately after) -- the failure of ``docker compose down``
+        itself is ignored (``|| true`` in the shell script), since a
+        brand-new repository name should never have any containers to
+        remove in the first place.
+        """
+        docker_dir = target_dir / "docker"
+        env_symlink = docker_dir / ".env"
+        env_symlink.symlink_to(Path("..") / "variables")
+        try:
+            process.run(
+                ["docker", "compose", "down"],
+                cwd=docker_dir,
+                check=False,
+                output_mode=ProcessOutputMode.INTERACTIVE,
+            )
+        finally:
+            env_symlink.unlink()
+
+    def _init_git(self, target_dir: Path) -> None:
+        """Initialize a git repository with an initial commit.
+
+        Skipped in CI or without git installed, matching
+        ``repository_installer.sh``'s ``[[ -z "${CI:-}" ]] && command -v
+        git`` check exactly -- any non-empty ``CI`` value skips this, not
+        just ``CI=true``.
+        """
+        if os.environ.get("CI"):
+            return
+        if shutil.which("git") is None:
+            return
+
+        self._console.info("→ Initializing git repository\n")
+        process.run(
+            ["git", "init", "-b", "main"], cwd=target_dir, output_mode=ProcessOutputMode.INTERACTIVE
+        )
+        process.run(["git", "add", "."], cwd=target_dir, output_mode=ProcessOutputMode.INTERACTIVE)
+        process.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=target_dir,
+            output_mode=ProcessOutputMode.INTERACTIVE,
+        )

--- a/tests/integration/test_repository_installer.py
+++ b/tests/integration/test_repository_installer.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for RepositoryInstaller, against real copier and a small local template.
+
+Mirrors test_model_manager.py's approach for ModelManager: copier is
+invoked as an in-process Python library (see
+services/repository_installer.py's module docstring), so these tests run
+copier for real against a small local template fixture (fast: no network,
+no ephemeral uvx environment to bootstrap) rather than mocking copier's
+Python API. openssl/git/docker are all real, fast, side-effect-free
+invocations for a repository that's never actually started -- `docker
+compose down` fails fast and harmlessly without a running daemon or
+compose file present, matching the shell script's own `|| true`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import copier
+import pytest
+
+from oarepo_cli.core.errors import ConfigurationError
+from oarepo_cli.services.repository_installer import RepositoryInstaller
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+COPIER_YML = """\
+repository_name:
+  type: str
+  help: Repository name
+  when: false
+"""
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def local_template(tmp_path: Path) -> Path:
+    """A small, real, git-tracked copier template: a hidden repository_name
+    question, a rendered README, and the docker/variables layout a real
+    repository template has (needed by certificate generation/the docker
+    compose cleanup step)."""
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    (template_dir / "copier.yml").write_text(COPIER_YML)
+    (template_dir / "README.md.jinja").write_text("# {{ repository_name }}\n")
+    docker_dir = template_dir / "docker"
+    docker_dir.mkdir()
+    (docker_dir / ".gitkeep").write_text("")
+    (template_dir / "variables").write_text("INVENIO_UI_PORT=5000\n")
+
+    _git("init", "-q", cwd=template_dir)
+    _git("add", "-A", cwd=template_dir)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=template_dir,
+    )
+    return template_dir
+
+
+@pytest.fixture(autouse=True)
+def _skip_git_init_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Most tests here aren't about git initialization -- skip it (as in CI) by
+    default, so only the tests that care about it opt back in."""
+    monkeypatch.setenv("CI", "true")
+
+
+def test_install_renders_local_template(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install() renders the template for real into ./<name>, using repository_name as data."""
+    monkeypatch.chdir(tmp_path)
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    assert target == tmp_path / "my-repo"
+    assert (target / "README.md").read_text() == "# my-repo\n"
+
+
+def test_install_config_file_answers_but_repository_name_always_wins(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A --config data file seeds answers, but repository_name is always forced to the
+    given name -- mirrors repository_installer.sh's unconditional `-d repository_name=`,
+    passed even when --data-file is also given (unlike ModelManager's create_model)."""
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "answers.yml"
+    config_file.write_text("repository_name: wrong-name\n")
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD", config_file=config_file
+    )
+
+    assert target == tmp_path / "my-repo"
+    assert (target / "README.md").read_text() == "# my-repo\n"
+
+
+def test_install_missing_config_file_raises(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-existent config_file raises ConfigurationError before copier ever runs."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ConfigurationError, match="Missing repository config file"):
+        RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+            "my-repo",
+            template=str(local_template),
+            version="HEAD",
+            config_file=tmp_path / "does-not-exist.yml",
+        )
+
+
+def test_template_url_handling_vcs_ref_only_for_github_urls(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vcs_ref is only passed to copier for https:// template URLs, never for local paths
+    (mirrors repository_installer.sh's `if [[ "${template}" == https://* ]]`)."""
+    monkeypatch.chdir(tmp_path)
+    calls: list[dict[str, Any]] = []
+    real_run_copy = copier.run_copy
+
+    def spy_run_copy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return real_run_copy(*args, **kwargs)
+
+    monkeypatch.setattr("oarepo_cli.services.repository_installer.copier.run_copy", spy_run_copy)
+
+    RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="some-ref"
+    )
+
+    assert calls[0]["vcs_ref"] is None
+
+
+def test_install_generates_development_certificates(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """openssl generates a real self-signed cert/key pair under docker/."""
+    monkeypatch.chdir(tmp_path)
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    cert = target / "docker" / "development.crt"
+    key = target / "docker" / "development.key"
+    assert cert.exists()
+    assert key.exists()
+    assert "BEGIN CERTIFICATE" in cert.read_text()
+
+
+def test_install_removes_transient_env_symlink(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The docker/.env symlink used for `docker compose down` is removed again afterward."""
+    monkeypatch.chdir(tmp_path)
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    assert not (target / "docker" / ".env").is_symlink()
+    assert not (target / "docker" / ".env").exists()
+
+
+def test_install_initializes_git_repository(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without CI set, git is initialized with an initial commit."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CI", raising=False)
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    assert (target / ".git").is_dir()
+    log = subprocess.run(
+        ["git", "log", "--oneline"], cwd=target, check=True, capture_output=True, text=True
+    )
+    assert "Initial commit" in log.stdout
+
+
+def test_install_skips_git_when_ci_env_set(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With CI set (to any non-empty value, not just "true"), git init is skipped entirely."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CI", "1")
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    assert not (target / ".git").exists()
+
+
+def test_install_skips_git_without_git_installed(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without git on PATH, git init is skipped entirely (mirrors repository_installer.sh's
+    `command -v git` check)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setattr("oarepo_cli.services.repository_installer.shutil.which", lambda _name: None)
+
+    target = RepositoryInstaller(ConsoleOutput(quiet=True)).install(
+        "my-repo", template=str(local_template), version="HEAD"
+    )
+
+    assert not (target / ".git").exists()

--- a/tests/unit/test_installer_cli.py
+++ b/tests/unit/test_installer_cli.py
@@ -3,24 +3,28 @@
 
 """Unit tests for the top-level `new` command (`cli/installer.py`).
 
-Covers argument parsing/defaults and the upfront validation ported from
+Covers argument parsing/defaults, the upfront validation ported from
 `repository_installer.sh`'s `parse_arguments()` (uv/uvx/python binaries
-must resolve on PATH, repository name must be non-blank) -- the actual
-scaffolding (Step 5.2's `RepositoryInstaller`, not implemented yet) isn't
-exercised here.
+must resolve on PATH, repository name must be non-blank), and delegation
+to `RepositoryInstaller` -- mocked here the same way
+test_repository_model.py mocks `ModelManager` for `repository model
+create`, since the actual scaffolding is already covered against a real
+local template by tests/integration/test_repository_installer.py.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from typer.testing import CliRunner
 
 from oarepo_cli.cli.main import app
+from oarepo_cli.core.errors import ConfigurationError
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from oarepo_cli.ui import ConsoleOutput
 
 runner = CliRunner()
 
@@ -34,20 +38,63 @@ def _all_binaries_present(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_new_uses_defaults() -> None:
-    """Only REPOSITORY_NAME given: python/template/version/uv/uvx all take their defaults."""
+def _fake_repository_installer(calls: list[dict[str, object]]) -> type:
+    class FakeRepositoryInstaller:
+        def __init__(self, console: ConsoleOutput) -> None:
+            calls.append({"console": console})
+
+        def install(
+            self,
+            name: str,
+            *,
+            template: str,
+            version: str,
+            config_file: Path | None = None,
+        ) -> Path:
+            calls.append(
+                {
+                    "method": "install",
+                    "name": name,
+                    "template": template,
+                    "version": version,
+                    "config_file": config_file,
+                }
+            )
+            return Path(name)
+
+    return FakeRepositoryInstaller
+
+
+def test_new_uses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only REPOSITORY_NAME given: python/template/version/uv/uvx all take their defaults,
+    and RepositoryInstaller.install() is called with them."""
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.installer.RepositoryInstaller", _fake_repository_installer(calls)
+    )
+
     result = runner.invoke(app, ["new", "my-repo"])
 
     assert result.exit_code == 0, result.output
     assert "my-repo" in result.output
-    assert "https://github.com/oarepo/nrp-app-copier" in result.output
-    assert "rdm-14" in result.output
+    assert calls[1] == {
+        "method": "install",
+        "name": "my-repo",
+        "template": "https://github.com/oarepo/nrp-app-copier",
+        "version": "rdm-14",
+        "config_file": None,
+    }
 
 
-def test_new_passes_all_options(tmp_path: Path) -> None:
-    """Every option overrides its default and is reflected in the confirmation message."""
+def test_new_passes_all_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every option overrides its default and is forwarded to RepositoryInstaller.install()."""
     config_file = tmp_path / "answers.yaml"
     config_file.write_text("repository_name: my-repo\n")
+
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "oarepo_cli.cli.installer.RepositoryInstaller", _fake_repository_installer(calls)
+    )
 
     result = runner.invoke(
         app,
@@ -70,8 +117,42 @@ def test_new_passes_all_options(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "../local-template" in result.output
-    assert "rdm-13" in result.output
+    assert calls[1] == {
+        "method": "install",
+        "name": "my-repo",
+        "template": "../local-template",
+        "version": "rdm-13",
+        "config_file": config_file,
+    }
+
+
+def test_new_reports_installer_error_and_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ConfigurationError raised by RepositoryInstaller is reported cleanly, exit code 1."""
+    config_file = tmp_path / "answers.yaml"
+    config_file.write_text("repository_name: my-repo\n")
+
+    class RaisingRepositoryInstaller:
+        def __init__(self, console: ConsoleOutput) -> None:  # noqa: ARG002
+            pass
+
+        def install(
+            self,
+            name: str,  # noqa: ARG002
+            *,
+            template: str,  # noqa: ARG002
+            version: str,  # noqa: ARG002
+            config_file: Path | None = None,
+        ) -> Path:
+            raise ConfigurationError(f"Missing repository config file: {config_file}")
+
+    monkeypatch.setattr("oarepo_cli.cli.installer.RepositoryInstaller", RaisingRepositoryInstaller)
+
+    result = runner.invoke(app, ["new", "my-repo", "--config", str(config_file)])
+
+    assert result.exit_code == 1
+    assert "Repository creation failed" in result.output
 
 
 def test_new_requires_repository_name() -> None:


### PR DESCRIPTION
## Summary
- New `services/repository_installer.py` (`RepositoryInstaller`), completing the `new` command's scaffolding logic that Step 5.1 (#155) left as a validated-but-unimplemented skeleton.
- **Reuses `services.models.ModelManager`'s copier pattern** (per request): `copier.run_copy` invoked in-process, using this venv's own installed `copier` + `copier-template-extensions`, rather than shelling out to `uvx --python <python_binary> --with copier-template-extensions --with pycountry copier copy ...` for a fresh ephemeral environment on every call.
  - Consequence: `--python`/`--uv`/`--uvx` are still validated by `new` (interface compatibility with `repository_installer.sh`) but no longer forwarded to `RepositoryInstaller`, since there's no longer a separate copier process to run them with. Documented in both `cli/installer.py` and the new class's docstring.
- `repository_name` is always forced into copier's `data`, even when `--config` is also given — matches `repository_installer.sh`'s unconditional `-d repository_name=`, which is a deliberate difference from `ModelManager.create_model`'s config-file handling (that one omits `-d model_name=` when a config file is given).
- Generates a self-signed development TLS cert/key pair via `openssl` (same RSA size/validity/subject as the shell script).
- Runs a best-effort `docker compose down` (failure ignored, matching `|| true`) via a transient `docker/.env` symlink, removed again immediately after.
- Initializes git with an initial commit, skipped in CI (any non-empty `CI` value, not just `"true"`) or without git installed.
- Updated `README.md`'s Repository Installer section and checked off Step 5.2 in `implementation-steps.md`.

## Test plan
- [x] `tests/integration/test_repository_installer.py` — exercises `RepositoryInstaller` against a small, real, local copier template (mirroring `test_model_manager.py`'s approach): copier params, config-file/`repository_name` precedence, certificate generation, docker cleanup, git init (and skipping it for CI / missing git)
- [x] `tests/unit/test_installer_cli.py` — updated to mock `RepositoryInstaller` (same pattern `test_repository_model.py` uses for `ModelManager`) since the CLI now does real work
- [x] `make check` (lint + format + type-check)
- [x] `make test` — full suite: 578 passed