### PR TITLE
fix: CI --help tests fail with empty Rich panel (COLUMNS/LINES not forced)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,14 +26,17 @@ from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
 # Rich/Click's help-text renderer falls back to os.get_terminal_size() on the
 # real stdout/stderr file descriptors, which typer.testing.CliRunner.invoke()
 # doesn't redirect (it only swaps the Python-level sys.stdout object) -- so
-# on a CI runner whose job step happens to have a narrow controlling pty,
-# `--help` output wraps differently than on a real dev terminal and can
-# split an option name (e.g. "--force") across a line break. Rich/Click both
-# prefer the COLUMNS/LINES env vars over that OS query when set, so pinning
-# them here makes every CliRunner-rendered help text deterministic across
-# environments.
-os.environ.setdefault("COLUMNS", "200")
-os.environ.setdefault("LINES", "50")
+# on a CI runner whose job step has no controlling terminal (or one reporting
+# a degenerate size), `--help` output can wrap down to almost nothing --
+# observed on GitHub Actions as help panels rendering as an empty box with no
+# visible option text at all (COLUMNS/LINES of "1" reproduces this exactly
+# locally). Rich/Click both prefer the COLUMNS/LINES env vars over that OS
+# query when set, so pinning them here makes every CliRunner-rendered help
+# text deterministic across environments -- unconditionally, not just
+# `setdefault`, since a CI environment that already exports a degenerate
+# COLUMNS/LINES value is exactly the failure case this works around.
+os.environ["COLUMNS"] = "200"
+os.environ["LINES"] = "50"
 
 
 def _cleanup_testlib(project_path: Path, stop_services: bool = True) -> None:


### PR DESCRIPTION
## Summary
- GitHub Actions CI (`ubuntu-24.04`) has been failing 4 `--help`-text assertion tests (`test_library_venv_help_displays`, `test_library_venv_no_editable_flag_exists`, `test_run_help_shows_oarepo_clis_own_help`, `test_new_help_lists_all_options`) with Rich rendering an empty box (just borders, no option text) instead of the real help output — pre-existing on `cli-as-python`, not introduced by any specific PR (confirmed on #163's and #162's post-merge CI runs too).
- Reproduced locally: running pytest with `COLUMNS=1 LINES=1` set produces the exact same degenerate empty-box output.
- Root cause: `tests/conftest.py` already pins `COLUMNS`/`LINES` to stabilize Rich's help rendering across environments, but used `os.environ.setdefault(...)` — a no-op if the CI job's environment already exports a (apparently degenerate) value for either variable. Switched to an unconditional assignment so our values always win, regardless of what the runner environment already set.

## Test plan
- [x] Reproduced the failure locally with `COLUMNS=1 LINES=1`, confirmed the fix makes all 4 previously-failing tests pass under that same hostile environment
- [x] `./run.sh check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)