### PR TITLE
Step 6.4.2: testrepo fixture uses oarepo-cli new instead of bash installer

### DIFF
--- a/docs/architecture/implementation-steps.md
+++ b/docs/architecture/implementation-steps.md
@@ -2140,13 +2140,13 @@ steps, etc.):
 **Current State**: The `testrepo_project` fixture in `tests/conftest.py` downloads the `repository_installer.sh` bash script from GitHub and executes it with copier to create a test repository.
 
 **Implementation**:
-- Modify the `testrepo_project` fixture to call `oarepo-cli new` command instead
-- Remove the dependency on downloading the bash script
-- Use the library scaffolding functionality that is already implemented
+- [x] Modify the `testrepo_project` fixture to call `oarepo-cli new` command instead
+- [x] Remove the dependency on downloading the bash script
+- [x] Use the library scaffolding functionality that is already implemented
 
 **Deliverables**:
-- Updated `testrepo_project` fixture using oarepo-cli `new` command
-- Removed bash script download logic from tests
+- [x] Updated `testrepo_project` fixture using oarepo-cli `new` command
+- [x] Removed bash script download logic from tests
 
 ---
 

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,6 @@ PYTHON_VERSION="${PYTHON_VERSION:-3.14}"
 export TERMINAL_WIDTH="${TERMINAL_WIDTH:-200}"
 export COLUMNS="${COLUMNS:-200}"
 export LINES="${LINES:-50}"
-export PYTEST_ADDOPTS="-vvv"
 
 if [ ! -d .venv ] ; then
     uv venv

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,21 @@ cd "${SCRIPT_DIR}"
 
 PYTHON_VERSION="${PYTHON_VERSION:-3.14}"
 
+# CI runners (e.g. GitHub Actions) have no controlling terminal, which has
+# been observed to make Typer/Rich's help-text rendering collapse down to an
+# empty bordered box with no visible option text at all. COLUMNS/LINES alone
+# (also pinned in tests/conftest.py) aren't enough to fix this reliably --
+# Typer's own Rich console reads TERMINAL_WIDTH once at import time and
+# passes it straight to Console(width=...), bypassing tty/COLUMNS detection
+# entirely, so it has to be a real process env var already in place before
+# Python (and therefore typer) is even imported -- too late to set from
+# conftest.py itself. Exported here, before the final exec below, so it's
+# inherited by every subprocess run.sh's oarepo-cli invocation spawns,
+# including pytest.
+export TERMINAL_WIDTH="${TERMINAL_WIDTH:-200}"
+export COLUMNS="${COLUMNS:-200}"
+export LINES="${LINES:-50}"
+
 if [ ! -d .venv ] ; then
     uv venv
     uv pip install -e .

--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,7 @@ PYTHON_VERSION="${PYTHON_VERSION:-3.14}"
 export TERMINAL_WIDTH="${TERMINAL_WIDTH:-200}"
 export COLUMNS="${COLUMNS:-200}"
 export LINES="${LINES:-50}"
+export PYTEST_ADDOPTS="-vvv"
 
 if [ ! -d .venv ] ; then
     uv venv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 import shutil
 import tempfile
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from colorama import AnsiToWin32
 from typer.testing import CliRunner
 
 if TYPE_CHECKING:
