### PR TITLE
fix(scripts): point runner wrappers at CESNET PyPI index

### DIFF
--- a/oarepo_cli/scripts/library_run.sh
+++ b/oarepo_cli/scripts/library_run.sh
@@ -18,6 +18,13 @@
 
 set -euo pipefail
 
+# OARepo packages and the CESNET-patched invenio-cli build (which oarepo-cli
+# requires) live in the CESNET GitLab PyPI registry, not on public PyPI. uv
+# gives an extra index higher priority than the default index, so invenio-cli
+# resolves to the patched build here. Override-able via the environment.
+export UV_EXTRA_INDEX_URL=${UV_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/.tools"
 VENV_DIR="${TOOLS_DIR}/venv"

--- a/oarepo_cli/scripts/library_run.sh
+++ b/oarepo_cli/scripts/library_run.sh
@@ -21,9 +21,9 @@ set -euo pipefail
 # OARepo packages and the CESNET-patched invenio-cli build (which oarepo-cli
 # requires) live in the CESNET GitLab PyPI registry, not on public PyPI. uv
 # gives an extra index higher priority than the default index, so invenio-cli
-# resolves to the patched build here. Override-able via the environment.
-export UV_EXTRA_INDEX_URL=${UV_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
-export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+# resolves to the patched build here. Overridable via the environment.
+export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:-https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple}"
+export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL:-https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/.tools"

--- a/oarepo_cli/scripts/repository_run.sh
+++ b/oarepo_cli/scripts/repository_run.sh
@@ -23,9 +23,9 @@ set -euo pipefail
 # OARepo packages and the CESNET-patched invenio-cli build (which oarepo-cli
 # requires) live in the CESNET GitLab PyPI registry, not on public PyPI. uv
 # gives an extra index higher priority than the default index, so invenio-cli
-# resolves to the patched build here. Override-able via the environment.
-export UV_EXTRA_INDEX_URL=${UV_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
-export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+# resolves to the patched build here. Overridable via the environment.
+export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:-https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple}"
+export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL:-https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/.tools"

--- a/oarepo_cli/scripts/repository_run.sh
+++ b/oarepo_cli/scripts/repository_run.sh
@@ -20,6 +20,13 @@
 
 set -euo pipefail
 
+# OARepo packages and the CESNET-patched invenio-cli build (which oarepo-cli
+# requires) live in the CESNET GitLab PyPI registry, not on public PyPI. uv
+# gives an extra index higher priority than the default index, so invenio-cli
+# resolves to the patched build here. Override-able via the environment.
+export UV_EXTRA_INDEX_URL=${UV_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+export PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-"https://gitlab.cesnet.cz/api/v4/projects/1408/packages/pypi/simple"}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="${SCRIPT_DIR}/.tools"
 VENV_DIR="${TOOLS_DIR}/venv"


### PR DESCRIPTION
## Problem

The `library_run.sh` / `repository_run.sh` wrapper scripts bootstrap `oarepo-cli` via a bare `uv pip install oarepo-cli` into `.tools/venv`. That resolves the transitive `invenio-cli` dependency against **public PyPI**, pulling the upstream build (e.g. `1.12.2`). `oarepo-cli`'s startup `dependency_check` then rejects it because it requires the **CESNET-patched** build (`…+oarepo.…`), erroring with:

```
Installed invenio-cli version '1.12.2' is the upstream PyPI build, but oarepo-cli
requires the CESNET-patched build …
```

The `[[tool.uv.index]]` / `[tool.uv.sources] invenio-cli = { index = "cesnet" }` pin in oarepo-cli's own `pyproject.toml` is **project-local** — it only applies when uv resolves from inside the project, not for a bare `uv pip install oarepo-cli` into an arbitrary venv. So the extra index has to be set in the wrapper itself.

## Fix

Export `UV_EXTRA_INDEX_URL` / `PIP_EXTRA_INDEX_URL` (both override-able via the environment) pointing at the CESNET GitLab PyPI registry, before the install step, in **both** runner scripts. uv gives an extra index higher priority than the default index, so `invenio-cli` resolves to the patched build.

This restores the behavior the old bash `library_runner.sh` had (it set the same two exports).

> Note: existing checkouts that already created `.tools/` with the upstream build need `./run.sh self-update` to rebuild the venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)