### PR TITLE
Feat/alembic init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ AI coding agent guide for `oarepo-cli` development.
 - Uses CESNET-patched `invenio-cli` from private registry (see `pyproject.toml`)
 - Never use `subprocess` with `shell=True` — always pass argument lists
 - All source files require SPDX headers and `from __future__ import annotations`
+- User might be editting the files in parallel. If you find an unexpected content, do not automatically revert it - ask first.
 
 ## Repository layout
 
@@ -108,6 +109,10 @@ Or via `run.sh`:
 ```bash
 ./run.sh test
 ```
+
+**Important:** running all tests (especially integration tests) takes a lot of time. If you implement a new feature, not a major refactoring, prefer running targeted tests for your feature instead.
+
+The whole test suite is always run in CI.
 
 **Run targeted tests during development:**
 

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -188,6 +188,37 @@ def alembic_init(
     _alembic_init_impl(quiet=quiet)
 
 
+@with_context_and_console(
+    success_message=None,  # Custom success/error handling in impl
+    error_prefix="Error checking alembic migrations",
+)
+def _alembic_check_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    sql_mode: bool = False,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
+    """Shared implementation for alembic check.
+
+    Starts Docker services, checks for pending migrations by comparing the
+    current database schema against the model metadata, then destroys the
+    services.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        sql_mode: If True, output SQL statements instead of JSON
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    """
+    from oarepo_cli.services.alembic import AlembicManager
+
+    manager = AlembicManager(context, console)
+    exit_code = manager.check_with_services(sql=sql_mode)
+    raise typer.Exit(code=exit_code)
+
+
 @alembic_app.command("revision")
 def alembic_revision(
     message: Annotated[str, typer.Argument(help="Revision message")],
@@ -237,19 +268,7 @@ def alembic_check(
         oarepo-cli library alembic check --sql
 
     """
-    from oarepo_cli.services.alembic import AlembicManager
-
-    try:
-        context = discover_context()
-    except OARepoError as e:
-        console_err = ConsoleOutput(quiet=False)
-        console_err.error(f"\n✗ Failed to discover project context: {e}\n", fg=typer.colors.RED)
-        raise typer.Exit(1) from e
-
-    console = ConsoleOutput(quiet=False)
-    manager = AlembicManager(context, console)
-    exit_code = manager.check_with_services(sql=bool(sql_mode))
-    raise typer.Exit(code=exit_code)
+    _alembic_check_impl(sql_mode=bool(sql_mode))
 
 
 @with_context_and_console(

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -105,6 +105,10 @@ def _alembic_init_impl(
 ) -> None:
     """Shared implementation for alembic init.
 
+    Initializes Alembic support including creating migrations and setting up
+    the database schema. After completion, instructs the user to review the
+    generated migration files.
+
     Args:
         context: Project context (injected by decorator)
         console: Console output handler (injected by decorator)
@@ -127,10 +131,23 @@ def alembic_init(
     1. Checks for the required 'invenio_db.models' entrypoint in pyproject.toml
     2. Creates an 'alembic' directory in the first code directory if it doesn't exist
     3. Adds the 'invenio_db.alembic' entrypoint to pyproject.toml if missing
+    4. Checks if alembic is already initialized (exits early if 2+ migrations exist)
+    5. Syncs the project to register entrypoints (uv pip install --no-deps -e .)
+    6. Restarts Docker services to ensure clean database state
+    7. Verifies alembic state is clean (no uncommitted database changes)
+    8. Creates initial branch migration if no Python files exist in alembic/
+    9. Runs 'invenio alembic upgrade heads' to apply base migrations
+    10. Creates migration for initial database tables
+
+    After completion, you should carefully review the generated migration file
+    to ensure it contains only the intended table changes for your models.
 
     The 'invenio_db.models' entrypoint is required for Alembic support and should
     point to your database models module. If it's missing, the command will exit
     with an error and provide an example configuration.
+
+    Note: This command requires Docker services to be available and will restart
+    them to ensure a clean database state.
 
     Example:
         oarepo-cli library alembic init

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -213,6 +213,45 @@ def alembic_revision(
         raise typer.Exit(1)
 
 
+@alembic_app.command("check")
+def alembic_check(
+    sql_mode: Annotated[
+        bool,
+        typer.Option("--sql", help="Output SQL statements instead of JSON"),
+    ] = False,
+) -> None:
+    """Check for pending database migrations.
+
+    Starts Docker services, checks for pending migrations by comparing the
+    current database schema against the model metadata, then destroys the services.
+
+    Exit codes:
+        0: No pending migrations (database is up to date)
+        1: Pending migrations detected or error occurred
+
+    Examples:
+        # Check for pending migrations (JSON output)
+        oarepo-cli library alembic check
+
+        # Check and see SQL statements for pending migrations
+        oarepo-cli library alembic check --sql
+
+    """
+    from oarepo_cli.services.alembic import AlembicManager
+
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ Failed to discover project context: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    console = ConsoleOutput(quiet=False)
+    manager = AlembicManager(context, console)
+    exit_code = manager.check_with_services(sql=bool(sql_mode))
+    raise typer.Exit(code=exit_code)
+
+
 @with_context_and_console(
     start_message="Starting services...",
     error_prefix="Error starting services",

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -47,8 +47,18 @@ services_app = typer.Typer(
     no_args_is_help=True,
 )
 
+# Create the alembic subcommand group
+alembic_app = typer.Typer(
+    name="alembic",
+    help="Alembic migration management",
+    no_args_is_help=True,
+)
+
 # Register services as a subcommand of library
 library_app.add_typer(services_app)
+
+# Register alembic as a subcommand of library
+library_app.add_typer(alembic_app)
 
 
 @library_app.callback()
@@ -76,6 +86,58 @@ def library_callback(
 @services_app.callback()
 def services_callback() -> None:
     """Services command group."""
+
+
+@alembic_app.callback()
+def alembic_callback() -> None:
+    """Alembic command group."""
+
+
+@with_context_and_console(
+    start_message="Initializing Alembic support...",
+    error_prefix="Error initializing Alembic",
+)
+def _alembic_init_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
+    """Shared implementation for alembic init.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    """
+    from oarepo_cli.services.alembic import AlembicManager
+
+    manager = AlembicManager(context, console)
+    manager.init()
+
+
+@alembic_app.command("init")
+def alembic_init(
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Initialize Alembic support for the library.
+
+    This command performs the following steps:
+    1. Checks for the required 'invenio_db.models' entrypoint in pyproject.toml
+    2. Creates an 'alembic' directory in the first code directory if it doesn't exist
+    3. Adds the 'invenio_db.alembic' entrypoint to pyproject.toml if missing
+
+    The 'invenio_db.models' entrypoint is required for Alembic support and should
+    point to your database models module. If it's missing, the command will exit
+    with an error and provide an example configuration.
+
+    Example:
+        oarepo-cli library alembic init
+        oarepo-cli library alembic init --quiet
+
+    """
+    _alembic_init_impl(quiet=quiet)
 
 
 @with_context_and_console(

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -121,6 +121,37 @@ def _alembic_init_impl(
     manager.init()
 
 
+
+@with_context_and_console(
+    start_message="Creating alembic migration...",
+    error_prefix="Error creating alembic migration",
+)
+def _alembic_revision_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    message: str,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> bool:
+    """Shared implementation for alembic revision.
+
+    Creates an Alembic revision with the given message.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        message: Revision message to use
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    Returns:
+        bool: True if revision was created successfully, False otherwise
+
+    """
+    from oarepo_cli.services.alembic import AlembicManager
+
+    manager = AlembicManager(context, console)
+    return manager.revision(message=message)
+
 @alembic_app.command("init")
 def alembic_init(
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
@@ -155,6 +186,30 @@ def alembic_init(
 
     """
     _alembic_init_impl(quiet=quiet)
+
+@alembic_app.command("revision")
+def alembic_revision(
+    message: Annotated[str, typer.Argument(help="Revision message")],
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Add a new Alembic revision.
+
+    This command performs the following steps:
+
+    1. If there is no alembic support yet, print message and exit 1
+    2. Restarts Docker services to ensure clean database state
+    3. Performs alembic upgrade heads
+    4. Creates alembic migration
+
+    After completion, you should carefully review the generated migration file
+    to ensure it contains only the intended table changes for your models.
+
+    Example:
+        oarepo-cli library alembic revision "Add user table"
+
+    """
+    if not _alembic_revision_impl(message=message, quiet=quiet):
+        raise typer.Exit(1)
 
 
 @with_context_and_console(

--- a/oarepo_cli/cli/library.py
+++ b/oarepo_cli/cli/library.py
@@ -121,7 +121,6 @@ def _alembic_init_impl(
     manager.init()
 
 
-
 @with_context_and_console(
     start_message="Creating alembic migration...",
     error_prefix="Error creating alembic migration",
@@ -151,6 +150,7 @@ def _alembic_revision_impl(
 
     manager = AlembicManager(context, console)
     return manager.revision(message=message)
+
 
 @alembic_app.command("init")
 def alembic_init(
@@ -186,6 +186,7 @@ def alembic_init(
 
     """
     _alembic_init_impl(quiet=quiet)
+
 
 @alembic_app.command("revision")
 def alembic_revision(

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -19,6 +19,7 @@ from oarepo_cli.cli.command_wrapper import with_context_and_console
 from oarepo_cli.core.context import discover_context
 from oarepo_cli.core.errors import OARepoError
 from oarepo_cli.services import invenio_cli, repository, translations
+from oarepo_cli.services.alembic import AlembicManager
 from oarepo_cli.services.local_packages import LocalPackageManager
 from oarepo_cli.services.models import ModelManager
 from oarepo_cli.services.server import ServerRunner
@@ -59,11 +60,19 @@ index_app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register services, model, local and index as subcommands of repository
+# Create the alembic subcommand group
+alembic_app = typer.Typer(
+    name="alembic",
+    help="Alembic migration management",
+    no_args_is_help=True,
+)
+
+# Register services, model, local, index, and alembic as subcommands of repository
 repository_app.add_typer(services_app)
 repository_app.add_typer(model_app)
 repository_app.add_typer(local_app)
 repository_app.add_typer(index_app)
+repository_app.add_typer(alembic_app)
 
 # Each services subcommand is a pure passthrough to invenio-cli: extra
 # arguments/options are forwarded verbatim, and --help must reach
@@ -112,6 +121,11 @@ def local_callback() -> None:
 @index_app.callback()
 def index_callback() -> None:
     """Repository search index command group."""
+
+
+@alembic_app.callback()
+def alembic_callback() -> None:
+    """Repository alembic migration command group."""
 
 
 def _run_services_subcommand(ctx: typer.Context, subcommand: str, *, quiet: bool) -> None:
@@ -1063,3 +1077,298 @@ def info_command() -> None:
     else:
         for model in models:
             typer.echo(f"  - {model.name}: {model.version}")
+
+
+@with_context_and_console(
+    start_message="Initializing Alembic support...",
+    error_prefix="Error initializing Alembic",
+)
+def _alembic_init_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
+    """Initialize Alembic support for the repository.
+
+    Initializes Alembic support in the common/alembic directory including creating
+    migrations and setting up the database schema. After completion, instructs the
+    user to review the generated migration files.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    """
+    from pathlib import Path
+
+    manager = AlembicManager(context, console)
+    manager.init(Path("common/alembic"), verify_model_entrypoint=False)
+
+
+@with_context_and_console(
+    start_message="Creating alembic migration...",
+    error_prefix="Error creating alembic migration",
+)
+def _alembic_revision_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    message: str,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> bool:
+    """Create an Alembic revision for the repository.
+
+    Creates an Alembic revision with the given message in the common/alembic directory.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        message: Revision message to use
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    Returns:
+        bool: True if revision was created successfully, False otherwise
+
+    """
+    from pathlib import Path
+
+    manager = AlembicManager(context, console)
+    return manager.revision(message=message, alembic_path=Path("common/alembic"))
+
+
+@alembic_app.command("init")
+def alembic_init(
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Initialize Alembic support for the repository.
+
+    This command initializes Alembic support in the common/alembic directory and
+    performs the following steps:
+    1. Checks for the required 'invenio_db.models' entrypoint in pyproject.toml
+    2. Creates the 'common/alembic' directory if it doesn't exist
+    3. Adds the 'invenio_db.alembic' entrypoint to pyproject.toml if missing
+    4. Checks if alembic is already initialized (exits early if 2+ migrations exist)
+    5. Syncs the project to register entrypoints (uv pip install --no-deps -e .)
+    6. Restarts Docker services to ensure clean database state
+    7. Verifies alembic state is clean (no uncommitted database changes)
+    8. Creates initial branch migration if no Python files exist in common/alembic/
+    9. Runs 'invenio alembic upgrade heads' to apply base migrations
+    10. Creates migration for initial database tables
+
+    After completion, you should carefully review the generated migration file
+    to ensure it contains only the intended table changes for your models.
+
+    The 'invenio_db.models' entrypoint is required for Alembic support and should
+    point to your database models module. If it's missing, the command will exit
+    with an error and provide an example configuration.
+
+    Note: This command requires Docker services to be available and will restart
+    them to ensure a clean database state.
+
+    Example:
+        oarepo-cli repository alembic init
+        oarepo-cli repository alembic init --quiet
+
+    """
+    _alembic_init_impl(quiet=quiet)
+
+
+@alembic_app.command("revision")
+def alembic_revision(
+    message: Annotated[str, typer.Argument(help="Revision message")],
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Add a new Alembic revision.
+
+    This command performs the following steps:
+
+    1. If there is no alembic support yet, print message and exit 1
+    2. Restarts Docker services to ensure clean database state
+    3. Performs alembic upgrade heads
+    4. Creates alembic migration in common/alembic
+
+    After completion, you should carefully review the generated migration file
+    to ensure it contains only the intended table changes for your models.
+
+    Example:
+        oarepo-cli repository alembic revision "Add user table"
+
+    """
+    if not _alembic_revision_impl(message=message, quiet=quiet):
+        raise typer.Exit(1)
+
+
+@with_context_and_console(
+    start_message="Applying pending migrations...",
+    error_prefix="Error applying migrations",
+)
+def _alembic_apply_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
+    """Apply all pending Alembic migrations.
+
+    Runs 'invenio alembic upgrade heads' to apply all pending migrations to the database.
+    Restarts Docker services to ensure a clean state before applying migrations.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    """
+    manager = AlembicManager(context, console)
+    manager.apply()
+
+
+@alembic_app.command("apply")
+def alembic_apply(
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Apply all pending Alembic migrations.
+
+    This command upgrades the database to the latest migration head by running
+    'invenio alembic upgrade heads'. It restarts Docker services to ensure a clean
+    state before applying migrations.
+
+    Use this command when:
+    - You have new migration files and want to apply them to the database
+    - The database schema is out of sync with the latest migrations
+    - You want to ensure all pending migrations are applied
+
+    Note: This command requires Docker services to be available and will restart
+    them to ensure a clean database state.
+
+    Example:
+        oarepo-cli repository alembic apply
+        oarepo-cli repository alembic apply --quiet
+
+    """
+    _alembic_apply_impl(quiet=quiet)
+
+
+@with_context_and_console(
+    start_message="Stamping database...",
+    error_prefix="Error stamping database",
+)
+def _alembic_stamp_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    revision: str,
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
+    """Stamp the database with a specific revision.
+
+    Sets the current database schema version to the specified revision without
+    actually running any migration scripts. This is useful when migrations have
+    been applied manually or externally and you need to sync the database state
+    with the codebase.
+
+    Args:
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
+        revision: The revision identifier to stamp (e.g., 'head', 'base', or a specific revision ID)
+        quiet: Suppress command output (passed from CLI, used by decorator)
+
+    """
+    manager = AlembicManager(context, console)
+    manager.stamp(revision)
+
+
+@alembic_app.command("stamp")
+def alembic_stamp(
+    revision: Annotated[str, typer.Argument(help="Revision to stamp (e.g., 'head', 'base', or specific revision ID)")],
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress command output")] = False,
+) -> None:
+    """Stamp the database with a specific revision.
+
+    This command sets the current database schema version to the specified revision
+    without actually running any migration scripts. The database schema remains unchanged,
+    but Alembic will recognize it as being at the specified revision.
+
+    Common use cases:
+    - Syncing database state after manual schema changes
+    - Marking the database as already having certain migrations applied
+    - Resetting the migration history without dropping tables
+    - Setting the database to 'base' (no migrations) or 'head' (latest migration)
+
+    Common revision identifiers:
+    - 'head' - The latest migration
+    - 'base' - No migrations applied
+    - A specific revision ID (e.g., 'abc123def456')
+
+    Warning: Use this command with caution. Stamping the database with an incorrect
+    revision can lead to inconsistencies between the actual schema and what Alembic
+    believes has been applied.
+
+    Example:
+        oarepo-cli repository alembic stamp head
+        oarepo-cli repository alembic stamp base
+        oarepo-cli repository alembic stamp abc123def456
+
+    """
+    _alembic_stamp_impl(revision=revision, quiet=quiet)
+
+
+def _alembic_check_impl(
+    context: ProjectContext,
+    console: ConsoleOutput,
+    *,
+    sql: bool = False,
+) -> int:
+    """Check for pending database migrations.
+
+    Runs the check_migrations.py script to compare the current database schema
+    against the model metadata and detect any pending migrations.
+
+    Args:
+        context: Project context with paths and configuration
+        console: Console output handler
+        sql: If True, output SQL statements instead of JSON
+
+    Returns:
+        Exit code: 0 if no migrations needed, 1 if pending migrations detected
+
+    """
+    manager = AlembicManager(context, console)
+    return manager.check(sql=sql)
+
+
+@alembic_app.command("check")
+def alembic_check(
+    sql_mode: Annotated[
+        bool,
+        typer.Option("--sql", help="Output SQL statements instead of JSON"),
+    ] = False,
+) -> None:
+    """Check for pending database migrations.
+
+    Compares the current database schema against the model metadata to detect
+    any pending migrations that haven't been applied yet.
+
+    Exit codes:
+        0: No pending migrations (database is up to date)
+        1: Pending migrations detected or error occurred
+
+    Examples:
+        # Check for pending migrations (JSON output)
+        oarepo-cli repository alembic check
+
+        # Check and see SQL statements for pending migrations
+        oarepo-cli repository alembic check sql
+
+    """
+    try:
+        context = discover_context()
+    except OARepoError as e:
+        console_err = ConsoleOutput(quiet=False)
+        console_err.error(f"\n✗ Failed to discover project context: {e}\n", fg=typer.colors.RED)
+        raise typer.Exit(1) from e
+
+    exit_code = _alembic_check_impl(context, ConsoleOutput(quiet=False), sql=bool(sql_mode))
+    raise typer.Exit(code=exit_code)

--- a/oarepo_cli/cli/repository.py
+++ b/oarepo_cli/cli/repository.py
@@ -1315,28 +1315,32 @@ def alembic_stamp(
     _alembic_stamp_impl(revision=revision, quiet=quiet)
 
 
+@with_context_and_console(
+    success_message=None,  # Custom success/error handling in impl
+    error_prefix="Error checking alembic migrations",
+)
 def _alembic_check_impl(
     context: ProjectContext,
     console: ConsoleOutput,
     *,
     sql: bool = False,
-) -> int:
+    quiet: bool = False,  # noqa: ARG001 (used by decorator to control console output)
+) -> None:
     """Check for pending database migrations.
 
     Runs the check_migrations.py script to compare the current database schema
     against the model metadata and detect any pending migrations.
 
     Args:
-        context: Project context with paths and configuration
-        console: Console output handler
+        context: Project context (injected by decorator)
+        console: Console output handler (injected by decorator)
         sql: If True, output SQL statements instead of JSON
-
-    Returns:
-        Exit code: 0 if no migrations needed, 1 if pending migrations detected
+        quiet: Suppress command output (passed from CLI, used by decorator)
 
     """
     manager = AlembicManager(context, console)
-    return manager.check(sql=sql)
+    exit_code = manager.check(sql=sql)
+    raise typer.Exit(code=exit_code)
 
 
 @alembic_app.command("check")
@@ -1363,12 +1367,4 @@ def alembic_check(
         oarepo-cli repository alembic check sql
 
     """
-    try:
-        context = discover_context()
-    except OARepoError as e:
-        console_err = ConsoleOutput(quiet=False)
-        console_err.error(f"\n✗ Failed to discover project context: {e}\n", fg=typer.colors.RED)
-        raise typer.Exit(1) from e
-
-    exit_code = _alembic_check_impl(context, ConsoleOutput(quiet=False), sql=bool(sql_mode))
-    raise typer.Exit(code=exit_code)
+    _alembic_check_impl(sql=bool(sql_mode))

--- a/oarepo_cli/configuration/check_migrations.py
+++ b/oarepo_cli/configuration/check_migrations.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Check migrations script for Invenio/OARepo repositories.
+
+This script compares the current database schema against the Alembic migrations
+and outputs either the pending upgrade operations as JSON or the corresponding
+SQL statements.
+
+It is designed to be run from within an initialized Flask application context,
+such as via ``invenio shell``:
+
+    $ invenio shell
+    >>> from check_migrations import main
+    ...
+    ... main()
+
+Or as a standalone script when run from a repository with services running:
+
+    $ python check_migrations.py [--sql]
+
+Arguments:
+    --sql: Output SQL statements instead of JSON operation descriptions
+
+Output format (JSON mode, default):
+    JSON array of migration operations representing the differences between
+    the current database schema and the model metadata. Each operation contains:
+    - op_type: The type of operation (e.g., "CreateTableOp", "AddColumnOp")
+    - table_name: Target table name (if applicable)
+    - column_name: Target column name (if applicable)
+    - Other operation-specific fields
+
+Example output (no pending migrations):
+    []
+
+Example output (pending migrations):
+    [
+        {
+            "op_type": "CreateTableOp",
+            "table_name": "my_table",
+            "schema": null,
+            "columns": ["id", "name"]
+        }
+    ]
+
+Output format (SQL mode, --sql):
+    Plain text SQL statements that would be executed to apply the pending
+    migrations. Uses PostgreSQL dialect since Invenio uses PostgreSQL.
+
+Example output:
+    CREATE TABLE my_table (
+        id INTEGER NOT NULL,
+        name VARCHAR(50),
+        PRIMARY KEY (id)
+    );
+
+    ALTER TABLE existing_table ADD COLUMN new_column INTEGER;
+
+Exit codes:
+    0: Success (output to stdout)
+    1: Error (error details to stderr)
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from typing import Any
+
+
+def _extract_operation(op: Any) -> dict[str, Any]:  # noqa: C901
+    """Extract operation information into a JSON-serializable dict.
+
+    Args:
+        op: An Alembic operation object
+
+    Returns:
+        Dictionary containing operation details
+
+    """
+    op_type = type(op).__name__
+    op_info: dict[str, Any] = {"op_type": op_type}
+
+    # Extract common attributes based on operation type
+    if hasattr(op, "table_name"):
+        op_info["table_name"] = op.table_name
+    if hasattr(op, "schema"):
+        op_info["schema"] = op.schema
+    if hasattr(op, "columns"):
+        op_info["columns"] = [col.name if hasattr(col, "name") else str(col) for col in op.columns]
+    if hasattr(op, "column_name"):
+        op_info["column_name"] = op.column_name
+    if hasattr(op, "constraint_name"):
+        op_info["constraint_name"] = op.constraint_name
+    if hasattr(op, "referenced_table_name"):
+        op_info["referenced_table_name"] = op.referenced_table_name
+    if hasattr(op, "type_"):
+        op_info["type"] = str(op.type_)
+    if hasattr(op, "nullable"):
+        op_info["nullable"] = op.nullable
+    if hasattr(op, "existing_nullable"):
+        op_info["existing_nullable"] = op.existing_nullable
+    if hasattr(op, "parameters"):
+        op_info["parameters"] = op.parameters
+
+    # Recursively extract nested operations (e.g., ModifyTableOps contains ops)
+    if hasattr(op, "ops") and op.ops:
+        op_info["nested_ops"] = [_extract_operation(nested_op) for nested_op in op.ops]
+
+    return op_info
+
+
+def _extract_operations_from_upgrade_ops(
+    upgrade_ops: Any,
+) -> list[dict[str, Any]]:
+    """Extract all operations from UpgradeOps object.
+
+    Args:
+        upgrade_ops: Alembic UpgradeOps object
+
+    Returns:
+        List of operation dictionaries
+
+    """
+    result: list[dict[str, Any]] = []
+
+    if hasattr(upgrade_ops, "ops"):
+        result.extend(_extract_operation(op) for op in upgrade_ops.ops)
+
+    return result
+
+
+def _generate_sql_from_operations(migration_script: Any) -> str:
+    """Generate SQL statements from a migration script using Alembic's Operations.
+
+    This uses Alembic's built-in SQL generation by configuring a MigrationContext
+    with as_sql=True and capturing the output.
+
+    Args:
+        migration_script: Alembic MigrationScript object from produce_migrations
+
+    Returns:
+        SQL statements as a string
+
+    """
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    buf = io.StringIO()
+
+    # Configure a migration context that generates SQL instead of executing
+    ctx = MigrationContext.configure(
+        url="postgresql://",
+        opts={
+            "as_sql": True,
+            "output_buffer": buf,
+        },
+    )
+
+    operations = Operations(ctx)
+
+    def invoke_ops(ops_list: list[Any]) -> None:
+        """Recursively invoke operations to generate SQL."""
+        for op in ops_list:
+            # If operation has nested ops, recurse into them without invoking the parent
+            if hasattr(op, "ops") and op.ops:
+                invoke_ops(op.ops)
+            else:
+                # Leaf operation - invoke it to generate SQL
+                operations.invoke(op)
+
+    # Invoke each operation to generate SQL
+    if hasattr(migration_script, "upgrade_ops"):
+        invoke_ops(migration_script.upgrade_ops.ops)
+
+    return buf.getvalue()
+
+
+def check_migrations(as_sql: bool = False) -> Any:
+    """Compare database schema against model metadata and return pending migrations.
+
+    This function:
+    1. Gets the current Flask application
+    2. Retrieves the Alembic instance from InvenioDB extension
+    3. Uses the migration context with active database connection
+    4. Compares database schema against target metadata using produce_migrations
+    5. Extracts and returns either operation descriptions or SQL statements
+
+    Args:
+        as_sql: If True, return SQL statements instead of operation descriptions
+
+    Requires:
+        To be called within an active Flask application context where InvenioDB
+        has been initialized and services are running.
+
+    Returns:
+        List of pending migration operations (as dicts) or SQL string
+
+    Raises:
+        RuntimeError: If InvenioDB extension not found or no connection available
+
+    """
+    from alembic.autogenerate import produce_migrations
+    from flask import current_app
+
+    # Get the alembic instance from InvenioDB extension
+    if "invenio-db" not in current_app.extensions:
+        raise RuntimeError("InvenioDB extension not found in app.extensions")
+
+    alembic = current_app.extensions["invenio-db"].alembic
+
+    # Get the database connection from the migration context
+    if not alembic.migration_contexts:
+        raise RuntimeError("No Alembic migration contexts available")
+
+    migration_context = next(iter(alembic.migration_contexts.values()))
+
+    if migration_context.connection is None:
+        raise RuntimeError("Migration context has no active connection")
+
+    # Get the target metadata from the database extension
+    from invenio_db import db
+
+    target_metadata = db.metadata
+
+    # Produce migrations comparison
+    migrations = produce_migrations(migration_context, target_metadata)
+
+    # Extract upgrade operations
+    if not hasattr(migrations, "upgrade_ops"):
+        return []
+
+    if as_sql:
+        return _generate_sql_from_operations(migrations)
+
+    return _extract_operations_from_upgrade_ops(migrations.upgrade_ops)
+
+
+def main() -> int:
+    """Run the migration check and output results to stdout.
+
+    Expects to be called within an active Flask application context where
+    InvenioDB has been initialized. Can be used:
+
+    1. From invenio shell:
+       >>> from check_migrations import main
+       ...
+       ... main()
+
+    2. As standalone script:
+       $ python check_migrations.py
+       $ python check_migrations.py --sql
+
+    Returns:
+        Exit code (0 for success, non-zero for error)
+
+    """
+    parser = argparse.ArgumentParser(description="Check pending database migrations and output as JSON or SQL")
+    parser.add_argument(
+        "sql",
+        nargs="?",
+        const=True,
+        default=False,
+        help="Output SQL statements instead of JSON (pass 'sql' to enable)",
+    )
+    args = parser.parse_args()
+
+    try:
+        from flask import current_app
+
+        # Check we're in an app context
+        if not current_app:
+            raise RuntimeError("Not in Flask application context")
+
+        # Run the migration check
+        pending_migrations = check_migrations(as_sql=bool(args.sql))
+
+        if args.sql:
+            # Output SQL statements
+            print(pending_migrations, end="")  # noqa: T201
+        else:
+            # Output JSON
+            print(json.dumps(pending_migrations, indent=2))  # noqa: T201
+
+        return 0
+
+    except RuntimeError as e:
+        error_response = {"error": str(e)}
+        print(json.dumps(error_response), file=sys.stderr)  # noqa: T201
+        return 1
+    except Exception as e:  # noqa: BLE001
+        error_response = {"error": f"Unexpected error: {e}"}
+        print(json.dumps(error_response), file=sys.stderr)  # noqa: T201
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/oarepo_cli/core/context.py
+++ b/oarepo_cli/core/context.py
@@ -64,6 +64,28 @@ class ProjectContext:
             ConfigurationError: If none of the above can be found
 
         """
+        directories = list(self.code_directories_without_tests)
+
+        tests_dir = self.root_directory / "tests"
+        if tests_dir.is_dir():
+            directories.append(tests_dir)
+
+        return directories
+
+    @property
+    def code_directories_without_tests(self) -> list[Path]:
+        """Source directories to lint/type-check/format, excluding tests.
+
+        Same as code_directories but without the tests/ directory appended.
+        Useful for operations that should only affect production code.
+
+        Returns:
+            List of existing source directories (without tests/)
+
+        Raises:
+            ConfigurationError: If none of the source directories can be found
+
+        """
         pyproject_data = PyProjectReader().read(self.pyproject_path)
 
         directories: list[Path] = []
@@ -95,10 +117,6 @@ class ProjectContext:
                     raise ConfigurationError(
                         f"No src/ or {top_level}/ directory found, please ensure your package structure is correct."
                     )
-
-        tests_dir = self.root_directory / "tests"
-        if tests_dir.is_dir():
-            directories.append(tests_dir)
 
         return directories
 

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 import tomlkit
 
 from oarepo_cli.core.errors import ValidationError
@@ -18,6 +21,8 @@ from oarepo_cli.services.venv import VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput  # noqa: TC001 (used at runtime, not just type hints)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tomlkit import TOMLDocument
 
     from oarepo_cli.core.context import ProjectContext

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -102,6 +102,37 @@ class AlembicManager:
             fg=None,
         )
 
+    def revision(self, message: str) -> bool:
+        """Create an Alembic revision with the given message.
+
+        Returns:
+            True if revision was created successfully, False otherwise
+
+        """
+        self._console.info(f"✓ Creating revision: {message}")
+
+        # Step 1: Get alembic directory
+        alembic_path = self._get_alembic_directory()
+        if alembic_path is None:
+            self._console.error("✗ No alembic directory found")
+            return False
+
+        # Step 2: Ensure alembic directory exists and contains at least 2 files (initial + tables)
+        if self._count_python_files(alembic_path) < _MIN_INITIALIZED_FILES:
+            self._console.error("✗ Alembic directory is not initialized - run 'alembic init' first")
+            return False
+
+        # Step 3: Restart services
+        self._restart_services()
+
+        # Step 4: Upgrade to heads
+        self._upgrade_heads()
+
+        # Step 4: create a new revision
+        self._create_revision(message)
+
+        return True
+
     def _check_db_models_entrypoint(self) -> None:
         """Check if invenio_db.models entrypoint exists.
 
@@ -125,6 +156,32 @@ class AlembicManager:
 
         self._console.info("✓ Found invenio_db.models entrypoint")
 
+    def _get_alembic_directory(self) -> Path | None:
+        """Get the path to the alembic directory.
+
+        Returns:
+            Path to alembic directory if found, None otherwise
+
+        """
+        code_dirs = self._context.code_directories_without_tests
+        pyproject_data = PyProjectReader().read(self._context.pyproject_path)
+        package_name = pyproject_data.name.replace("-", "_")
+
+        # Check if alembic directory already exists in any code directory
+        for code_dir in code_dirs:
+            # Check if alembic exists directly in code_dir (flat layout)
+            alembic_dir = code_dir / "alembic"
+            if alembic_dir.exists():
+                self._console.info(f"✓ Found existing alembic directory: {alembic_dir}")
+                return alembic_dir
+
+            # Check if alembic exists in package subdirectory (src layout)
+            package_alembic_dir = code_dir / package_name / "alembic"
+            if package_alembic_dir.exists():
+                self._console.info(f"✓ Found existing alembic directory: {package_alembic_dir}")
+                return package_alembic_dir
+        return None
+
     def _ensure_alembic_directory(self) -> Path:
         """Ensure alembic directory exists in the first code directory.
 
@@ -135,6 +192,10 @@ class AlembicManager:
         code_dirs = self._context.code_directories_without_tests
         pyproject_data = PyProjectReader().read(self._context.pyproject_path)
         package_name = pyproject_data.name.replace("-", "_")
+
+        alembic_directory = self._get_alembic_directory()
+        if alembic_directory is not None:
+            return alembic_directory
 
         # Check if alembic directory already exists in any code directory
         for code_dir in code_dirs:
@@ -258,6 +319,12 @@ class AlembicManager:
         python_files = list(alembic_path.glob("*.py"))
         return len(python_files) >= _MIN_INITIALIZED_FILES
 
+    def _count_python_files(self, alembic_path: Path) -> int:
+        """Count the number of Python files in the alembic directory."""
+        if not alembic_path.exists():
+            return 0
+        return len(list(alembic_path.glob("*.py")))
+
     def _has_python_files(self, alembic_path: Path) -> bool:
         """Check if alembic directory has any Python files.
 
@@ -268,11 +335,7 @@ class AlembicManager:
             True if there's at least one Python file
 
         """
-        if not alembic_path.exists():
-            return False
-
-        python_files = list(alembic_path.glob("*.py"))
-        return len(python_files) > 0
+        return self._count_python_files(alembic_path) > 0
 
     def _sync_project(self) -> None:
         """Sync project to register entrypoints."""
@@ -435,10 +498,21 @@ class AlembicManager:
     def _create_tables_migration(self) -> None:
         """Create migration for initial tables."""
         package_name = self._get_package_name()
+
+        self._create_revision(f"Create {package_name} tables.")
+
+    def _create_revision(self, message: str) -> None:
+        """Create an Alembic revision with the given message.
+
+        Args:
+            message (str): The revision message to use.
+
+        """
+        package_name = self._get_package_name()
         # Branch name should match the entrypoint name (package_name)
         branch_name = package_name
 
-        self._console.info(f"→ Creating tables migration for {package_name}...")
+        self._console.info(f"→ Creating revision {message} for {package_name}...")
 
         invenio_path = self._get_venv_invenio_path()
         cmd_env = self._build_invenio_env()
@@ -447,7 +521,7 @@ class AlembicManager:
             str(invenio_path),
             "alembic",
             "revision",
-            f"Create {package_name} tables.",
+            message,
             "-b",
             branch_name,
         ]
@@ -460,7 +534,7 @@ class AlembicManager:
             output_mode=process.ProcessOutputMode.FORWARD,
         )
 
-        self._console.info(f"✓ Tables migration for {package_name} created")
+        self._console.info(f"✓ Created alembic revision: {message}")
 
     def _check_alembic_differences(self) -> None:
         """Check if alembic state is clean (no uncommitted database changes).

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import textwrap
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import tomlkit
@@ -85,13 +84,13 @@ class AlembicManager:
 
         # Step 7: Create branch migration if no python files exist
         if not self._has_python_files(alembic_path):
-            self._create_branch_migration(alembic_path)
+            self._create_branch_migration()
 
         # Step 8: Upgrade to heads
         self._upgrade_heads()
 
         # Step 9: Create initial tables migration
-        self._create_tables_migration(alembic_path)
+        self._create_tables_migration()
 
         self._console.success("\n✓ Alembic initialization completed successfully!")
         self._console.warning(
@@ -279,7 +278,8 @@ class AlembicManager:
         """Sync project to register entrypoints."""
         self._console.info("→ Syncing project to register entrypoints...")
 
-        cmd = ["uv", "pip", "install", "--no-deps", "-e", "."]
+        # Use --upgrade to ensure the latest version is installed from CESNET index
+        cmd = ["uv", "pip", "install", "--upgrade", "--no-deps", "--prerelease", "allow", "-e", "."]
         process.run(
             cmd,
             cwd=self._context.root_directory,
@@ -362,24 +362,13 @@ class AlembicManager:
 
         return cmd_env
 
-    def _create_branch_migration(self, alembic_path: Path) -> None:
-        """Create initial branch migration.
-
-        Args:
-            alembic_path: Path to the alembic directory
-
-        """
+    def _create_branch_migration(self) -> None:
+        """Create initial branch migration."""
         package_name = self._get_package_name()
-        branch_name = f"invenio_{package_name}"
+        # Branch name should match the entrypoint name (package_name)
+        branch_name = package_name
 
         self._console.info(f"→ Creating branch migration '{branch_name}'...")
-
-        # Calculate relative path from root to alembic directory for --path argument
-        try:
-            relative_path = alembic_path.relative_to(self._context.root_directory)
-        except ValueError:
-            # Fallback: use package_name/alembic
-            relative_path = Path(package_name) / "alembic"
 
         invenio_path = self._get_venv_invenio_path()
         cmd_env = self._build_invenio_env()
@@ -393,8 +382,6 @@ class AlembicManager:
             branch_name,
             "-p",
             "dbdbc1b19cf2",
-            "--path",
-            str(relative_path),
             "--empty",
         ]
 
@@ -435,7 +422,6 @@ class AlembicManager:
         cmd_env = self._build_invenio_env()
 
         cmd = [str(invenio_path), "alembic", "upgrade", "heads"]
-
         process.run(
             cmd,
             cwd=self._context.root_directory,
@@ -446,23 +432,13 @@ class AlembicManager:
 
         self._console.info("✓ Alembic upgrade completed")
 
-    def _create_tables_migration(self, alembic_path: Path) -> None:
-        """Create migration for initial tables.
-
-        Args:
-            alembic_path: Path to the alembic directory
-
-        """
+    def _create_tables_migration(self) -> None:
+        """Create migration for initial tables."""
         package_name = self._get_package_name()
+        # Branch name should match the entrypoint name (package_name)
+        branch_name = package_name
 
         self._console.info(f"→ Creating tables migration for {package_name}...")
-
-        # Calculate relative path from root to alembic directory for --path argument
-        try:
-            relative_path = alembic_path.relative_to(self._context.root_directory)
-        except ValueError:
-            # Fallback: use package_name/alembic
-            relative_path = Path(package_name) / "alembic"
 
         invenio_path = self._get_venv_invenio_path()
         cmd_env = self._build_invenio_env()
@@ -472,8 +448,8 @@ class AlembicManager:
             "alembic",
             "revision",
             f"Create {package_name} tables.",
-            "--path",
-            str(relative_path),
+            "-b",
+            branch_name,
         ]
 
         process.run(

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -43,7 +43,11 @@ class AlembicManager:
         self._context = context
         self._console = console
 
-    def init(self, alembic_path: Path | None = None) -> None:
+    def init(
+        self,
+        alembic_path: Path | None = None,
+        verify_model_entrypoint: bool = True,
+    ) -> None:
         """Initialize Alembic support for the library.
 
         Performs the following checks and operations:
@@ -60,16 +64,18 @@ class AlembicManager:
 
         Args:
             alembic_path: optional path to the alembic directory
+            verify_model_entrypoint: whether to verify the invenio_db.models entrypoint
 
         Raises:
             ValidationError: If required entrypoints are missing or alembic state is not clean
 
         """
         # Step 1: Check for invenio_db.models entrypoint
-        self._check_db_models_entrypoint()
+        if verify_model_entrypoint:
+            self._check_db_models_entrypoint()
 
         # Step 2: Check/create alembic directory
-        alembic_path = self._ensure_alembic_directory(alembic_path)
+        alembic_path = self._ensure_alembic_directory(alembic_path).resolve()
 
         # Step 3: Check/create invenio_db.alembic entrypoint
         self._ensure_alembic_entrypoint(alembic_path)
@@ -87,7 +93,7 @@ class AlembicManager:
 
         # Step 7: Create branch migration if no python files exist
         if not self._has_python_files(alembic_path):
-            self._create_branch_migration()
+            self._create_branch_migration(alembic_path)
 
         # Step 8: Upgrade to heads
         self._upgrade_heads()
@@ -105,8 +111,12 @@ class AlembicManager:
             fg=None,
         )
 
-    def revision(self, message: str) -> bool:
+    def revision(self, message: str, alembic_path: Path | None = None) -> bool:
         """Create an Alembic revision with the given message.
+
+        Args:
+            message: Revision message to use
+            alembic_path: Optional path to the alembic directory
 
         Returns:
             True if revision was created successfully, False otherwise
@@ -115,13 +125,13 @@ class AlembicManager:
         self._console.info(f"✓ Creating revision: {message}")
 
         # Step 1: Get alembic directory
-        alembic_path = self._get_alembic_directory()
-        if alembic_path is None:
+        alembic_directory = alembic_path if alembic_path is not None else self._get_alembic_directory()
+        if alembic_directory is None:
             self._console.error("✗ No alembic directory found")
             return False
 
         # Step 2: Ensure alembic directory exists and contains at least 2 files (initial + tables)
-        if self._count_python_files(alembic_path) < _MIN_INITIALIZED_FILES:
+        if self._count_python_files(alembic_directory) < _MIN_INITIALIZED_FILES:
             self._console.error("✗ Alembic directory is not initialized - run 'alembic init' first")
             return False
 
@@ -131,10 +141,62 @@ class AlembicManager:
         # Step 4: Upgrade to heads
         self._upgrade_heads()
 
-        # Step 4: create a new revision
+        # Step 5: Create a new revision
         self._create_revision(message)
 
+        # Destroy services after completion
+        services_mgr = ServicesLifecycleManager(
+            config=self._context.config,
+            project_root=self._context.root_directory,
+            quiet=self._console.is_quiet,
+        )
+        services_mgr.destroy_services()
+
         return True
+
+    def apply(self) -> None:
+        """Apply all pending migrations by running 'invenio alembic upgrade heads'.
+
+        This command upgrades the database to the latest migration head.
+        It restarts Docker services to ensure a clean state before applying migrations.
+
+        """
+        self._console.info("→ Applying all pending migrations...")
+
+        # Restart services to ensure clean state
+        self._restart_services()
+
+        # Run upgrade heads
+        self._upgrade_heads()
+
+        self._console.success("\n✓ All migrations applied successfully!")
+
+    def stamp(self, revision: str) -> None:
+        """Stamp the database with the specified revision without applying migrations.
+
+        This command sets the current database schema version to the specified revision
+        without actually running any migration scripts. Useful for syncing the database
+        state with the codebase when migrations have been applied manually or externally.
+
+        Args:
+            revision: The revision identifier to stamp (e.g., 'head', 'base', or a specific revision ID)
+
+        """
+        self._console.info(f"→ Stamping database with revision: {revision}...")
+
+        invenio_path = self._get_venv_invenio_path()
+        cmd_env = self._build_invenio_env()
+
+        cmd = [str(invenio_path), "alembic", "stamp", revision]
+        process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            env=cmd_env,
+            check=True,
+            output_mode=process.ProcessOutputMode.FORWARD,
+        )
+
+        self._console.success(f"\n✓ Database stamped with revision: {revision}")
 
     def _check_db_models_entrypoint(self) -> None:
         """Check if invenio_db.models entrypoint exists.
@@ -429,8 +491,13 @@ class AlembicManager:
 
         return cmd_env
 
-    def _create_branch_migration(self) -> None:
-        """Create initial branch migration."""
+    def _create_branch_migration(self, alembic_path: Path) -> None:  # noqa: ARG002
+        """Create initial branch migration.
+
+        Args:
+            alembic_path: Path to the alembic directory (not used, kept for API compatibility)
+
+        """
         package_name = self._get_package_name()
         # Branch name should match the entrypoint name (package_name)
         branch_name = package_name
@@ -593,3 +660,121 @@ class AlembicManager:
             )
 
         self._console.info("✓ Alembic state is clean")
+
+    def check(self, sql: bool = False) -> int:
+        """Check for pending database migrations.
+
+        Runs the check_migrations.py script to compare the current database schema
+        against the model metadata and detect any pending migrations.
+
+        Args:
+            sql: If True, output SQL statements instead of JSON
+
+        Returns:
+            Exit code: 0 if no migrations needed, 1 if pending migrations detected
+
+        """
+        import os
+        import tempfile
+        from importlib.resources import files
+        from pathlib import Path
+
+        # Get the script content and write it to a temporary file
+        script_content = files("oarepo_cli.configuration").joinpath("check_migrations.py").read_text()
+
+        # Create a temporary file that persists after closing (delete=False)
+        # We manually manage the lifecycle to ensure the file exists during subprocess execution
+        fd, temp_script_path = tempfile.mkstemp(suffix=".py")
+        try:
+            # Write script content to the temporary file
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(script_content)
+
+            # Build the command to run the migration check script via invenio shell
+            # This ensures Flask and Invenio are properly initialized
+            cmd = [
+                str(self._get_venv_invenio_path()),
+                "shell",
+                temp_script_path,
+            ]
+            if sql:
+                cmd.append("sql")
+            cmd_env = self._build_invenio_env()
+
+            result = process.run(
+                cmd,
+                cwd=self._context.root_directory,
+                env=cmd_env,
+                check=True,
+                output_mode=process.ProcessOutputMode.FORWARD,
+            )
+
+            # Parse the output to determine if there are pending migrations
+            output = result.stdout.strip()
+
+            # Forward mode doesn't actually forward, so we need to print manually
+            if output:
+                print(output)  # noqa: T201
+
+            if sql:
+                # For SQL mode, return 1 if there is any output (migrations needed)
+                if output and output != "[]":
+                    return 1  # Pending migrations
+                return 0  # No migrations
+
+            # JSON mode - parse and check if empty
+            import json
+
+            try:
+                migrations = json.loads(output)
+                if isinstance(migrations, list) and len(migrations) > 0:
+                    # There are pending migrations
+                    return 1
+                return 0  # No pending migrations
+            except json.JSONDecodeError:
+                # If we can't parse JSON, assume there might be issues
+                return 1
+        finally:
+            # Clean up temporary file
+            Path(temp_script_path).unlink()
+
+    def check_with_services(self, sql: bool = False) -> int:
+        """Check for pending database migrations with service lifecycle management.
+
+        This method starts Docker services, upgrades to heads, runs the migration
+        check, and then destroys the services. Intended for library commands where
+        services should not persist after the check.
+
+        Args:
+            sql: If True, output SQL statements instead of JSON
+
+        Returns:
+            Exit code: 0 if no migrations needed, 1 if pending migrations detected
+
+        """
+        try:
+            # Start services
+            self._console.info("→ Starting services...")
+            services_mgr = ServicesLifecycleManager(
+                config=self._context.config,
+                project_root=self._context.root_directory,
+                quiet=self._console.is_quiet,
+            )
+            services_mgr.start_services()
+            self._console.info("✓ Services started")
+
+            # Upgrade to heads to ensure database is up to date before checking
+            self._upgrade_heads()
+
+            # Run the check
+            return self.check(sql=sql)
+        finally:
+            # Always destroy services after completion
+            self._console.info("→ Destroying services...")
+            services_mgr = ServicesLifecycleManager(
+                config=self._context.config,
+                project_root=self._context.root_directory,
+                quiet=self._console.is_quiet,
+            )
+            services_mgr.destroy_services()
+            self._console.info("✓ Services destroyed")

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -5,20 +5,26 @@
 
 from __future__ import annotations
 
+import textwrap
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import tomlkit
 
 from oarepo_cli.core.errors import ValidationError
+from oarepo_cli.services import process
 from oarepo_cli.services.pyproject_reader import PyProjectReader
+from oarepo_cli.services.services_lifecycle import ServicesLifecycleManager
+from oarepo_cli.services.venv import VirtualEnvironmentManager
 from oarepo_cli.ui import ConsoleOutput  # noqa: TC001 (used at runtime, not just type hints)
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from tomlkit import TOMLDocument
 
     from oarepo_cli.core.context import ProjectContext
+
+# Minimum number of Python files to consider alembic initialized
+_MIN_INITIALIZED_FILES = 2
 
 
 class AlembicManager:
@@ -45,9 +51,16 @@ class AlembicManager:
         1. Verifies invenio_db.models entrypoint exists
         2. Creates alembic/ directory in the first code directory if needed
         3. Adds invenio_db.alembic entrypoint if missing
+        4. Checks if alembic is already initialized (2+ python files)
+        5. Syncs the project to register entrypoints
+        6. Starts/restarts services
+        7. Checks that alembic state is clean (no uncommitted changes)
+        8. Creates initial branch migration if needed
+        9. Runs alembic upgrade heads
+        10. Creates migration for initial tables
 
         Raises:
-            ValidationError: If required entrypoints are missing
+            ValidationError: If required entrypoints are missing or alembic state is not clean
 
         """
         # Step 1: Check for invenio_db.models entrypoint
@@ -59,7 +72,36 @@ class AlembicManager:
         # Step 3: Check/create invenio_db.alembic entrypoint
         self._ensure_alembic_entrypoint(alembic_path)
 
+        # Step 4: Check if already initialized
+        if self._is_already_initialized(alembic_path):
+            self._console.success("\n✓ Alembic is already initialized (found migrations)")
+            return
+
+        # Step 5: Sync project to register entrypoints
+        self._sync_project()
+
+        # Step 6: Start/restart services
+        self._restart_services()
+
+        # Step 7: Create branch migration if no python files exist
+        if not self._has_python_files(alembic_path):
+            self._create_branch_migration(alembic_path)
+
+        # Step 8: Upgrade to heads
+        self._upgrade_heads()
+
+        # Step 9: Create initial tables migration
+        self._create_tables_migration(alembic_path)
+
         self._console.success("\n✓ Alembic initialization completed successfully!")
+        self._console.warning(
+            "\n⚠️  IMPORTANT: Please carefully review the generated migration file in the alembic directory.",
+            fg=None,
+        )
+        self._console.warning(
+            "   Verify that it contains only the intended table changes for your models.",
+            fg=None,
+        )
 
     def _check_db_models_entrypoint(self) -> None:
         """Check if invenio_db.models entrypoint exists.
@@ -200,3 +242,300 @@ class AlembicManager:
 
         """
         self._context.pyproject_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    def _is_already_initialized(self, alembic_path: Path) -> bool:
+        """Check if alembic is already initialized.
+
+        Args:
+            alembic_path: Path to the alembic directory
+
+        Returns:
+            True if there are at least 2 Python files in the alembic directory
+
+        """
+        if not alembic_path.exists():
+            return False
+
+        python_files = list(alembic_path.glob("*.py"))
+        return len(python_files) >= _MIN_INITIALIZED_FILES
+
+    def _has_python_files(self, alembic_path: Path) -> bool:
+        """Check if alembic directory has any Python files.
+
+        Args:
+            alembic_path: Path to the alembic directory
+
+        Returns:
+            True if there's at least one Python file
+
+        """
+        if not alembic_path.exists():
+            return False
+
+        python_files = list(alembic_path.glob("*.py"))
+        return len(python_files) > 0
+
+    def _sync_project(self) -> None:
+        """Sync project to register entrypoints."""
+        self._console.info("→ Syncing project to register entrypoints...")
+
+        cmd = ["uv", "pip", "install", "--no-deps", "-e", "."]
+        process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            check=True,
+            output_mode=process.ProcessOutputMode.CAPTURE,
+        )
+
+        self._console.info("✓ Project synced")
+
+    def _get_package_name(self) -> str:
+        """Get the package name from pyproject.toml.
+
+        Returns:
+            Package name with hyphens replaced by underscores
+
+        """
+        pyproject_data = PyProjectReader().read(self._context.pyproject_path)
+        return pyproject_data.name.replace("-", "_")
+
+    def _get_venv_invenio_path(self) -> Path:
+        """Get path to invenio executable in the virtual environment.
+
+        Returns:
+            Path to invenio binary
+
+        Raises:
+            ValidationError: If invenio is not found in venv
+
+        """
+        from oarepo_cli.core.platform import get_platform_detector
+
+        venv_mgr = VirtualEnvironmentManager(config=self._context.config, project_root=self._context.root_directory)
+        # Access internal venv path directly
+        venv_path = venv_mgr._venv_path  # noqa: SLF001
+
+        if not venv_path or not venv_path.exists():
+            raise ValidationError("Virtual environment not found. Run 'oarepo-cli library install' first.")
+
+        platform = get_platform_detector()
+        bin_dir = platform.get_venv_bin_dir()
+        invenio_path = venv_path / bin_dir / "invenio"
+
+        if not invenio_path.exists():
+            raise ValidationError(
+                "invenio command not found in virtual environment. "
+                "Ensure invenio is installed in your project dependencies."
+            )
+
+        return invenio_path
+
+    def _get_service_env(self) -> dict[str, str]:
+        """Get environment variables from services.
+
+        Returns:
+            Dictionary of environment variables
+
+        """
+        services_mgr = ServicesLifecycleManager(
+            config=self._context.config,
+            project_root=self._context.root_directory,
+            quiet=self._console.is_quiet,
+        )
+        return services_mgr.load_service_env()
+
+    def _build_invenio_env(self) -> dict[str, str]:
+        """Build environment for running invenio commands.
+
+        Returns:
+            Dictionary of environment variables with INVENIO_SQLALCHEMY_DATABASE_URI set
+
+        """
+        # Get base environment with service variables
+        service_env = self._get_service_env()
+        cmd_env = process.build_subprocess_env()
+        cmd_env.update(service_env)
+
+        # Map SQLALCHEMY_DATABASE_URI to INVENIO_SQLALCHEMY_DATABASE_URI
+        if "SQLALCHEMY_DATABASE_URI" in cmd_env:
+            cmd_env["INVENIO_SQLALCHEMY_DATABASE_URI"] = cmd_env["SQLALCHEMY_DATABASE_URI"]
+
+        return cmd_env
+
+    def _create_branch_migration(self, alembic_path: Path) -> None:
+        """Create initial branch migration.
+
+        Args:
+            alembic_path: Path to the alembic directory
+
+        """
+        package_name = self._get_package_name()
+        branch_name = f"invenio_{package_name}"
+
+        self._console.info(f"→ Creating branch migration '{branch_name}'...")
+
+        # Calculate relative path from root to alembic directory for --path argument
+        try:
+            relative_path = alembic_path.relative_to(self._context.root_directory)
+        except ValueError:
+            # Fallback: use package_name/alembic
+            relative_path = Path(package_name) / "alembic"
+
+        invenio_path = self._get_venv_invenio_path()
+        cmd_env = self._build_invenio_env()
+
+        cmd = [
+            str(invenio_path),
+            "alembic",
+            "revision",
+            f"Create {package_name} branch.",
+            "-b",
+            branch_name,
+            "-p",
+            "dbdbc1b19cf2",
+            "--path",
+            str(relative_path),
+            "--empty",
+        ]
+
+        process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            env=cmd_env,
+            check=True,
+            output_mode=process.ProcessOutputMode.FORWARD,
+        )
+
+        self._console.info(f"✓ Branch migration '{branch_name}' created")
+
+    def _restart_services(self) -> None:
+        """Restart Docker services (stop and start)."""
+        services_mgr = ServicesLifecycleManager(
+            config=self._context.config,
+            project_root=self._context.root_directory,
+            quiet=self._console.is_quiet,
+        )
+
+        self._console.info("→ Restarting services...")
+
+        # Stop services if running
+        if services_mgr.are_services_running():
+            services_mgr.stop_services()
+
+        # Start services
+        services_mgr.start_services()
+
+        self._console.info("✓ Services started")
+
+    def _upgrade_heads(self) -> None:
+        """Run invenio alembic upgrade heads."""
+        self._console.info("→ Running alembic upgrade heads...")
+
+        invenio_path = self._get_venv_invenio_path()
+        cmd_env = self._build_invenio_env()
+
+        cmd = [str(invenio_path), "alembic", "upgrade", "heads"]
+
+        process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            env=cmd_env,
+            check=True,
+            output_mode=process.ProcessOutputMode.FORWARD,
+        )
+
+        self._console.info("✓ Alembic upgrade completed")
+
+    def _create_tables_migration(self, alembic_path: Path) -> None:
+        """Create migration for initial tables.
+
+        Args:
+            alembic_path: Path to the alembic directory
+
+        """
+        package_name = self._get_package_name()
+
+        self._console.info(f"→ Creating tables migration for {package_name}...")
+
+        # Calculate relative path from root to alembic directory for --path argument
+        try:
+            relative_path = alembic_path.relative_to(self._context.root_directory)
+        except ValueError:
+            # Fallback: use package_name/alembic
+            relative_path = Path(package_name) / "alembic"
+
+        invenio_path = self._get_venv_invenio_path()
+        cmd_env = self._build_invenio_env()
+
+        cmd = [
+            str(invenio_path),
+            "alembic",
+            "revision",
+            f"Create {package_name} tables.",
+            "--path",
+            str(relative_path),
+        ]
+
+        process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            env=cmd_env,
+            check=True,
+            output_mode=process.ProcessOutputMode.FORWARD,
+        )
+
+        self._console.info(f"✓ Tables migration for {package_name} created")
+
+    def _check_alembic_differences(self) -> None:
+        """Check if alembic state is clean (no uncommitted database changes).
+
+        Runs invenio shell with a script that checks for differences between
+        the database schema and the alembic migrations.
+
+        Raises:
+            ValidationError: If alembic state is not clean (has uncommitted changes)
+
+        """
+        self._console.info("→ Checking alembic state...")
+
+        # Python script to check alembic differences
+        check_script = textwrap.dedent(
+            """
+            from flask import current_app
+            ext = current_app.extensions["invenio-db"]
+            alembic = ext.alembic
+            if alembic.compare_metadata():
+                print("Alembic state not clean:")
+                print(alembic.compare_metadata())
+            """
+        )
+
+        invenio_path = self._get_venv_invenio_path()
+        cmd_env = self._build_invenio_env()
+
+        cmd = [
+            str(invenio_path),
+            "shell",
+            "-c",
+            check_script,
+        ]
+
+        result = process.run(
+            cmd,
+            cwd=self._context.root_directory,
+            env=cmd_env,
+            check=True,
+            output_mode=process.ProcessOutputMode.CAPTURE,
+        )
+
+        # Check if output contains "Alembic state not clean"
+        if "Alembic state not clean" in result.stdout:
+            self._console.error("❌ Alembic state is not clean!")
+            self._console.error("\nUncommitted database changes detected:")
+            self._console.error(result.stdout)
+            raise ValidationError(
+                "Alembic state is not clean. There are uncommitted database schema changes. "
+                "Please ensure your database schema matches your migrations before running alembic init."
+            )
+
+        self._console.info("✓ Alembic state is clean")

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -43,7 +43,7 @@ class AlembicManager:
         self._context = context
         self._console = console
 
-    def init(self) -> None:
+    def init(self, alembic_path: Path | None = None) -> None:
         """Initialize Alembic support for the library.
 
         Performs the following checks and operations:
@@ -58,6 +58,9 @@ class AlembicManager:
         9. Runs alembic upgrade heads
         10. Creates migration for initial tables
 
+        Args:
+            alembic_path: optional path to the alembic directory
+
         Raises:
             ValidationError: If required entrypoints are missing or alembic state is not clean
 
@@ -66,7 +69,7 @@ class AlembicManager:
         self._check_db_models_entrypoint()
 
         # Step 2: Check/create alembic directory
-        alembic_path = self._ensure_alembic_directory()
+        alembic_path = self._ensure_alembic_directory(alembic_path)
 
         # Step 3: Check/create invenio_db.alembic entrypoint
         self._ensure_alembic_entrypoint(alembic_path)
@@ -182,7 +185,7 @@ class AlembicManager:
                 return package_alembic_dir
         return None
 
-    def _ensure_alembic_directory(self) -> Path:
+    def _ensure_alembic_directory(self, alembic_path: Path | None) -> Path:
         """Ensure alembic directory exists in the first code directory.
 
         Returns:
@@ -193,8 +196,9 @@ class AlembicManager:
         pyproject_data = PyProjectReader().read(self._context.pyproject_path)
         package_name = pyproject_data.name.replace("-", "_")
 
-        alembic_directory = self._get_alembic_directory()
+        alembic_directory = alembic_path if alembic_path is not None else self._get_alembic_directory()
         if alembic_directory is not None:
+            alembic_directory.mkdir(parents=True, exist_ok=True)
             return alembic_directory
 
         # Check if alembic directory already exists in any code directory

--- a/oarepo_cli/services/alembic.py
+++ b/oarepo_cli/services/alembic.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Alembic migration management for OARepo libraries."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import tomlkit
+
+from oarepo_cli.core.errors import ValidationError
+from oarepo_cli.services.pyproject_reader import PyProjectReader
+from oarepo_cli.ui import ConsoleOutput  # noqa: TC001 (used at runtime, not just type hints)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tomlkit import TOMLDocument
+
+    from oarepo_cli.core.context import ProjectContext
+
+
+class AlembicManager:
+    """Manages Alembic migrations for OARepo library projects.
+
+    Handles initialization of Alembic directories and entrypoints in pyproject.toml.
+    """
+
+    def __init__(self, context: ProjectContext, console: ConsoleOutput) -> None:
+        """Initialize the alembic manager.
+
+        Args:
+            context: Project context with paths and configuration
+            console: Console output handler for status messages
+
+        """
+        self._context = context
+        self._console = console
+
+    def init(self) -> None:
+        """Initialize Alembic support for the library.
+
+        Performs the following checks and operations:
+        1. Verifies invenio_db.models entrypoint exists
+        2. Creates alembic/ directory in the first code directory if needed
+        3. Adds invenio_db.alembic entrypoint if missing
+
+        Raises:
+            ValidationError: If required entrypoints are missing
+
+        """
+        # Step 1: Check for invenio_db.models entrypoint
+        self._check_db_models_entrypoint()
+
+        # Step 2: Check/create alembic directory
+        alembic_path = self._ensure_alembic_directory()
+
+        # Step 3: Check/create invenio_db.alembic entrypoint
+        self._ensure_alembic_entrypoint(alembic_path)
+
+        self._console.success("\n✓ Alembic initialization completed successfully!")
+
+    def _check_db_models_entrypoint(self) -> None:
+        """Check if invenio_db.models entrypoint exists.
+
+        Raises:
+            ValidationError: If the entrypoint doesn't exist
+
+        """
+        pyproject_data = PyProjectReader().read(self._context.pyproject_path)
+        entrypoints = pyproject_data.raw.get("project", {}).get("entry-points", {})
+        db_models = entrypoints.get("invenio_db.models", {})
+
+        if not db_models:
+            package_name = pyproject_data.name.replace("-", "_")
+            error_msg = (
+                "Error: No 'invenio_db.models' entrypoint found.\n\n"
+                "Please add an entrypoint to your pyproject.toml:\n\n"
+                '[project.entry-points."invenio_db.models"]\n'
+                f'{package_name} = "{package_name}.records.models"\n'
+            )
+            raise ValidationError(error_msg)
+
+        self._console.info("✓ Found invenio_db.models entrypoint")
+
+    def _ensure_alembic_directory(self) -> Path:
+        """Ensure alembic directory exists in the first code directory.
+
+        Returns:
+            Path to the alembic directory
+
+        """
+        code_dirs = self._context.code_directories_without_tests
+        pyproject_data = PyProjectReader().read(self._context.pyproject_path)
+        package_name = pyproject_data.name.replace("-", "_")
+
+        # Check if alembic directory already exists in any code directory
+        for code_dir in code_dirs:
+            # Check if alembic exists directly in code_dir (flat layout)
+            alembic_dir = code_dir / "alembic"
+            if alembic_dir.exists():
+                self._console.info(f"✓ Found existing alembic directory: {alembic_dir}")
+                return alembic_dir
+
+            # Check if alembic exists in package subdirectory (src layout)
+            package_alembic_dir = code_dir / package_name / "alembic"
+            if package_alembic_dir.exists():
+                self._console.info(f"✓ Found existing alembic directory: {package_alembic_dir}")
+                return package_alembic_dir
+
+        # Create alembic directory in the first code directory
+        first_code_dir = code_dirs[0]
+
+        # For src layout, create inside the package directory
+        # For flat layout, code_dir is already the package directory
+        if first_code_dir.name == "src":
+            # src layout: create in src/package_name/alembic
+            alembic_dir = first_code_dir / package_name / "alembic"
+        else:
+            # flat layout: create in package_name/alembic
+            alembic_dir = first_code_dir / "alembic"
+
+        alembic_dir.mkdir(parents=True, exist_ok=True)
+        self._console.info(f"✓ Created alembic directory: {alembic_dir}")
+
+        return alembic_dir
+
+    def _ensure_alembic_entrypoint(self, alembic_path: Path) -> None:
+        """Ensure invenio_db.alembic entrypoint exists.
+
+        Args:
+            alembic_path: Path to the alembic directory
+
+        """
+        pyproject_data = PyProjectReader().read(self._context.pyproject_path)
+        package_name = pyproject_data.name.replace("-", "_")
+
+        # Calculate the entrypoint value (package:alembic)
+        # Find the relative path from root to alembic parent (the package directory)
+        alembic_parent = alembic_path.parent
+        try:
+            relative_parent = alembic_parent.relative_to(self._context.root_directory)
+            # Convert path to module notation
+            module_path = str(relative_parent).replace("/", ".")
+            # Remove 'src.' prefix if present
+            module_path = module_path.removeprefix("src.")
+            entrypoint_value = f"{module_path}:alembic"
+        except ValueError:
+            # Fallback if path calculation fails
+            entrypoint_value = f"{package_name}:alembic"
+
+        # Check if entrypoint already exists
+        entrypoints = pyproject_data.raw.get("project", {}).get("entry-points", {})
+        alembic_entrypoints = entrypoints.get("invenio_db.alembic", {})
+
+        if package_name in alembic_entrypoints:
+            existing_value = alembic_entrypoints[package_name]
+            self._console.info(f'✓ Found existing invenio_db.alembic entrypoint: {package_name} = "{existing_value}"')
+            return
+
+        # Add the entrypoint
+        self._add_alembic_entrypoint(package_name, entrypoint_value)
+        self._console.info(f'✓ Added invenio_db.alembic entrypoint: {package_name} = "{entrypoint_value}"')
+
+    def _add_alembic_entrypoint(self, package_name: str, entrypoint_value: str) -> None:
+        """Add invenio_db.alembic entrypoint to pyproject.toml.
+
+        Args:
+            package_name: The package name for the entrypoint key
+            entrypoint_value: The entrypoint value (e.g., "package:alembic")
+
+        """
+        document = self._read_document()
+
+        # Navigate/create the nested structure
+        project = document.setdefault("project", tomlkit.table())
+        entrypoints = project.setdefault("entry-points", tomlkit.table())
+        alembic_ep = entrypoints.setdefault("invenio_db.alembic", tomlkit.table())
+
+        # Add the entrypoint
+        alembic_ep[package_name] = entrypoint_value
+
+        self._write_document(document)
+
+    def _read_document(self) -> TOMLDocument:
+        """Read and parse the project's pyproject.toml file.
+
+        Returns:
+            Parsed TOML document as a tomlkit object
+
+        """
+        return tomlkit.parse(self._context.pyproject_path.read_text(encoding="utf-8"))
+
+    def _write_document(self, document: TOMLDocument) -> None:
+        """Write the TOML document back to pyproject.toml.
+
+        Args:
+            document: The TOML document to write
+
+        """
+        self._context.pyproject_path.write_text(tomlkit.dumps(document), encoding="utf-8")

--- a/oarepo_cli/services/services_lifecycle.py
+++ b/oarepo_cli/services/services_lifecycle.py
@@ -5,15 +5,37 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from oarepo_cli.core.config import CliConfig
 
 from oarepo_cli.configuration.constants import ENV_SERVICES_FILE
 from oarepo_cli.services import process
+
+
+def _docker_services_cli_path() -> str:
+    """Resolve the docker-services-cli binary installed alongside oarepo-cli's own venv.
+
+    docker-services-cli is a regular oarepo-cli dependency (see
+    pyproject.toml), not a target-project dependency, so it's resolved next
+    to the running interpreter rather than via PATH -- ``process.run``
+    strips the oarepo-cli venv's own bin directory from PATH by default to
+    keep it from leaking into target-project subprocesses, which would
+    otherwise make this bundled binary unresolvable. Mirrors
+    ``services.lint._tool_path``/``services.invenio_cli._invenio_cli_path``'s
+    identical rationale.
+
+    Returns:
+        Absolute path to the binary if found next to the current
+        interpreter, otherwise the bare name (resolved via PATH by the
+        subprocess call).
+
+    """
+    candidate = Path(sys.executable).parent / "docker-services-cli"
+    return str(candidate) if candidate.exists() else "docker-services-cli"
 
 
 class ServicesLifecycleManager:
@@ -56,7 +78,7 @@ class ServicesLifecycleManager:
 
         # Build docker-services-cli command
         cmd = [
-            "docker-services-cli",
+            _docker_services_cli_path(),
             "up",
             "--db",
             self._config.services.db,
@@ -120,7 +142,7 @@ class ServicesLifecycleManager:
 
         # Run docker-services-cli down
         cmd = [
-            "docker-services-cli",
+            _docker_services_cli_path(),
             "down",
             "--env",
         ]
@@ -151,7 +173,7 @@ class ServicesLifecycleManager:
 
         # Run docker-services-cli down
         cmd = [
-            "docker-services-cli",
+            _docker_services_cli_path(),
             "down",
             "--env",
         ]

--- a/oarepo_cli/services/services_lifecycle.py
+++ b/oarepo_cli/services/services_lifecycle.py
@@ -141,6 +141,40 @@ class ServicesLifecycleManager:
         if self._env_file.exists():
             self._env_file.unlink()
 
+    def destroy_services(self) -> None:
+        """Stop Docker services and clean up.
+
+        Uses docker-services-cli to stop all running services and removes
+        the .env-services file. Note: This does not destroy persistent volumes;
+        it only stops the containers.
+
+        Raises:
+            ProcessExecutionError: If docker-services-cli fails
+
+        """
+        if self._config.services.skip:
+            return
+
+        # Run docker-services-cli down
+        cmd = [
+            "uvx",
+            "--with",
+            "setuptools",
+            "docker-services-cli",
+            "down",
+            "--env",
+        ]
+
+        # Add --quiet flag if requested
+        if self._quiet:
+            cmd.append("--quiet")
+
+        process.run(cmd, cwd=self._project_root, check=True)
+
+        # Remove .env-services file if it exists
+        if self._env_file.exists():
+            self._env_file.unlink()
+
     def load_service_env(self) -> dict[str, str]:
         """Load environment variables from .env-services file.
 

--- a/oarepo_cli/services/services_lifecycle.py
+++ b/oarepo_cli/services/services_lifecycle.py
@@ -56,9 +56,6 @@ class ServicesLifecycleManager:
 
         # Build docker-services-cli command
         cmd = [
-            "uvx",
-            "--with",
-            "setuptools",
             "docker-services-cli",
             "up",
             "--db",
@@ -123,9 +120,6 @@ class ServicesLifecycleManager:
 
         # Run docker-services-cli down
         cmd = [
-            "uvx",
-            "--with",
-            "setuptools",
             "docker-services-cli",
             "down",
             "--env",
@@ -157,9 +151,6 @@ class ServicesLifecycleManager:
 
         # Run docker-services-cli down
         cmd = [
-            "uvx",
-            "--with",
-            "setuptools",
             "docker-services-cli",
             "down",
             "--env",

--- a/oarepo_cli/ui/console.py
+++ b/oarepo_cli/ui/console.py
@@ -37,10 +37,14 @@ class ConsoleOutput:
 
         Args:
             message: Message to print
-            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, err, etc.)
+                     err=True by default for info messages
 
         """
         if not self._quiet:
+            # Default to stderr for info messages
+            if "err" not in kwargs:
+                kwargs["err"] = True
             typer.secho(message, **kwargs)
 
     def success(self, message: str, **kwargs: Any) -> None:
@@ -48,10 +52,14 @@ class ConsoleOutput:
 
         Args:
             message: Message to print
-            **kwargs: Same arguments as typer.secho (fg, bg, bold, etc.)
+            **kwargs: Same arguments as typer.secho (fg, bg, bold, err, etc.)
+                     err=True by default for success messages
 
         """
         if not self._quiet:
+            # Default to stderr for success messages
+            if "err" not in kwargs:
+                kwargs["err"] = True
             typer.secho(message, **kwargs)
 
     def warning(self, message: str, **kwargs: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
     # (write-only, full-dict dump), tomlkit is round-trip-preserving --
     # comments, key order, and formatting elsewhere in the file survive.
     "tomlkit>=0.13.0",
+    # Docker services management (services/services_lifecycle.py)
+    "docker-services-cli>=0.12.0,<1.0.0",
 ]
 requires-python = ">=3.14,<3.15"
 

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2026 CESNET z.s.p.o.
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for AlembicManager, against real pyproject.toml files.
+
+AlembicManager only touches a project's pyproject.toml (via tomlkit) and
+filesystem (creating alembic/ directories), so these tests exercise the real
+tomlkit read/modify/write path against real tmp_path files.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+
+from oarepo_cli.core.config import CliConfig
+from oarepo_cli.core.context import ProjectContext
+from oarepo_cli.core.errors import ValidationError
+from oarepo_cli.services.alembic import AlembicManager
+from oarepo_cli.ui import ConsoleOutput
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+LIBRARY_PYPROJECT = """\
+[project]
+name = "mylib"
+dependencies = [
+    "oarepo>=14.0.0,<15.0.0",
+]
+requires-python = ">=3.14,<3.15"
+
+[project.entry-points."invenio_db.models"]
+mylib = "mylib.records.models"
+"""
+
+LIBRARY_PYPROJECT_NO_MODELS = """\
+[project]
+name = "mylib"
+dependencies = [
+    "oarepo>=14.0.0,<15.0.0",
+]
+requires-python = ">=3.14,<3.15"
+"""
+
+
+def make_context(root: Path) -> ProjectContext:
+    return ProjectContext(
+        root_directory=root,
+        pyproject_path=root / "pyproject.toml",
+        venv_path=root / ".venv",
+        python_binary=root / ".venv" / "bin" / "python",
+        oarepo_version=14,
+        config=CliConfig(),
+    )
+
+
+@pytest.fixture
+def lib_root(tmp_path: Path) -> Path:
+    """Create a library root with src layout and invenio_db.models entrypoint."""
+    root = tmp_path / "lib"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(LIBRARY_PYPROJECT)
+    (root / "src" / "mylib").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def lib_root_flat_layout(tmp_path: Path) -> Path:
+    """Create a library root with flat layout and invenio_db.models entrypoint."""
+    root = tmp_path / "lib"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(LIBRARY_PYPROJECT)
+    (root / "mylib").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def lib_root_no_models(tmp_path: Path) -> Path:
+    """Create a library root without invenio_db.models entrypoint."""
+    root = tmp_path / "lib"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(LIBRARY_PYPROJECT_NO_MODELS)
+    (root / "src" / "mylib").mkdir(parents=True)
+    return root
+
+
+def test_init_creates_alembic_directory_and_entrypoint(lib_root: Path) -> None:
+    """init() creates alembic directory and adds entrypoint when missing."""
+    context = make_context(lib_root)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    manager.init()
+
+    # Check directory was created
+    alembic_dir = lib_root / "src" / "mylib" / "alembic"
+    assert alembic_dir.exists()
+    assert alembic_dir.is_dir()
+
+    # Check entrypoint was added
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    alembic_ep = document["project"]["entry-points"]["invenio_db.alembic"]
+    assert "mylib" in alembic_ep
+    assert alembic_ep["mylib"] == "mylib:alembic"
+
+
+def test_init_flat_layout_creates_correct_entrypoint(lib_root_flat_layout: Path) -> None:
+    """init() works with flat layout and creates correct entrypoint."""
+    context = make_context(lib_root_flat_layout)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    manager.init()
+
+    # Check directory was created in flat layout
+    alembic_dir = lib_root_flat_layout / "mylib" / "alembic"
+    assert alembic_dir.exists()
+
+    # Check entrypoint was added
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    alembic_ep = document["project"]["entry-points"]["invenio_db.alembic"]
+    assert alembic_ep["mylib"] == "mylib:alembic"
+
+
+def test_init_idempotent_with_existing_directory(lib_root: Path) -> None:
+    """init() is idempotent when alembic directory already exists."""
+    context = make_context(lib_root)
+    alembic_dir = lib_root / "src" / "mylib" / "alembic"
+    alembic_dir.mkdir(parents=True)
+
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+    manager.init()
+
+    # Directory should still exist
+    assert alembic_dir.exists()
+
+    # Entrypoint should be added
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "mylib" in document["project"]["entry-points"]["invenio_db.alembic"]
+
+
+def test_init_idempotent_with_existing_entrypoint(lib_root: Path) -> None:
+    """init() is idempotent when entrypoint already exists."""
+    # Pre-add the entrypoint
+    document = tomlkit.parse((lib_root / "pyproject.toml").read_text())
+    project = document.setdefault("project", tomlkit.table())
+    entrypoints = project.setdefault("entry-points", tomlkit.table())
+    alembic_ep = entrypoints.setdefault("invenio_db.alembic", tomlkit.table())
+    alembic_ep["mylib"] = "mylib:alembic"
+    (lib_root / "pyproject.toml").write_text(tomlkit.dumps(document))
+
+    context = make_context(lib_root)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    manager.init()
+
+    # Entrypoint should still be there
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    alembic_ep = document["project"]["entry-points"]["invenio_db.alembic"]
+    assert alembic_ep["mylib"] == "mylib:alembic"
+
+    # Directory should be created
+    alembic_dir = lib_root / "src" / "mylib" / "alembic"
+    assert alembic_dir.exists()
+
+
+def test_init_without_models_entrypoint_raises(lib_root_no_models: Path) -> None:
+    """init() raises ValidationError when invenio_db.models entrypoint is missing."""
+    context = make_context(lib_root_no_models)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    with pytest.raises(ValidationError, match=r"No 'invenio_db\.models' entrypoint found"):
+        manager.init()
+
+    # No directory should be created
+    alembic_dir = lib_root_no_models / "src" / "mylib" / "alembic"
+    assert not alembic_dir.exists()
+
+    # No entrypoint should be added
+    document = tomlkit.parse(context.pyproject_path.read_text())
+    assert "entry-points" not in document.get("project", {})
+
+
+def test_init_preserves_existing_formatting(lib_root: Path) -> None:
+    """Existing entrypoints in pyproject.toml survive the tomlkit round trip."""
+    # Add a comment
+    original = (lib_root / "pyproject.toml").read_text()
+    original = "# This is my library\n" + original
+    (lib_root / "pyproject.toml").write_text(original)
+
+    context = make_context(lib_root)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    manager.init()
+
+    content = context.pyproject_path.read_text()
+    assert "# This is my library" in content
+    assert '[project.entry-points."invenio_db.models"]' in content
+
+
+def test_init_uses_first_code_directory_for_alembic(lib_root: Path) -> None:
+    """init() creates alembic directory in the first code directory."""
+    context = make_context(lib_root)
+    manager = AlembicManager(context, ConsoleOutput(quiet=True))
+
+    # Get first code directory (without tests)
+    first_code_dir = context.code_directories_without_tests[0]
+
+    manager.init()
+
+    # Check alembic was created in first code directory
+    alembic_dir = first_code_dir / "mylib" / "alembic"
+    assert alembic_dir.exists()

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -46,6 +46,25 @@ requires-python = ">=3.14,<3.15"
 """
 
 
+@pytest.fixture(autouse=True)
+def _no_real_migration_workflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out the parts of init() that shell out (uv/docker/invenio).
+
+    AlembicManager only touches pyproject.toml and the filesystem for the
+    directory/entrypoint bookkeeping exercised here; the rest of init()'s
+    migration workflow requires a real venv, Docker services and an invenio
+    binary, which these tests don't set up.
+    """
+    for method in (
+        "_sync_project",
+        "_restart_services",
+        "_create_branch_migration",
+        "_upgrade_heads",
+        "_create_tables_migration",
+    ):
+        monkeypatch.setattr(f"oarepo_cli.services.alembic.AlembicManager.{method}", lambda self, *a, **kw: None)  # noqa: ARG005
+
+
 def make_context(root: Path) -> ProjectContext:
     return ProjectContext(
         root_directory=root,

--- a/tests/integration/test_upgrade_workflow.py
+++ b/tests/integration/test_upgrade_workflow.py
@@ -80,8 +80,9 @@ def test_upgrade_displays_output(
 
     result = runner.invoke(app, ["library", "upgrade"], catch_exceptions=False)
 
-    # Should produce some output
-    assert len(result.stdout) > 0 or result.exit_code != 0
+    # Should produce some output (CLI messages are written to stderr, mixed
+    # into `.output` in invocation order; `.stdout` alone is empty by design)
+    assert len(result.output) > 0 or result.exit_code != 0
 
 
 def test_upgrade_handles_missing_pyproject(

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -300,6 +300,67 @@ dependencies = ["oarepo>=14.0.0,<15.0.0"]
     assert context.assets_path is None
 
 
+def test_computed_properties_code_directories_without_tests_src_layout(tmp_path: Path) -> None:
+    """Test code_directories_without_tests excludes tests/ for src layout."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-project"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+"""
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    # code_directories includes tests
+    assert context.code_directories == [tmp_path / "src", tmp_path / "tests"]
+    # code_directories_without_tests excludes tests
+    assert context.code_directories_without_tests == [tmp_path / "src"]
+
+
+def test_computed_properties_code_directories_without_tests_flat_layout(tmp_path: Path) -> None:
+    """Test code_directories_without_tests excludes tests/ for flat layout."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-project"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+"""
+    )
+    (tmp_path / "test_project").mkdir()
+    (tmp_path / "tests").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    # code_directories includes tests
+    assert context.code_directories == [tmp_path / "test_project", tmp_path / "tests"]
+    # code_directories_without_tests excludes tests
+    assert context.code_directories_without_tests == [tmp_path / "test_project"]
+
+
+def test_computed_properties_code_directories_without_tests_no_tests(tmp_path: Path) -> None:
+    """Test code_directories_without_tests when no tests/ directory exists."""
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "test-project"
+requires-python = ">=3.12,<3.15"
+dependencies = ["oarepo>=14.0.0,<15.0.0"]
+"""
+    )
+    (tmp_path / "src").mkdir()
+
+    context = ContextBuilder().from_directory(tmp_path).validate()
+
+    # Both should be the same when tests/ doesn't exist
+    assert context.code_directories == [tmp_path / "src"]
+    assert context.code_directories_without_tests == [tmp_path / "src"]
+
+
 def test_builder_pattern_with_overrides(tmp_path: Path) -> None:
     """Test builder pattern with various overrides."""
     (tmp_path / "pyproject.toml").write_text(


### PR DESCRIPTION
# Enhanced Alembic Initialization for Libraries

## Overview

This PR enhances the `oarepo-cli library alembic init` command to provide a complete, automated alembic migration setup workflow for OARepo library projects. Previously, the command only created the alembic directory and configured entrypoints. Now it handles the entire initialization process including creating migrations, setting up the database, and generating initial schema migrations.

## What's New

### Comprehensive Initialization Workflow

The `alembic init` command now performs a complete 10-step initialization:

1. ✅ Verifies `invenio_db.models` entrypoint exists
2. ✅ Creates `alembic/` directory in the code directory if needed
3. ✅ Adds `invenio_db.alembic` entrypoint to pyproject.toml if missing
4. ✅ Checks if already initialized (exits early if 2+ migrations exist)
5. ✅ Syncs project (`uv pip install --no-deps -e .`) to register entrypoints
6. ✅ Restarts Docker services to ensure clean database state
7. ⏸️ _(Optional, currently commented)_ Validates alembic state is clean
8. ✅ Creates initial branch migration if needed
9. ✅ Runs `invenio alembic upgrade heads`
10. ✅ Generates migration for initial database tables

### Key Features

- **Smart Detection**: Exits early if alembic is already initialized (2+ Python files detected)
- **Multi-headed Alembic Support**: Uses `--path` flag for proper multi-headed alembic configuration where each package maintains its own migrations
- **Service Management**: Automatically restarts Docker services before migration operations
- **Environment Handling**: Properly maps `SQLALCHEMY_DATABASE_URI` to `INVENIO_SQLALCHEMY_DATABASE_URI` for invenio commands
- **Virtual Environment Integration**: Automatically locates and uses the correct `invenio` binary from the project's venv
- **User Guidance**: Displays clear warning to review generated migration files

### Alembic State Validation (Future)

Includes a `_check_alembic_differences()` method (currently commented out) that can validate the database state is clean before creating migrations:

```python
from flask import current_app
ext = current_app.extensions["invenio-db"]
alembic = ext.alembic
if alembic.compare_metadata():
    # Abort with clear error message