@@ -37,6 +39,30 @@ from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 # COLUMNS/LINES value is exactly the failure case this works around.
 os.environ["COLUMNS"] = "200"
 os.environ["LINES"] = "50"
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI escape sequences (Rich/Click color codes) from text.
+
+    Rich's option highlighter can wrap sub-spans of what looks like one
+    token -- e.g. the "--" prefix and the option name -- in separate style
+    codes, splitting a literal substring like "--force" across escape
+    sequences in the raw captured stdout. This shows up far more often on a
+    CI runner with no controlling terminal than in a real dev terminal, and
+    survives even with COLUMNS/LINES/TERMINAL_WIDTH pinned (those fix
+    wrapping width, not color-code placement). Stripping the codes first
+    makes `"--force" in ...`-style assertions robust regardless of how the
+    output ended up colorized.
+    """
+    output = io.StringIO()
+    AnsiToWin32(output, strip=True, convert=False).write(text)
+    return output.getvalue()
+
+
+@pytest.fixture
+def strip_ansi() -> Callable[[str], str]:
+    """Fixture handle for ``_strip_ansi``, for tests asserting on CliRunner help text."""
+    return _strip_ansi
 
 
 def _cleanup_testlib(project_path: Path, stop_services: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,14 +26,17 @@ from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 # Rich/Click's help-text renderer falls back to os.get_terminal_size() on the
 # real stdout/stderr file descriptors, which typer.testing.CliRunner.invoke()
 # doesn't redirect (it only swaps the Python-level sys.stdout object) -- so
-# on a CI runner whose job step happens to have a narrow controlling pty,
-# `--help` output wraps differently than on a real dev terminal and can
-# split an option name (e.g. "--force") across a line break. Rich/Click both
-# prefer the COLUMNS/LINES env vars over that OS query when set, so pinning
-# them here makes every CliRunner-rendered help text deterministic across
-# environments.
-os.environ.setdefault("COLUMNS", "200")
-os.environ.setdefault("LINES", "50")
+# on a CI runner whose job step has no controlling terminal (or one reporting
+# a degenerate size), `--help` output can wrap down to almost nothing --
+# observed on GitHub Actions as help panels rendering as an empty box with no
+# visible option text at all (COLUMNS/LINES of "1" reproduces this exactly
+# locally). Rich/Click both prefer the COLUMNS/LINES env vars over that OS
+# query when set, so pinning them here makes every CliRunner-rendered help
+# text deterministic across environments -- unconditionally, not just
+# `setdefault`, since a CI environment that already exports a degenerate
+# COLUMNS/LINES value is exactly the failure case this works around.
+os.environ["COLUMNS"] = "200"
+os.environ["LINES"] = "50"
 
 
 def _cleanup_testlib(project_path: Path, stop_services: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,19 +8,19 @@ from __future__ import annotations
 import contextlib
 import os
 import shutil
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from typer.testing import CliRunner
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
+from oarepo_cli.cli.main import app
 from oarepo_cli.core.config import CliConfig, ServicesConfig, TestingConfig
 from oarepo_cli.core.context import ProjectContext
-from oarepo_cli.core.platform import get_platform_detector
 from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 
 # Rich/Click's help-text renderer falls back to os.get_terminal_size() on the
@@ -140,13 +140,6 @@ def _remove_pycache_directories(project_path: Path) -> None:
         shutil.rmtree(pycache)
 
 
-# https://raw.githubusercontent.com/oarepo/oarepo/refs/heads/main/tools/repository_installer.sh
-# creates a real repository from the nrp-app-copier template, as documented at
-# https://nrp-cz.github.io/docs/installation/create_instance
-REPOSITORY_INSTALLER_URL = (
-    "https://raw.githubusercontent.com/oarepo/oarepo/refs/heads/main/tools/repository_installer.sh"
-)
-
 REPOSITORY_CONFIG_YAML = """\
 repository_human_name: Test Repository
 repository_description: Integration test repository for oarepo-cli
@@ -211,13 +204,14 @@ def testrepo_project() -> Path:
     Unlike ``testlib_project`` (a small, hand-written fixture committed to
     the repo), a real repository is too large and heavyweight (its own
     nested git repo, generated docker/i18n/UI assets) to commit. Instead
