### PR TITLE
Step 5.3: Integration Tests for Installer

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -1988,15 +1988,22 @@ reused; `services.repository.run_tests()` was added instead, and
 ### Step 5.3: Integration Tests for Installer
 **Goal**: End-to-end installer tests.
 
-- [ ] Test full installation flow
-- [ ] Test template variations (GitHub vs local)
-- [ ] Test error handling (invalid template, missing python)
+- [x] Test full installation flow
+- [x] Test template variations (GitHub vs local)
+- [x] Test error handling (invalid template, missing python) -- also fixed a
+      bug found while writing this: `copier.run_copy` raises inconsistent
+      exception types (some `copier.errors.CopierError` subclasses, others
+      bare `ValueError`s), which weren't caught by `cli.installer`'s
+      `except OARepoError`, producing an uncaught traceback for e.g. an
+      invalid `--template` instead of the usual clean error message.
+      `RepositoryInstaller.install()` now normalizes any exception from
+      `copier.run_copy` into `ConfigurationError`.
 
 **Tests** (`tests/integration/test_repository_installer_e2e.py`):
-- [ ] Test successful installation
-- [ ] Test certificate files exist
-- [ ] Test docker compose file present
-- [ ] Test git repo initialized
+- [x] Test successful installation
+- [x] Test certificate files exist
+- [x] Test docker compose file present
+- [x] Test git repo initialized
 
 ---
 

--- a/oarepo_cli/services/repository_installer.py
+++ b/oarepo_cli/services/repository_installer.py
@@ -111,14 +111,23 @@ class RepositoryInstaller:
         quiet_for_copier = self._console.is_quiet
         data: dict[str, Any] = _load_yaml_data(config_file) if config_file is not None else {}
         data["repository_name"] = name
-        copier.run_copy(
-            template,
-            target_dir,
-            data=data,
-            vcs_ref=version if is_github else None,
-            unsafe=True,
-            quiet=quiet_for_copier,
-        )
+        try:
+            copier.run_copy(
+                template,
+                target_dir,
+                data=data,
+                vcs_ref=version if is_github else None,
+                unsafe=True,
+                quiet=quiet_for_copier,
+            )
+        except Exception as e:
+            # copier's own exceptions are inconsistent -- some are
+            # copier.errors.CopierError subclasses, others (e.g. an invalid
+            # local template path) are bare ValueErrors -- so every failure
+            # from this call is normalized into our own exception hierarchy
+            # here, rather than leaving callers to guess which of copier's
+            # exception types to expect.
+            raise ConfigurationError(f"Failed to render template '{template}': {e}") from e
 
         self._generate_certificates(target_dir)
         self._clean_docker_state(target_dir)

--- a/tests/integration/test_repository_installer_e2e.py
+++ b/tests/integration/test_repository_installer_e2e.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""End-to-end tests for the `oarepo-cli new` command.
+
+Unlike test_repository_installer.py (which exercises RepositoryInstaller
+directly, mirroring test_model_manager.py's approach for ModelManager),
+these tests drive the full stack through the CLI entry point
+(`runner.invoke(app, ["new", ...])`), the same way
+test_repository_model.py's `test_model_create_and_update_against_real_template`
+checks the `model` command group is wired up correctly end to end -- here
+confirming argument parsing, validation, RepositoryInstaller delegation,
+and error reporting all work together, against a small local template
+(fast: no network, no ephemeral uvx environment to bootstrap).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+import copier
+import pytest
+from typer.testing import CliRunner
+
+from oarepo_cli.cli.main import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+COPIER_YML = """\
+repository_name:
+  type: str
+  help: Repository name
+  when: false
+"""
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def local_template(tmp_path: Path) -> Path:
+    """A small, real, git-tracked copier template with the docker/ layout (including
+    a docker-compose.yml, unlike test_repository_installer.py's fixture) a real
+    repository template has."""
+    template_dir = tmp_path / "template"
+    template_dir.mkdir()
+    (template_dir / "copier.yml").write_text(COPIER_YML)
+    (template_dir / "README.md.jinja").write_text("# {{ repository_name }}\n")
+    docker_dir = template_dir / "docker"
+    docker_dir.mkdir()
+    (docker_dir / "docker-compose.yml").write_text("services: {}\n")
+    (template_dir / "variables").write_text("INVENIO_UI_PORT=5000\n")
+
+    _git("init", "-q", cwd=template_dir)
+    _git("add", "-A", cwd=template_dir)
+    _git(
+        "-c",
+        "user.email=test@test.com",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=template_dir,
+    )
+    return template_dir
+
+
+def test_new_full_installation_flow(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`oarepo-cli new` renders the template, generates certificates, cleans up
+    the transient docker/.env symlink (while leaving the template's own
+    docker-compose.yml untouched), and initializes git -- all through the
+    real CLI entry point, exit code 0."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CI", raising=False)  # exercise real git init too
+
+    result = runner.invoke(
+        app,
+        ["new", "--template", str(local_template), "--version", "HEAD", "my-repo"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    target = tmp_path / "my-repo"
+    assert (target / "README.md").read_text() == "# my-repo\n"
+
+    # Certificate files exist
+    assert (target / "docker" / "development.crt").read_text().count("BEGIN CERTIFICATE") == 1
+    assert (target / "docker" / "development.key").exists()
+
+    # The template's own docker compose file survived the transient .env symlink dance
+    assert (target / "docker" / "docker-compose.yml").exists()
+    assert not (target / "docker" / ".env").exists()
+
+    # Git repo initialized with an initial commit
+    assert (target / ".git").is_dir()
+    log = subprocess.run(
+        ["git", "log", "--oneline"], cwd=target, check=True, capture_output=True, text=True
+    )
+    assert "Initial commit" in log.stdout
+
+
+def test_new_template_variation_vcs_ref_only_for_github_style_urls(
+    tmp_path: Path, local_template: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--version is only forwarded to copier as vcs_ref for https:// (GitHub-style)
+    templates, never for local paths -- exercised through the full CLI, not just
+    RepositoryInstaller directly (unlike test_repository_installer.py's equivalent
+    check), confirming the CLI layer forwards --template/--version correctly."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CI", "true")
+    calls: list[dict[str, Any]] = []
+
+    # Local template: real end-to-end run, vcs_ref must come through as None.
+    real_run_copy = copier.run_copy
+
+    def spy_run_copy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return real_run_copy(*args, **kwargs)
+
+    monkeypatch.setattr("oarepo_cli.services.repository_installer.copier.run_copy", spy_run_copy)
+
+    result = runner.invoke(
+        app,
+        ["new", "--template", str(local_template), "--version", "some-ref", "repo-local"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert calls[0]["vcs_ref"] is None
+
+    # GitHub-style URL: faked (no real network), but confirms the CLI forwards
+    # --version as vcs_ref down to copier for an https:// --template.
+    calls.clear()
+
+    def fake_run_copy(template: str, dst: Path, **kwargs: Any) -> None:  # noqa: ARG001
+        calls.append(kwargs)
+        (dst / "docker").mkdir(parents=True)
+
+    monkeypatch.setattr("oarepo_cli.services.repository_installer.copier.run_copy", fake_run_copy)
+
+    result = runner.invoke(
+        app,
+        [
+            "new",
+            "--template",
+            "https://example.com/org/template.git",
+            "--version",
+            "v2",
+            "repo-github",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert calls[0]["vcs_ref"] == "v2"
+
+
+def test_new_reports_invalid_template_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An invalid/nonexistent --template is reported with the same clean
+    "Repository creation failed" message as any other failure, not an
+    uncaught traceback -- copier itself raises inconsistent exception types
+    here (a bare ValueError for this particular case, not one of its own
+    copier.errors.CopierError subclasses), which RepositoryInstaller
+    normalizes into ConfigurationError."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["new", "--template", str(tmp_path / "does-not-exist"), "my-repo"])
+
+    assert result.exit_code == 1
+    assert result.exception is not None
+    assert isinstance(result.exception, SystemExit)
+    assert "✗ Repository creation failed" in result.output
+    assert not (tmp_path / "my-repo").exists()
+
+
+def test_new_reports_missing_python_binary_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A --python binary that doesn't resolve on PATH is rejected before anything
+    else runs -- exercised with a real, definitely-nonexistent path (unlike
+    test_installer_cli.py's equivalent unit test, which mocks shutil.which)."""
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["new", "--python", "/definitely/does/not/exist", "my-repo"])
+
+    assert result.exit_code == 1
+    assert "--python" in result.output
+    assert not (tmp_path / "my-repo").exists()


### PR DESCRIPTION
## Summary
- New `tests/integration/test_repository_installer_e2e.py`, driving `oarepo-cli new` end-to-end through the CLI entry point (`runner.invoke(app, [...])`), unlike Step 5.2's `test_repository_installer.py` which calls `RepositoryInstaller` directly — same relationship as `test_model_manager.py` (direct) vs. `test_repository_model.py` (CLI, mirroring its `test_model_create_and_update_against_real_template`).
- Covers everything in the step's checklist: full installation flow, certificate files, the template's own `docker-compose.yml` surviving the transient `.env` symlink cleanup, git init, template variations (`vcs_ref` only forwarded for `https://` templates, never local paths — verified through the full CLI), and error handling for an invalid template / missing `--python` binary.
- **Bug fix found while writing the error-handling tests**: `copier.run_copy` raises inconsistent exception types — some are `copier.errors.CopierError` subclasses, but a nonexistent local template path raises a bare `ValueError`. `cli.installer`'s `except OARepoError` didn't catch either case that wasn't already an `OARepoError`, so an invalid `--template` produced an uncaught traceback instead of the clean "✗ Repository creation failed: ..." message every other failure mode gets. Fixed by having `RepositoryInstaller.install()` wrap the `copier.run_copy` call and normalize any exception into `ConfigurationError`.
- Checked off Step 5.3 in `implementation-steps.md` (Phase 5 is now fully complete).

## Test plan
- [x] `tests/integration/test_repository_installer_e2e.py` (4 new tests)
- [x] Full existing suite (`test_repository_installer.py`, `test_installer_cli.py`) still passes after the `RepositoryInstaller` fix
- [x] `make check` (lint + format + type-check)
- [x] `make test` — full suite: 582 passed