-    it's created on demand, once, via the real installer described at
-    https://nrp-cz.github.io/docs/installation/create_instance -- the same
-    ``repository_installer.sh`` a user would run, driving the
-    ``nrp-app-copier`` template through ``copier``. If ``tests/testrepo``
-    already exists (from a previous run), creation is skipped entirely and
-    the cached scaffold is reused, since generation itself is slow
-    (network + copier) even before ``repository install`` runs anything.
+    it's created on demand, once, via ``oarepo-cli new`` itself -- the same
+    scaffolding operation (``nrp-app-copier`` template through ``copier``)
+    a user would run, exercised in-process through ``CliRunner`` rather
+    than downloading and shelling out to ``repository_installer.sh``. If
+    ``tests/testrepo`` already exists (from a previous run), creation is
+    skipped entirely and the cached scaffold is reused, since generation
+    itself is slow (network + copier) even before ``repository install``
+    runs anything.
     """
     root = Path(__file__).parent / "testrepo"
     if (root / "pyproject.toml").exists():
@@ -226,34 +220,23 @@ def testrepo_project() -> Path:
     root.parent.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as tmp:
-        tmp_path = Path(tmp)
-        installer = tmp_path / "repository_installer.sh"
-        subprocess.run(  # noqa: S603 - just a test, not a security issue
-            ["curl", "-fsSL", "-o", str(installer), REPOSITORY_INSTALLER_URL],  # noqa: S607 - curl is trusted
-            check=True,
-        )
-        installer.chmod(0o755)
-
-        config_file = tmp_path / "repo_config.yaml"
+        config_file = Path(tmp) / "repo_config.yaml"
         config_file.write_text(REPOSITORY_CONFIG_YAML)
 
-        # macOS ships bash 3.2 as /bin/bash (frozen for licensing reasons),
-        # which mishandles the script's `"${@}"` expansion under `set -u`
-        # when called with zero arguments. Same issue and fix as
-        # PlatformDetector.get_default_shell().
-        subprocess.run(  # noqa: S603 - just a test, not a security issue to run the program
-            [
-                get_platform_detector().get_default_shell(),
-                str(installer),
-                "--python",
-                "python3.14",
-                "--config",
-                str(config_file),
-                root.name,
-            ],
-            cwd=root.parent,
-            check=True,
-        )
+        cwd = Path.cwd()
+        os.chdir(root.parent)
+        try:
+            result = CliRunner().invoke(
+                app,
+                ["new", "--config", str(config_file), root.name],
+                catch_exceptions=False,
+            )
+        finally:
+            os.chdir(cwd)
+
+    if result.exit_code != 0:
+        msg = f"Failed to create testrepo fixture via 'oarepo-cli new':\n{result.output}"
+        raise RuntimeError(msg)
 
     return root
 

--- a/tests/integration/test_library_venv.py
+++ b/tests/integration/test_library_venv.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from oarepo_cli.cli.main import app
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -46,14 +47,15 @@ def test_library_venv_creates_venv_real(
         assert (venv_path / "bin" / "python").exists()
 
 
-def test_library_venv_help_displays(runner: CliRunner) -> None:
+def test_library_venv_help_displays(runner: CliRunner, strip_ansi: Callable[[str], str]) -> None:
     """Test that 'library venv --help' displays help text."""
     result = runner.invoke(app, ["library", "venv", "--help"])
+    output = strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "Set up virtual environment" in result.stdout
-    assert "--force" in result.stdout
-    assert "--no-editable" in result.stdout
+    assert "Set up virtual environment" in output
+    assert "--force" in output
+    assert "--no-editable" in output
 
 
 def test_library_venv_force_flag_exists(runner: CliRunner) -> None:
@@ -64,12 +66,12 @@ def test_library_venv_force_flag_exists(runner: CliRunner) -> None:
     assert "--force" in result.stdout or "-f" in result.stdout
 
 
-def test_library_venv_no_editable_flag_exists(runner: CliRunner) -> None:
+def test_library_venv_no_editable_flag_exists(runner: CliRunner, strip_ansi: Callable[[str], str]) -> None:
     """Test that --no-editable flag is recognized."""
     result = runner.invoke(app, ["library", "venv", "--help"])
 
     assert result.exit_code == 0
-    assert "--no-editable" in result.stdout
+    assert "--no-editable" in strip_ansi(result.stdout)
 
 
 def test_library_venv_strips_parent_venv_real(

--- a/tests/integration/test_repository_run.py
+++ b/tests/integration/test_repository_run.py
@@ -31,7 +31,7 @@ from oarepo_cli.cli.main import app
 from oarepo_cli.core.errors import ConfigurationError, ProcessExecutionError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
 
@@ -180,7 +180,7 @@ def test_run_reports_server_runner_error_and_exits_1(
     assert "Failed to start server" in result.output
 
 
-def test_run_help_shows_oarepo_clis_own_help(mock_context: Mock) -> None:
+def test_run_help_shows_oarepo_clis_own_help(mock_context: Mock, strip_ansi: Callable[[str], str]) -> None:
     """Help shows oarepo-cli's own options.
 
     Shows --no-services/--no-celery/--quiet, unlike the services subcommands,
@@ -188,11 +188,12 @@ def test_run_help_shows_oarepo_clis_own_help(mock_context: Mock) -> None:
     """
     runner = CliRunner()
     result = runner.invoke(app, ["repository", "run", "--help"])
+    output = strip_ansi(result.output)
 
     assert result.exit_code == 0, result.output
-    assert "--no-services" in result.output
-    assert "--no-celery" in result.output
-    assert "--quiet" in result.output
+    assert "--no-services" in output
+    assert "--no-celery" in output
+    assert "--quiet" in output
 
 
 FAKE_INVENIO_CLI_SCRIPT = """#!/bin/sh

--- a/tests/unit/test_installer_cli.py
+++ b/tests/unit/test_installer_cli.py
@@ -24,6 +24,8 @@ from oarepo_cli.cli.main import app
 from oarepo_cli.core.errors import ConfigurationError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from oarepo_cli.ui import ConsoleOutput
 
 runner = CliRunner()
@@ -213,9 +215,10 @@ def test_new_rejects_missing_config_file() -> None:
     assert result.exit_code == 2
 
 
-def test_new_help_lists_all_options() -> None:
+def test_new_help_lists_all_options(strip_ansi: Callable[[str], str]) -> None:
     """--help documents every option and the positional repository_name argument."""
     result = runner.invoke(app, ["new", "--help"])
+    output = strip_ansi(result.output)
 
     assert result.exit_code == 0
     for expected in (
@@ -227,4 +230,4 @@ def test_new_help_lists_all_options() -> None:
         "--config",
         "repository_name",
     ):
-        assert expected in result.output
+        assert expected in output


### PR DESCRIPTION
## Summary
- `tests/conftest.py`'s `testrepo_project` fixture no longer downloads `repository_installer.sh` from GitHub and shells out to it via bash to scaffold the test repository.
- It now drives `oarepo-cli new` in-process through `typer.testing.CliRunner`, exercising the same `RepositoryInstaller`/copier code path real users go through, seeded with the same `repo_config.yaml` answers file as before.
- Removed the now-unused `curl`/bash-script-download logic and the `get_platform_detector`/`subprocess` imports that only existed to support it.

## Test plan
- [x] Verified the fixture regenerates `tests/testrepo` correctly from scratch (removed the cached scaffold and reran it directly): real repo created, TLS cert generated, git initialized.
- [x] `./run.sh test` — full suite, 521 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)